### PR TITLE
feat: 근무 요일 다중 지정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.json:json:20250107'
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+	implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
@@ -33,10 +33,10 @@ public class CreatePostingRequestDto {
 
     @Schema(description = "공고 스케줄", example = "[" +
             "{" +
-                "\"dayOfWeek\": \"MONDAY\", \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
+                "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
             "}," +
             "{" +
-                "\"dayOfWeek\": \"TUESDAY\", \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": 2" +
+                "\"workingDays\": [\"FRIDAY\"], \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": 2" +
             "}" +
         "]")
     private List<PostingScheduleDto> schedules;

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleDto.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -13,8 +14,8 @@ import java.time.LocalTime;
 @Schema(description = "공고 스케줄 DTO")
 public class PostingScheduleDto {
 
-    @Schema(description = "요일", example = "MONDAY")
-    private DayOfWeek dayOfWeek;
+    @Schema(description = "근무 요일", example = "['MONDAY', 'WEDNESDAY']")
+    private List<DayOfWeek> workingDays;
 
     @Schema(description = "시작 시간", example = "09:00")
     private LocalTime startTime;

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
@@ -11,7 +11,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -57,10 +56,10 @@ public class Posting {
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "posting", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostingSchedule> schedules = new ArrayList<>();
+    private List<PostingSchedule> schedules;
 
     @OneToMany(mappedBy = "posting", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostingKeyword> keywords = new ArrayList<>();
+    private List<PostingKeyword> keywords;
 
     public static Posting create(CreatePostingRequestDto request) {
         Posting posting = Posting.builder()

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
@@ -1,8 +1,10 @@
 package com.dreamteam.alter.domain.posting.entity;
 
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingScheduleDto;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,9 +32,9 @@ public class PostingSchedule {
     @JoinColumn(name = "posting_id", nullable = false)
     private Posting posting;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "day_of_week", nullable = false)
-    private DayOfWeek dayOfWeek;
+    @Type(JsonBinaryType.class)
+    @Column(name = "working_days", nullable = false, columnDefinition = "jsonb")
+    private List<DayOfWeek> workingDays;
 
     @Column(name = "start_time", nullable = false)
     private LocalTime startTime;
@@ -56,7 +59,7 @@ public class PostingSchedule {
     public static PostingSchedule create(PostingScheduleDto request, Posting posting) {
         return PostingSchedule.builder()
             .posting(posting)
-            .dayOfWeek(request.getDayOfWeek())
+            .workingDays(request.getWorkingDays())
             .startTime(request.getStartTime())
             .endTime(request.getEndTime())
             .positions_needed(request.getPositionsNeeded())


### PR DESCRIPTION
## ID
- ALT-9

## 변경 내용
- 근무 스케줄의 근무 요일을 여러 개 설정 가능하도록 구현

## 구현 사항
- Json 타입으로 DB에 다중으로 저장하도록 수정