### PR TITLE
feat: JWT 재발급 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.adapter.inbound.general.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.domain.user.port.inbound.ReissueTokenUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/users")
+@RequiredArgsConstructor
+@Validated
+public class UserController implements UserControllerSpec {
+
+    @Resource(name = "reissueToken")
+    private final ReissueTokenUseCase reissueToken;
+
+    @Override
+    @PostMapping("/token")
+    public ResponseEntity<CommonApiResponse<GenerateTokenResponseDto>> reissueToken(Authentication authentication) {
+        return ResponseEntity.ok(CommonApiResponse.of(reissueToken.execute(authentication)));
+    }
+
+    @Override
+    @PostMapping("/logout")
+    public ResponseEntity<CommonApiResponse<Void>> logoutUser(Authentication authentication) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserControllerSpec.java
@@ -1,0 +1,49 @@
+package com.dreamteam.alter.adapter.inbound.general.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "App - 사용자")
+public interface UserControllerSpec {
+
+    @Operation(summary = "사용자 토큰 재발급", description = "헤더에 RefreshToken을 담아 요청")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "재발급 성공 (JWT 응답)"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "RefreshToken을 통한 요청이 아닐 경우",
+                        value = "{\"code\" : \"B002\"}"
+                    ),
+                    @ExampleObject(
+                        name = "이용 정지된 사용자",
+                        value = "{\"code\" : \"B003\"}"
+                    ),
+                    @ExampleObject(
+                        name = "탈퇴한 사용자",
+                        value = "{\"code\" : \"B004\"}"
+                    ),
+                    @ExampleObject(
+                        name = "서버 내부 처리 오류",
+                        value = "{\"code\" : \"C001\"}"
+                    ),
+                }))
+    })
+    ResponseEntity<CommonApiResponse<GenerateTokenResponseDto>> reissueToken(Authentication authentication);
+
+    ResponseEntity<CommonApiResponse<Void>> logoutUser(Authentication authentication);
+
+}

--- a/src/main/java/com/dreamteam/alter/application/auth/filter/AbstractCustomAuthenticationFilter.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/filter/AbstractCustomAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.dreamteam.alter.application.auth.filter;
 
-import com.dreamteam.alter.domain.auth.exception.ForbiddenAccessException;
-import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -10,11 +8,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
@@ -73,12 +69,7 @@ public abstract class AbstractCustomAuthenticationFilter extends AbstractAuthent
             successfulAuthentication(request, response, chain, authentication);
         } catch (InternalAuthenticationServiceException ex) {
             unsuccessfulAuthentication(request, response, ex);
-        } catch (AuthenticationException ex) {
-            throw new InternalAuthException();
-        } catch (AccessDeniedException ex) {
-            throw new ForbiddenAccessException();
         }
-
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
@@ -105,7 +105,7 @@ public class AuthService {
         }
     }
 
-    private void saveAuthorization(Authorization authorization) throws JsonProcessingException {
+    public void saveAuthorization(Authorization authorization) throws JsonProcessingException {
         String key = buildKey(
             authorization.getScope(),
             authorization.getUser().getId(),

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/ReissueToken.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/ReissueToken.java
@@ -1,0 +1,57 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.auth.token.RefreshTokenAuthentication;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.auth.port.outbound.AuthorizationRepository;
+import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.ReissueTokenUseCase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service("reissueToken")
+@RequiredArgsConstructor
+public class ReissueToken implements ReissueTokenUseCase {
+
+    private final AuthorizationRepository authorizationRepository;
+
+    private final AuthService authService;
+
+    private final TokenScope scope = TokenScope.APP;
+
+    @Override
+    public GenerateTokenResponseDto execute(Authentication authentication) {
+        if (BooleanUtils.isFalse(RefreshTokenAuthentication.class.isAssignableFrom(authentication.getClass()))) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_REQUIRED);
+        }
+
+        Authorization authorization = (Authorization) authentication.getDetails();
+        User user = authorization.getUser();
+
+        switch (user.getStatus()) {
+            case SUSPENDED -> throw new CustomException(ErrorCode.SUSPENDED_USER);
+            case DELETED -> throw new CustomException(ErrorCode.DELETED_USER);
+        }
+
+        authorization.expire();
+        authorizationRepository.save(authorization); // 영속성으로 관리되지 않으므로 직접 저장
+
+        Authorization newAuthorization;
+        try {
+            newAuthorization = authService.generateAuthorization(user, scope);
+            authService.saveAuthorization(newAuthorization);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return GenerateTokenResponseDto.of(newAuthorization);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/common/config/SecurityConfig.java
+++ b/src/main/java/com/dreamteam/alter/common/config/SecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -106,7 +106,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(customAuthenticationEntryPoint)
                 .accessDeniedHandler(customAccessDeniedHandler)
             )
-            .addFilterBefore(accessTokenAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(accessTokenAuthenticationFilter(authenticationManager), ExceptionTranslationFilter.class)
             .addFilterAfter(refreshTokenAuthenticationFilter(authenticationManager), AccessTokenAuthenticationFilter.class)
             .addFilterAfter(anonymousAuthenticationFilter(authenticationManager), RefreshTokenAuthenticationFilter.class)
             .build();

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     NICKNAME_DUPLICATED(400, "A008", "이미 사용중인 닉네임입니다."),
 
     ILLEGAL_ARGUMENT(400, "B001", "잘못된 요청입니다."),
+    REFRESH_TOKEN_REQUIRED(400, "B002", "RefreshToken을 통해 요청해야 합니다."),
+    SUSPENDED_USER(400, "B003", "이용이 정지된 사용자입니다."),
+    DELETED_USER(400, "B004", "탈퇴한 사용자입니다."),
 
     INTERNAL_SERVER_ERROR(400, "C001", "서버 내부 오류입니다."),
     ;

--- a/src/main/java/com/dreamteam/alter/domain/auth/entity/Authorization.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/entity/Authorization.java
@@ -25,7 +25,7 @@ public class Authorization {
     @Column(name = "id")
     private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -76,6 +76,10 @@ public class Authorization {
             .refreshTokenExpiredAt(refreshTokenExpiredAt)
             .status(AuthorizationStatus.ACTIVE)
             .build();
+    }
+
+    public void expire() {
+        this.status = AuthorizationStatus.EXPIRED;
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/ReissueTokenUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/ReissueTokenUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import org.springframework.security.core.Authentication;
+
+public interface ReissueTokenUseCase {
+    GenerateTokenResponseDto execute(Authentication authentication);
+}


### PR DESCRIPTION
## ID
- ALT-14

## 변경 내용
- JWT 재발급 로직 및 엔드포인트 구성
- 그 외 Spring Security 인증 로직 수정

## 구현 사항
- JWT 재발급 요청 발생 시 Claims 추출하여 인가 코드 확인
- DB로부터 인가 코드 조회, 조회 결과 없을 시 비인가 토큰으로 간주
- 관련 에러 코드 추가

## 구현 시연
<img width="700" alt="image" src="https://github.com/user-attachments/assets/37ce951b-34bb-447a-a82f-4bc92688ae60" />

## 참고 사항
- logout 추후 구현 예정
