### PR TITLE
feat: 내부 인증 로직 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/CustomJwtSubject.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/CustomJwtSubject.java
@@ -15,13 +15,13 @@ public class CustomJwtSubject {
 
     private TokenType type;
 
-    private String userId;
+    private Long userId;
 
     public static CustomJwtSubject of(
         String authorizationId,
         TokenScope scope,
         TokenType type,
-        String userId
+        Long userId
     ) {
         return new CustomJwtSubject(authorizationId, scope, type, userId);
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/LoginUserDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/LoginUserDto.java
@@ -1,0 +1,41 @@
+package com.dreamteam.alter.adapter.inbound.general.auth.dto;
+
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.type.UserRole;
+import lombok.*;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginUserDto {
+
+    private TokenScope scope;
+
+    private Long id;
+
+    private String email;
+
+    private UserRole role;
+
+    public static LoginUserDto of(TokenScope scope, User user) {
+        return LoginUserDto.builder()
+            .scope(scope)
+            .id(user.getId())
+            .email(user.getEmail())
+            .role(user.getRole())
+            .build();
+    }
+
+    public static LoginUserDto of(Authorization authorization) {
+        return LoginUserDto.builder()
+            .scope(authorization.getScope())
+            .id(authorization.getUser().getId())
+            .email(authorization.getUser().getEmail())
+            .role(authorization.getUser().getRole())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/auth/external/AuthorizationRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/auth/external/AuthorizationRepositoryImpl.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 @Transactional
@@ -16,6 +18,11 @@ public class AuthorizationRepositoryImpl implements AuthorizationRepository {
     @Override
     public void save(Authorization authorization) {
         authorizationJpaRepository.save(authorization);
+    }
+
+    @Override
+    public Optional<Authorization> findById(String id) {
+        return authorizationJpaRepository.findById(id);
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/application/auth/entrypoint/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/entrypoint/CustomAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.dreamteam.alter.application.auth.entrypoint;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
+        ErrorCode errorCode = ErrorCode.FORBIDDEN;
+
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter()
+            .write(objectMapper.writeValueAsString(ErrorResponse.of(
+                errorCode,
+                accessDeniedException.getMessage()
+            )));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/entrypoint/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/entrypoint/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.dreamteam.alter.application.auth.entrypoint;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter()
+            .write(objectMapper.writeValueAsString(ErrorResponse.of(
+                errorCode,
+                authException.getMessage()
+            )));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/filter/AbstractCustomAuthenticationFilter.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/filter/AbstractCustomAuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.dreamteam.alter.application.auth.filter;
+
+import com.dreamteam.alter.domain.auth.exception.ForbiddenAccessException;
+import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.io.IOException;
+
+public abstract class AbstractCustomAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    protected final AuthenticationEntryPoint authenticationEntryPoint;
+
+    public AbstractCustomAuthenticationFilter(
+        RequestMatcher requestMatcher,
+        AuthenticationManager authenticationManager,
+        AuthenticationEntryPoint authenticationEntryPoint
+    ) {
+        super(requestMatcher);
+        // 인증 성공 후 강제 redirection을 막음
+        setAuthenticationSuccessHandler(new AuthenticationSuccessHandler() {
+            @Override
+            public void onAuthenticationSuccess(
+                HttpServletRequest request,
+                HttpServletResponse response,
+                Authentication authentication
+            ) throws IOException, ServletException {
+                // ignore
+            }
+        });
+        setAuthenticationManager(authenticationManager);
+        this.authenticationEntryPoint = authenticationEntryPoint;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+                                                                                              IOException,
+                                                                                              ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+                                                                                                         IOException,
+                                                                                                         ServletException {
+        if (BooleanUtils.isFalse(requiresAuthentication(request, response))) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            Authentication authentication = attemptAuthentication(request, response);
+            if (ObjectUtils.isNotEmpty(authentication) && authentication.isAuthenticated()) {
+                SecurityContextHolder.getContext()
+                    .setAuthentication(authentication);
+            }
+            chain.doFilter(request, response);
+            successfulAuthentication(request, response, chain, authentication);
+        } catch (InternalAuthenticationServiceException ex) {
+            unsuccessfulAuthentication(request, response, ex);
+        } catch (AuthenticationException ex) {
+            throw new InternalAuthException();
+        } catch (AccessDeniedException ex) {
+            throw new ForbiddenAccessException();
+        }
+
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/filter/AccessTokenAuthenticationFilter.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/filter/AccessTokenAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.dreamteam.alter.application.auth.filter;
+
+import com.dreamteam.alter.application.auth.token.AccessTokenAuthentication;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.auth.exception.InvalidAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class AccessTokenAuthenticationFilter extends AbstractCustomAuthenticationFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public AccessTokenAuthenticationFilter(
+        AuthenticationManager authenticationManager,
+        AuthenticationEntryPoint authenticationEntryPoint
+    ) {
+        super(request -> true, authenticationManager, authenticationEntryPoint);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        if (ObjectUtils.isEmpty(request)) {
+            throw new InvalidAuthException();
+        }
+
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.isBlank(authorization) || BooleanUtils.isFalse(StringUtils.containsIgnoreCase(authorization, BEARER_PREFIX))) {
+            return null;
+        }
+
+        String accessToken = StringUtils.replaceIgnoreCase(authorization, BEARER_PREFIX, "");
+        AccessTokenAuthentication authenticationToken = new AccessTokenAuthentication(accessToken);
+
+        return getAuthenticationManager().authenticate(authenticationToken);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/filter/AnonymousAuthenticationFilter.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/filter/AnonymousAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.dreamteam.alter.application.auth.filter;
+
+import com.dreamteam.alter.application.auth.entrypoint.CustomAuthenticationEntryPoint;
+import com.dreamteam.alter.application.auth.token.AnonymousAuthentication;
+import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+public class AnonymousAuthenticationFilter extends AbstractCustomAuthenticationFilter {
+
+    public AnonymousAuthenticationFilter(
+        AuthenticationManager authenticationManager,
+        CustomAuthenticationEntryPoint authenticationEntryPoint
+    ) {
+        super(request -> true, authenticationManager, authenticationEntryPoint);
+    }
+
+    @Override
+    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+                                                                                                         IOException,
+                                                                                                         ServletException {
+        if (BooleanUtils.isFalse(requiresAuthentication(request, response))) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            Authentication preAuthentication = SecurityContextHolder.getContext().getAuthentication();
+            if (ObjectUtils.isNotEmpty(preAuthentication) && preAuthentication.isAuthenticated()) {
+                chain.doFilter(request, response);
+                return;
+            }
+
+            Authentication authentication = attemptAuthentication(request, response);
+            if (authentication.isAuthenticated()) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            chain.doFilter(request, response);
+        } catch (InternalAuthenticationServiceException ex) {
+            unsuccessfulAuthentication(request, response, ex);
+        } catch (AuthenticationException ex) {
+            throw new InternalAuthException();
+        }
+
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        AnonymousAuthentication authenticationToken = new AnonymousAuthentication();
+
+        return getAuthenticationManager().authenticate(authenticationToken);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/filter/RefreshTokenAuthenticationFilter.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/filter/RefreshTokenAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.dreamteam.alter.application.auth.filter;
+
+import com.dreamteam.alter.application.auth.token.RefreshTokenAuthentication;
+import com.dreamteam.alter.domain.auth.exception.InvalidAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class RefreshTokenAuthenticationFilter extends AbstractCustomAuthenticationFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public RefreshTokenAuthenticationFilter(
+        AuthenticationManager authenticationManager,
+        AuthenticationEntryPoint authenticationEntryPoint
+    ) {
+        super(request -> true, authenticationManager, authenticationEntryPoint);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        if (ObjectUtils.isEmpty(request)) {
+            throw new InvalidAuthException();
+        }
+
+        Authentication preAuthentication = SecurityContextHolder.getContext().getAuthentication();
+        if (ObjectUtils.isNotEmpty(preAuthentication) && preAuthentication.isAuthenticated()) {
+            return preAuthentication;
+        }
+
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.isBlank(authorization) || BooleanUtils.isFalse(StringUtils.containsIgnoreCase(authorization, BEARER_PREFIX))) {
+            return null;
+        }
+
+        String refreshToken = StringUtils.replaceIgnoreCase(authorization, BEARER_PREFIX, "");
+        RefreshTokenAuthentication refreshTokenAuthentication = new RefreshTokenAuthentication(refreshToken);
+
+        return getAuthenticationManager().authenticate(refreshTokenAuthentication);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/provider/AbstractJwtAuthenticationProvider.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/provider/AbstractJwtAuthenticationProvider.java
@@ -1,0 +1,54 @@
+package com.dreamteam.alter.application.auth.provider;
+
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.CustomJwtSubject;
+import com.dreamteam.alter.domain.auth.exception.ExpiredAuthException;
+import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+public abstract class AbstractJwtAuthenticationProvider implements AuthenticationProvider {
+
+    protected final SecretKey jwtSecretKey;
+    protected final ObjectMapper objectMapper;
+
+    public AbstractJwtAuthenticationProvider(
+        @Value("${jwt.secret}") String secretKey,
+        ObjectMapper objectMapper
+    ) {
+        this.jwtSecretKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.objectMapper = objectMapper;
+    }
+
+    protected CustomJwtSubject parseJwt(String token) throws ExpiredJwtException {
+        try {
+            Claims claims = checkJwt(token).getPayload();
+            return objectMapper.readValue(claims.getSubject(), CustomJwtSubject.class);
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredAuthException();
+        } catch (Exception e) {
+            throw new InternalAuthException();
+        }
+    }
+
+    protected Jws<Claims> checkJwt(String token) throws ExpiredJwtException {
+        try {
+            return Jwts.parser()
+                .verifyWith(jwtSecretKey)
+                .build()
+                .parseSignedClaims(token);
+        } catch (
+            UnsupportedJwtException
+            | MalformedJwtException
+            | IllegalArgumentException e
+        ) {
+            throw new InternalAuthException();
+        }
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/provider/AccessTokenAuthenticationProvider.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/provider/AccessTokenAuthenticationProvider.java
@@ -1,0 +1,114 @@
+package com.dreamteam.alter.application.auth.provider;
+
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.CustomJwtSubject;
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.LoginUserDto;
+import com.dreamteam.alter.adapter.outbound.auth.external.AuthorizationRepositoryImpl;
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.auth.token.AccessTokenAuthentication;
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.auth.exception.ExpiredAuthException;
+import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
+import com.dreamteam.alter.domain.auth.exception.InvalidAuthException;
+import com.dreamteam.alter.domain.auth.exception.RevokedAuthException;
+import com.dreamteam.alter.domain.auth.type.AuthorizationStatus;
+import com.dreamteam.alter.domain.auth.type.TokenType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Collections;
+
+@Component
+@Transactional
+public class AccessTokenAuthenticationProvider extends AbstractJwtAuthenticationProvider implements
+                                                                                         AuthenticationProvider {
+
+    private final AuthService authService;
+    private final AuthorizationRepositoryImpl authorizationRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    public AccessTokenAuthenticationProvider(
+        @Value("${jwt.secret}") String jwtSecret,
+        ObjectMapper objectMapper,
+        AuthService authService,
+        AuthorizationRepositoryImpl authorizationRepository,
+        StringRedisTemplate redisTemplate
+    ) {
+        super(jwtSecret, objectMapper);
+        this.authService = authService;
+        this.authorizationRepository = authorizationRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return authenticate((AccessTokenAuthentication) authentication);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return AccessTokenAuthentication.class.isAssignableFrom(authentication);
+    }
+
+    private Authentication authenticate(AccessTokenAuthentication authentication) {
+        Instant now = Instant.now();
+        String accessToken = (String) authentication.getPrincipal();
+
+        CustomJwtSubject subject = parseJwt(accessToken);
+        if (BooleanUtils.isFalse(TokenType.ACCESS.equals(subject.getType()))) {
+            return authentication;
+        }
+
+        Authorization authorization = getAuthorization(subject);
+        if (ObjectUtils.isEmpty(authorization)) {
+            Authorization dbAuthorization = getAuthorizationFromDB(subject.getAuthorizationId());
+
+            if (AuthorizationStatus.REVOKED.equals(dbAuthorization.getStatus())) {
+                throw new RevokedAuthException();
+            }
+
+            return authentication;
+        }
+
+        if (!now.isBefore(authorization.getAccessTokenExpiredAt())) {
+            throw new ExpiredAuthException();
+        }
+
+        LoginUserDto userDetail = LoginUserDto.of(authorization);
+        return new AccessTokenAuthentication(
+            accessToken,
+            userDetail,
+            Collections.singletonList(new SimpleGrantedAuthority(authorization.getUser()
+                .getRole()
+                .toString()))
+        );
+    }
+
+    private Authorization getAuthorization(CustomJwtSubject subject) {
+        String key = authService.buildKey(subject.getScope(), subject.getUserId(), subject.getAuthorizationId());
+        try {
+            return objectMapper.readValue(
+                redisTemplate.opsForValue().get(key),
+                Authorization.class
+            );
+        } catch (JsonProcessingException e) {
+            throw new InternalAuthException();
+        }
+    }
+
+    private Authorization getAuthorizationFromDB(String authorizationId) {
+        return authorizationRepository.findById(authorizationId)
+            .orElseThrow(InvalidAuthException::new);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/provider/AnonymousAuthenticationProvider.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/provider/AnonymousAuthenticationProvider.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.application.auth.provider;
+
+import com.dreamteam.alter.application.auth.token.AnonymousAuthentication;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnonymousAuthenticationProvider implements AuthenticationProvider {
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return authentication;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return AnonymousAuthentication.class.isAssignableFrom(authentication);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/provider/RefreshTokenAuthenticationProvider.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/provider/RefreshTokenAuthenticationProvider.java
@@ -1,0 +1,83 @@
+package com.dreamteam.alter.application.auth.provider;
+
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.CustomJwtSubject;
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.LoginUserDto;
+import com.dreamteam.alter.adapter.outbound.auth.external.AuthorizationRepositoryImpl;
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.auth.token.RefreshTokenAuthentication;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.auth.exception.ExpiredAuthException;
+import com.dreamteam.alter.domain.auth.exception.InvalidAuthException;
+import com.dreamteam.alter.domain.auth.exception.RevokedAuthException;
+import com.dreamteam.alter.domain.auth.type.AuthorizationStatus;
+import com.dreamteam.alter.domain.auth.type.TokenType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Collections;
+
+@Component
+public class RefreshTokenAuthenticationProvider extends AbstractJwtAuthenticationProvider implements
+                                                                                          AuthenticationProvider {
+
+    private final AuthorizationRepositoryImpl authorizationRepository;
+
+    public RefreshTokenAuthenticationProvider(
+        @Value("${jwt.secret}") String jwtSecret,
+        ObjectMapper objectMapper,
+        AuthorizationRepositoryImpl authorizationRepository
+    ) {
+        super(jwtSecret, objectMapper);
+        this.authorizationRepository = authorizationRepository;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return authenticate((RefreshTokenAuthentication) authentication);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return RefreshTokenAuthentication.class.isAssignableFrom(authentication);
+    }
+
+    private Authentication authenticate(RefreshTokenAuthentication authentication) {
+        Instant now = Instant.now();
+        String refreshToken = authentication.getPrincipal();
+
+        CustomJwtSubject subject = parseJwt(refreshToken);
+        if (BooleanUtils.isFalse(TokenType.REFRESH.equals(subject.getType()))) {
+            return authentication;
+        }
+
+        Authorization authorization = authorizationRepository.findById(subject.getAuthorizationId())
+            .orElseThrow(InvalidAuthException::new);
+
+        if (BooleanUtils.isFalse(now.isBefore(authorization.getRefreshTokenExpiredAt()))
+            || AuthorizationStatus.EXPIRED.equals(authorization.getStatus())) {
+            throw new ExpiredAuthException();
+        }
+
+
+        if (AuthorizationStatus.REVOKED.equals(authorization.getStatus())) {
+            throw new RevokedAuthException();
+        }
+
+        RefreshTokenAuthentication authorizedToken = new RefreshTokenAuthentication(refreshToken, authorization);
+        authorizedToken.setAuthenticated(true);
+
+        return authorizedToken;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
                     authorizationId,
                     scope,
                     TokenType.ACCESS,
-                    String.valueOf(user.getId())
+                    user.getId()
                 ),
                 accessTokenExpiredAt
             );
@@ -82,7 +82,7 @@ public class AuthService {
                     authorizationId,
                     scope,
                     TokenType.REFRESH,
-                    String.valueOf(user.getId())
+                    user.getId()
                 ),
                 refreshTokenExpiredAt
             );
@@ -106,7 +106,11 @@ public class AuthService {
     }
 
     private void saveAuthorization(Authorization authorization) throws JsonProcessingException {
-        String key = buildKey(authorization);
+        String key = buildKey(
+            authorization.getScope(),
+            authorization.getUser().getId(),
+            authorization.getId()
+        );
 
         // Redis
         redisTemplate.opsForValue().set(
@@ -120,12 +124,12 @@ public class AuthService {
         authorizationRepository.save(authorization);
     }
 
-    private String buildKey(Authorization authorization) {
+    public String buildKey(TokenScope scope, Long userId, String authorizationId) {
         return String.join(":",
             AUTHORIZATION_PREFIX,
-            String.valueOf(authorization.getScope()),
-            String.valueOf(authorization.getUser().getId()),
-            authorization.getId()
+            String.valueOf(scope),
+            String.valueOf(userId),
+            authorizationId
         );
     }
 

--- a/src/main/java/com/dreamteam/alter/application/auth/token/AccessTokenAuthentication.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/token/AccessTokenAuthentication.java
@@ -1,0 +1,43 @@
+package com.dreamteam.alter.application.auth.token;
+
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.LoginUserDto;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class AccessTokenAuthentication extends AbstractAuthenticationToken {
+
+    private final String token;
+
+    public AccessTokenAuthentication(
+        String token
+    ) {
+        super(Collections.emptyList());
+        this.token = token;
+        setAuthenticated(false);
+    }
+
+    public AccessTokenAuthentication(
+        String token,
+        LoginUserDto loginUser,
+        Collection<GrantedAuthority> authorities
+    ) {
+        super(authorities);
+        this.token = token;
+        setAuthenticated(true);
+        setDetails(loginUser);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return token;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/token/AnonymousAuthentication.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/token/AnonymousAuthentication.java
@@ -1,0 +1,29 @@
+package com.dreamteam.alter.application.auth.token;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+public class AnonymousAuthentication extends AbstractAuthenticationToken {
+
+    private static final GrantedAuthority ANONYMOUS_ROLE = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+
+    public AnonymousAuthentication() {
+        super(List.of(ANONYMOUS_ROLE));
+
+        setAuthenticated(false);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/token/RefreshTokenAuthentication.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/token/RefreshTokenAuthentication.java
@@ -1,0 +1,56 @@
+package com.dreamteam.alter.application.auth.token;
+
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RefreshTokenAuthentication extends AbstractAuthenticationToken {
+
+    private static final GrantedAuthority ANONYMOUS_ROLE = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+
+    private final String token;
+    private final Authorization authorization;
+
+    public RefreshTokenAuthentication(
+        String token
+    ) {
+        super(List.of(ANONYMOUS_ROLE));
+        this.token = token;
+        this.authorization = null;
+//        setAuthenticated(false);
+    }
+
+    public RefreshTokenAuthentication(
+        String token,
+        Authorization authorization
+    ) {
+        super(Collections.singletonList(getAuthority(authorization)));
+        this.token = token;
+        this.authorization = authorization;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return token;
+    }
+
+    @Override
+    public Authorization getDetails() {
+        return authorization;
+    }
+
+    private static SimpleGrantedAuthority getAuthority(Authorization authorization) {
+        return new SimpleGrantedAuthority(authorization.getUser().getRole().toString());
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/exception/ExpiredAuthException.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/exception/ExpiredAuthException.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.auth.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class ExpiredAuthException extends AuthenticationException {
+    public ExpiredAuthException() {
+        super("만료된 인증 정보입니다.");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/exception/ForbiddenAccessException.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/exception/ForbiddenAccessException.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.auth.exception;
+
+import org.springframework.security.access.AccessDeniedException;
+
+public class ForbiddenAccessException extends AccessDeniedException {
+    public ForbiddenAccessException() {
+        super("접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/exception/InternalAuthException.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/exception/InternalAuthException.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.auth.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InternalAuthException extends AuthenticationException {
+    public InternalAuthException() {
+        super("내부 인증 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/exception/InvalidAuthException.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/exception/InvalidAuthException.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.auth.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidAuthException extends AuthenticationException {
+    public InvalidAuthException() {
+        super("유효하지 않은 인증 정보입니다.");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/exception/RevokedAuthException.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/exception/RevokedAuthException.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.auth.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class RevokedAuthException extends AuthenticationException {
+    public RevokedAuthException() {
+        super("철회된 인증 정보입니다.");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/port/outbound/AuthorizationRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/port/outbound/AuthorizationRepository.java
@@ -2,6 +2,9 @@ package com.dreamteam.alter.domain.auth.port.outbound;
 
 import com.dreamteam.alter.domain.auth.entity.Authorization;
 
+import java.util.Optional;
+
 public interface AuthorizationRepository {
     void save(Authorization authorization);
+    Optional<Authorization> findById(String id);
 }


### PR DESCRIPTION
## ID
- ALT-13

## 변경 내용
- Spring Security 인증 로직 사용자화

## 구현 사항
- Security FilterChain 구현
- Filter, Provider 구성
- FilterChain 관련 예외는 서비스 관련 예외와는 별도로 관리되도록 구성

## 참고 사항
- API 구현 간 내부 인증 로직은 변경될 수 있음