### PR TITLE
feat: 공고 등록 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
@@ -1,0 +1,34 @@
+package com.dreamteam.alter.adapter.inbound.general.posting.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
+import com.dreamteam.alter.domain.posting.port.inbound.CreatePostingUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/postings")
+@PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
+@RequiredArgsConstructor
+@Validated
+public class PostingController implements PostingControllerSpec {
+
+    @Resource(name = "createPosting")
+    private final CreatePostingUseCase createPosting;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> createPosting(
+        CreatePostingRequestDto request
+    ) {
+        createPosting.execute(request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingControllerSpec.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.adapter.inbound.general.posting.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "App - 공고 API")
+public interface PostingControllerSpec {
+
+    @Operation(summary = "공고 등록", description = "")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "공고 등록 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "서버 내부 오류",
+                        value = "{\"code\" : \"C001\"}"
+                    ),
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> createPosting(@Valid @RequestBody CreatePostingRequestDto request);
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
@@ -1,0 +1,44 @@
+package com.dreamteam.alter.adapter.inbound.general.posting.dto;
+
+import com.dreamteam.alter.domain.posting.type.PaymentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "공고 생성 요청 DTO")
+public class CreatePostingRequestDto {
+
+    @Schema(description = "업장 ID (임시)", example = "1")
+    private Long workspaceId;
+
+    @Schema(description = "공고 제목", example = "홀서빙 구합니다")
+    private String title;
+
+    @Schema(description = "공고 설명", example = "홀서빙 구합니다. 주말 근무 가능하신 분 우대합니다.")
+    private String description;
+
+    @Schema(description = "급여", example = "10000")
+    private int payAmount;
+
+    @Schema(description = "급여 타입", example = "HOURLY")
+    private PaymentType paymentType;
+
+    @Schema(description = "키워드", example = "[2, 3, 1]")
+    private List<Long> keywords;
+
+    @Schema(description = "공고 스케줄", example = "[" +
+            "{" +
+                "\"dayOfWeek\": \"MONDAY\", \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
+            "}," +
+            "{" +
+                "\"dayOfWeek\": \"TUESDAY\", \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": 2" +
+            "}" +
+        "]")
+    private List<PostingScheduleDto> schedules;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleDto.java
@@ -1,0 +1,31 @@
+package com.dreamteam.alter.adapter.inbound.general.posting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "공고 스케줄 DTO")
+public class PostingScheduleDto {
+
+    @Schema(description = "요일", example = "MONDAY")
+    private DayOfWeek dayOfWeek;
+
+    @Schema(description = "시작 시간", example = "09:00")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "18:00")
+    private LocalTime endTime;
+
+    @Schema(description = "필요 인원", example = "3")
+    private int positionsNeeded;
+
+    @Schema(description = "직무 id", example = "3")
+    private Long position;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.adapter.outbound.posting.persistence;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostingJpaRepository extends JpaRepository<Posting, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.adapter.outbound.posting.persistence;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class PostingRepositoryImpl implements PostingRepository {
+
+    private final PostingJpaRepository postingJpaRepository;
+
+    @Override
+    public Posting save(Posting posting) {
+        return postingJpaRepository.save(posting);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/CreatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/CreatePosting.java
@@ -1,0 +1,24 @@
+package com.dreamteam.alter.application.posting;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import com.dreamteam.alter.domain.posting.port.inbound.CreatePostingUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("createPosting")
+@RequiredArgsConstructor
+@Transactional
+public class CreatePosting implements CreatePostingUseCase {
+
+    private final PostingRepository postingRepository;
+
+    @Override
+    public void execute(CreatePostingRequestDto request) {
+        Posting posting = Posting.create(request);
+        postingRepository.save(posting);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
@@ -1,0 +1,92 @@
+package com.dreamteam.alter.domain.posting.entity;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
+import com.dreamteam.alter.domain.posting.type.PaymentType;
+import com.dreamteam.alter.domain.posting.type.PostingStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "postings")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class Posting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "workspace_id", nullable = false)
+    private Long workspace;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "pay_amount", nullable = false)
+    private int payAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pay_type", nullable = false)
+    private PaymentType paymentType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PostingStatus status;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "posting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostingSchedule> schedules = new ArrayList<>();
+
+    @OneToMany(mappedBy = "posting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostingKeyword> keywords = new ArrayList<>();
+
+    public static Posting create(CreatePostingRequestDto request) {
+        Posting posting = Posting.builder()
+            .workspace(request.getWorkspaceId())
+            .title(request.getTitle())
+            .description(request.getDescription())
+            .payAmount(request.getPayAmount())
+            .paymentType(request.getPaymentType())
+            .status(PostingStatus.OPEN)
+            .build();
+
+        if (ObjectUtils.isNotEmpty(request.getSchedules())) {
+            posting.schedules = request.getSchedules()
+                .stream()
+                .map(scheduleDto -> PostingSchedule.create(scheduleDto, posting))
+                .toList();
+        }
+
+        if (ObjectUtils.isNotEmpty(request.getKeywords())) {
+            posting.keywords = request.getKeywords()
+                .stream()
+                .map(keyword -> PostingKeyword.create(keyword, posting))
+                .toList();
+        }
+
+        return posting;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingKeyword.java
@@ -1,0 +1,47 @@
+package com.dreamteam.alter.domain.posting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "posting_keywords")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class PostingKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "posting_id", nullable = false)
+    private Posting posting;
+
+    @Column(name = "keyword", nullable = false)
+    private Long keyword;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static PostingKeyword create(Long keyword, Posting posting) {
+        return PostingKeyword.builder()
+            .posting(posting)
+            .keyword(keyword)
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
@@ -1,0 +1,67 @@
+package com.dreamteam.alter.domain.posting.entity;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingScheduleDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Table(name = "posting_schedules")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class PostingSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "posting_id", nullable = false)
+    private Posting posting;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "positions_needed", nullable = false)
+    private int positions_needed;
+
+    @Column(name = "position", nullable = false)
+    private Long position;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static PostingSchedule create(PostingScheduleDto request, Posting posting) {
+        return PostingSchedule.builder()
+            .posting(posting)
+            .dayOfWeek(request.getDayOfWeek())
+            .startTime(request.getStartTime())
+            .endTime(request.getEndTime())
+            .positions_needed(request.getPositionsNeeded())
+            .position(request.getPosition())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/CreatePostingUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/CreatePostingUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
+
+public interface CreatePostingUseCase {
+    void execute(CreatePostingRequestDto request);
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingRepository.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.posting.port.outbound;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+
+public interface PostingRepository {
+
+    Posting save(Posting posting);
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/type/PaymentType.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/type/PaymentType.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.posting.type;
+
+public enum PaymentType {
+    HOURLY,
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    ;
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/type/PostingStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/type/PostingStatus.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.posting.type;
+
+public enum PostingStatus {
+    OPEN,
+    CLOSED,
+    CANCELLED,
+    DELETED,
+    ;
+}


### PR DESCRIPTION
## ID
- ALT-9

## 변경 내용
- 공고 등록 API를 위한 엔티티, 및 엔드포인트 구성

## 구현 사항
- 공고 관련 Type Enum 정의
- Posting, PostingSchedule, PostingKeyword 엔티티 구현 및 연관관계 설정
- 공고 등록 API 구현

## 참고 사항
- DTO validation 구성 예정
- 엔티티 필드 별 제약조건 구성 예정
