### PR TITLE
feat: 공고 등록 키워드 응답 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
@@ -5,9 +5,11 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingDetailResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingKeywordListResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingListResponseDto;
 import com.dreamteam.alter.domain.posting.port.inbound.CreatePostingUseCase;
 import com.dreamteam.alter.domain.posting.port.inbound.GetPostingDetailUseCase;
+import com.dreamteam.alter.domain.posting.port.inbound.GetPostingKeywordListUseCase;
 import com.dreamteam.alter.domain.posting.port.inbound.GetPostingsWithCursorUseCase;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/app/postings")
@@ -31,6 +35,9 @@ public class PostingController implements PostingControllerSpec {
 
     @Resource(name = "getPostingDetail")
     private final GetPostingDetailUseCase getPostingDetail;
+
+    @Resource(name = "getPostingKeywordList")
+    private final GetPostingKeywordListUseCase getPostingKeywordList;
 
     @Override
     @PostMapping
@@ -55,6 +62,12 @@ public class PostingController implements PostingControllerSpec {
         @PathVariable Long postingId
     ) {
         return ResponseEntity.ok(CommonApiResponse.of(getPostingDetail.execute(postingId)));
+    }
+
+    @Override
+    @GetMapping("/available-keywords")
+    public ResponseEntity<CommonApiResponse<List<PostingKeywordListResponseDto>>> getAvailablePostingKeywords() {
+        return ResponseEntity.ok(CommonApiResponse.of(getPostingKeywordList.execute()));
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingControllerSpec.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse
 import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingDetailResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingKeywordListResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,6 +18,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "App - 공고 API")
 public interface PostingControllerSpec {
@@ -72,5 +75,21 @@ public interface PostingControllerSpec {
                 }))
     })
     ResponseEntity<CommonApiResponse<PostingDetailResponseDto>> getPostingDetail(Long postingId);
+
+    @Operation(summary = "등록 가능한 공고 키워드 조회", description = "")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "공고 키워드 리스트 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "키워드 리스트 찾을 수 없음",
+                        value = "{\"code\" : \"B009\"}"
+                    ),
+                }))
+    })
+    ResponseEntity<CommonApiResponse<List<PostingKeywordListResponseDto>>> getAvailablePostingKeywords();
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
@@ -33,10 +33,10 @@ public class CreatePostingRequestDto {
 
     @Schema(description = "공고 스케줄", example = "[" +
             "{" +
-                "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
+                "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": \"설거지\"" +
             "}," +
             "{" +
-                "\"workingDays\": [\"FRIDAY\"], \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": 2" +
+                "\"workingDays\": [\"FRIDAY\"], \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": \"홀서빙\"" +
             "}" +
         "]")
     private List<CreatePostingScheduleRequestDto> schedules;

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
@@ -1,10 +1,11 @@
 package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.general.workspace.dto.PostingDetailWorkspaceResponseDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingDetailResponse;
 import com.dreamteam.alter.domain.posting.type.PaymentType;
-import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -17,30 +18,39 @@ import java.util.List;
 @Schema(description = "공고 상세 조회 응답 DTO")
 public class PostingDetailResponseDto {
 
+    @NotNull
     @Schema(description = "공고 ID", example = "1")
     private Long id;
 
-    @Column(name = "workspace_id", nullable = false)
-    private Workspace workspace;
+    @NotNull
+    @Schema(description = "업장 정보", example = "1")
+    private PostingDetailWorkspaceResponseDto workspace;
 
+    @NotBlank
     @Schema(description = "공고 제목", example = "홀서빙 구합니다")
     private String title;
 
-    @Column(name = "description", nullable = false)
+    @NotBlank
+    @Schema(description = "공고 설명", example = "홀서빙 구합니다. 많은 지원 부탁드립니다.")
     private String description;
 
+    @NotNull
     @Schema(description = "급여", example = "10000")
     private int payAmount;
 
+    @NotNull
     @Schema(description = "급여 타입", example = "HOURLY")
     private PaymentType paymentType;
 
+    @NotNull
     @Schema(description = "생성일", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 
+    @NotNull
     @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
-    private List<KeywordListResponseDto> keywords;
+    private List<PostingKeywordListResponseDto> keywords;
 
+    @NotNull
     @Schema(description = "공고 스케줄", example = "[" +
         "{" +
         "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
@@ -54,7 +64,7 @@ public class PostingDetailResponseDto {
     public static PostingDetailResponseDto from(PostingDetailResponse entity) {
         return PostingDetailResponseDto.builder()
             .id(entity.getId())
-            .workspace(entity.getWorkspace())
+            .workspace(PostingDetailWorkspaceResponseDto.from(entity.getWorkspace()))
             .title(entity.getTitle())
             .description(entity.getDescription())
             .payAmount(entity.getPayAmount())
@@ -64,7 +74,7 @@ public class PostingDetailResponseDto {
                 .map(PostingScheduleResponseDto::from)
                 .toList())
             .keywords(entity.getPostingKeywords().stream()
-                .map(KeywordListResponseDto::from)
+                .map(PostingKeywordListResponseDto::from)
                 .toList())
             .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingKeywordListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingKeywordListResponseDto.java
@@ -2,6 +2,8 @@ package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 
 import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,16 +13,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Schema(title = "키워드 리스트 응답 DTO")
-public class KeywordListResponseDto {
+public class PostingKeywordListResponseDto {
 
+    @NotNull
     @Schema(title = "키워드 ID", example = "1")
     private Long id;
 
+    @NotBlank
     @Schema(title = "키워드 이름", example = "홀서빙")
     private String name;
 
-    public static KeywordListResponseDto from(PostingKeyword postingKeyword) {
-        return new KeywordListResponseDto(
+    public static PostingKeywordListResponseDto from(PostingKeyword postingKeyword) {
+        return new PostingKeywordListResponseDto(
             postingKeyword.getId(),
             postingKeyword.getName()
         );

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
@@ -3,6 +3,8 @@ package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingListResponse;
 import com.dreamteam.alter.domain.posting.type.PaymentType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -15,24 +17,31 @@ import java.util.List;
 @Schema(description = "공고 리스트 조회 응답 DTO")
 public class PostingListResponseDto {
 
+    @NotNull
     @Schema(description = "공고 ID", example = "1")
     private Long id;
 
+    @NotBlank
     @Schema(description = "공고 제목", example = "홀서빙 구합니다")
     private String title;
 
+    @NotNull
     @Schema(description = "급여", example = "10000")
     private int payAmount;
 
+    @NotNull
     @Schema(description = "급여 타입", example = "HOURLY")
     private PaymentType paymentType;
 
+    @NotNull
     @Schema(description = "생성일", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 
+    @NotNull
     @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
-    private List<KeywordListResponseDto> keywords;
+    private List<PostingKeywordListResponseDto> keywords;
 
+    @NotNull
     @Schema(description = "공고 스케줄", example = "[" +
         "{" +
         "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
@@ -54,7 +63,7 @@ public class PostingListResponseDto {
                 .map(PostingScheduleResponseDto::from)
                 .toList())
             .keywords(entity.getPostingKeywords().stream()
-                .map(KeywordListResponseDto::from)
+                .map(PostingKeywordListResponseDto::from)
                 .toList())
             .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleResponseDto.java
@@ -2,6 +2,8 @@ package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 
 import com.dreamteam.alter.domain.posting.entity.PostingSchedule;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.DayOfWeek;
@@ -15,18 +17,27 @@ import java.util.List;
 @Schema(description = "공고 스케줄 응답 DTO")
 public class PostingScheduleResponseDto {
 
+    @NotNull
     @Schema(description = "근무 요일", example = "['MONDAY', 'WEDNESDAY']")
     private List<DayOfWeek> workingDays;
 
+    @NotNull
     @Schema(description = "시작 시간", example = "09:00")
     private LocalTime startTime;
 
+    @NotNull
     @Schema(description = "종료 시간", example = "18:00")
     private LocalTime endTime;
 
+    @NotNull
     @Schema(description = "필요 인원", example = "3")
     private int positionsNeeded;
 
+    @NotNull
+    @Schema(description = "지원 가능한 포지션 수", example = "2")
+    private int positionsAvailable;
+
+    @NotBlank
     @Schema(description = "아르바이트 포지션", example = "홀서빙")
     private String position;
 
@@ -36,6 +47,7 @@ public class PostingScheduleResponseDto {
                 .startTime(entity.getStartTime())
                 .endTime(entity.getEndTime())
                 .positionsNeeded(entity.getPositionsNeeded())
+                .positionsAvailable(entity.getPositionsAvailable())
                 .position(entity.getPosition())
                 .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/workspace/dto/PostingDetailWorkspaceResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/workspace/dto/PostingDetailWorkspaceResponseDto.java
@@ -1,0 +1,63 @@
+package com.dreamteam.alter.adapter.inbound.general.workspace.dto;
+
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "공고 상세 조회 업장 정보 응답 DTO")
+public class PostingDetailWorkspaceResponseDto {
+
+    @NotNull
+    @Schema(description = "업장 ID", example = "1")
+    private Long id;
+
+    @NotBlank
+    @Schema(description = "업장 이름", example = "카페 알터")
+    private String name;
+
+    @NotBlank
+    @Schema(description = "업장 상세 주소", example = "서울특별시 강남구 테헤란로 123")
+    private String fullAddress;
+
+    @NotBlank
+    @Schema(description = "업장 시/도", example = "서울")
+    private String province;
+
+    @NotBlank
+    @Schema(description = "업장 시/군/구", example = "강남구")
+    private String district;
+
+    @NotBlank
+    @Schema(description = "업장 읍/면/동", example = "역삼동")
+    private String town;
+
+    @NotNull
+    @Schema(description = "업장 위도", example = "37.5665")
+    private BigDecimal latitude;
+
+    @NotNull
+    @Schema(description = "업장 경도", example = "126.9780")
+    private BigDecimal longitude;
+
+    public static PostingDetailWorkspaceResponseDto from(Workspace workspace) {
+        return PostingDetailWorkspaceResponseDto.builder()
+            .id(workspace.getId())
+            .name(workspace.getBusinessName())
+            .fullAddress(workspace.getFullAddress())
+            .province(workspace.getProvince())
+            .district(workspace.getDistrict())
+            .town(workspace.getTown())
+            .latitude(workspace.getLatitude())
+            .longitude(workspace.getLongitude())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingKeywordQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingKeywordQueryRepositoryImpl.java
@@ -26,4 +26,13 @@ public class PostingKeywordQueryRepositoryImpl implements PostingKeywordQueryRep
             .fetch();
     }
 
+    @Override
+    public List<PostingKeyword> findAll() {
+        QPostingKeyword qPostingKeyword = QPostingKeyword.postingKeyword;
+
+        return queryFactory
+            .selectFrom(qPostingKeyword)
+            .fetch();
+    }
+
 }

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
@@ -1,4 +1,4 @@
-package com.dreamteam.alter.application.posting;
+package com.dreamteam.alter.application.posting.usecase;
 
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.CreatePostingRequestDto;
 import com.dreamteam.alter.common.exception.CustomException;

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingDetail.java
@@ -1,4 +1,4 @@
-package com.dreamteam.alter.application.posting;
+package com.dreamteam.alter.application.posting.usecase;
 
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingDetailResponseDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingDetailResponse;

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingKeywordList.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingKeywordList.java
@@ -1,0 +1,34 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingKeywordListResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.inbound.GetPostingKeywordListUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("getPostingKeywordList")
+@RequiredArgsConstructor
+public class GetPostingKeywordList implements GetPostingKeywordListUseCase {
+
+    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+
+    @Override
+    public List<PostingKeywordListResponseDto> execute() {
+        List<PostingKeyword> postingKeywords = postingKeywordQueryRepository.findAll();
+
+        if (ObjectUtils.isEmpty(postingKeywords)) {
+            throw new CustomException(ErrorCode.POSTING_KEYWORDS_NOT_FOUND);
+        }
+
+        return postingKeywords.stream()
+            .map(PostingKeywordListResponseDto::from)
+            .toList();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingsWithCursor.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingsWithCursor.java
@@ -1,4 +1,4 @@
-package com.dreamteam.alter.application.posting;
+package com.dreamteam.alter.application.posting.usecase;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.*;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingListResponseDto;

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_KEYWORD(400, "B006", "잘못된 키워드 요청입니다."),
     POSTING_NOT_FOUND(400, "B007", "존재하지 않는 공고입니다."),
     WORKSPACE_NOT_FOUND(400, "B008", "존재하지 않는 업장입니다."),
+    POSTING_KEYWORDS_NOT_FOUND(400, "B009", "키워드 목록을 찾을 수 없습니다."),
 
     INTERNAL_SERVER_ERROR(400, "C001", "서버 내부 오류입니다."),
     ;

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingSchedule.java
@@ -46,6 +46,9 @@ public class PostingSchedule {
     @Column(name = "positions_needed", nullable = false)
     private int positionsNeeded;
 
+    @Column(name = "positions_available", nullable = false)
+    private int positionsAvailable;
+
     @Column(name = "position", length = 128, nullable = false)
     private String position;
 
@@ -68,6 +71,7 @@ public class PostingSchedule {
             .startTime(request.getStartTime())
             .endTime(request.getEndTime())
             .positionsNeeded(request.getPositionsNeeded())
+            .positionsAvailable(request.getPositionsNeeded())
             .position(request.getPosition())
             .status(PostingStatus.OPEN)
             .build();

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingKeywordListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingKeywordListUseCase.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingKeywordListResponseDto;
+
+import java.util.List;
+
+public interface GetPostingKeywordListUseCase {
+    List<PostingKeywordListResponseDto> execute();
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordQueryRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface PostingKeywordQueryRepository {
     List<PostingKeyword> findByIds(List<Long> keywordIds);
+    List<PostingKeyword> findAll();
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/Workspace.java
@@ -43,6 +43,7 @@ public class Workspace {
     @Column(name = "description", length = Integer.MAX_VALUE, nullable = true)
     private String description;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private WorkspaceStatus status;
 


### PR DESCRIPTION
## ID
- ALT-34

## 변경 내용
- 공고 등록 시 설정 가능한 키워드 리스트 조회 API 구현
- 공고 상세 조회 응답 스펙 변경

## 구현 사항
- 공고 상세 조회 시 업장(workspace)에 관한 기본 정보 응답 추가
- 기타 매핑 이슈 및 누락 이슈 해결