### PR TITLE
feat: 사용자 프로필 조회, 자격 사항 CRUD API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.domain.user.port.inbound.ReissueTokenUseCase;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/app/users")
+@PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
 @RequiredArgsConstructor
 @Validated
 public class UserController implements UserControllerSpec {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
@@ -12,11 +12,13 @@ import com.dreamteam.alter.domain.user.port.inbound.UpdateUserPostingApplication
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/app/users/me/postings/applications")
+@PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
 @RequiredArgsConstructor
 @Validated
 public class UserPostingController implements UserPostingControllerSpec {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
@@ -1,0 +1,35 @@
+package com.dreamteam.alter.adapter.inbound.general.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import com.dreamteam.alter.application.aop.AppActionContext;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfInfoUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/users/me")
+@PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
+@RequiredArgsConstructor
+@Validated
+public class UserSelfController implements UserSelfControllerSpec {
+
+    @Resource(name = "getUserSelfInfo")
+    private final GetUserSelfInfoUseCase getUserSelfInfo;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<CommonApiResponse<UserSelfInfoResponseDto>> getUserSelfInfo() {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(CommonApiResponse.of(getUserSelfInfo.execute(actor)));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
@@ -1,18 +1,18 @@
 package com.dreamteam.alter.adapter.inbound.general.user.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
-import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.*;
 import com.dreamteam.alter.application.aop.AppActionContext;
 import com.dreamteam.alter.domain.user.context.AppActor;
-import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfInfoUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.*;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/app/users/me")
@@ -24,12 +24,79 @@ public class UserSelfController implements UserSelfControllerSpec {
     @Resource(name = "getUserSelfInfo")
     private final GetUserSelfInfoUseCase getUserSelfInfo;
 
+    @Resource(name = "addUserCertificate")
+    private final AddUserCertificateUseCase addUserCertificate;
+
+    @Resource(name = "getUserSelfCertificateList")
+    private final GetUserSelfCertificateListUseCase getUserSelfCertificateList;
+
+    @Resource(name = "getUserSelfCertificate")
+    private final GetUserSelfCertificateUseCase getUserSelfCertificate;
+
+    @Resource(name = "updateUserSelfCertificate")
+    private final UpdateUserSelfCertificateUseCase updateUserSelfCertificate;
+
+    @Resource(name = "deleteUserSelfCertificate")
+    private final DeleteUserSelfCertificateUseCase deleteUserSelfCertificate;
+
     @Override
     @GetMapping
     public ResponseEntity<CommonApiResponse<UserSelfInfoResponseDto>> getUserSelfInfo() {
         AppActor actor = AppActionContext.getInstance().getActor();
 
         return ResponseEntity.ok(CommonApiResponse.of(getUserSelfInfo.execute(actor)));
+    }
+
+    @Override
+    @PostMapping("/certificates")
+    public ResponseEntity<CommonApiResponse<Void>> addUserCertificate(
+        CreateUserCertificateRequestDto request
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        addUserCertificate.execute(request, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/certificates")
+    public ResponseEntity<CommonApiResponse<List<UserSelfCertificateListResponseDto>>> getUserSelfCertificateList() {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(CommonApiResponse.of(getUserSelfCertificateList.execute(actor)));
+    }
+
+    @Override
+    @GetMapping("/certificates/{certificateId}")
+    public ResponseEntity<CommonApiResponse<UserSelfCertificateResponseDto>> getUserSelfCertificate(
+        @PathVariable Long certificateId
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(CommonApiResponse.of(getUserSelfCertificate.execute(actor, certificateId)));
+    }
+
+    @Override
+    @PutMapping("/certificates/{certificateId}")
+    public ResponseEntity<CommonApiResponse<Void>> updateUserSelfCertificate(
+        @PathVariable Long certificateId,
+        UpdateUserCertificateRequestDto request
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        updateUserSelfCertificate.execute(actor, certificateId, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @DeleteMapping("/certificates/{certificateId}")
+    public ResponseEntity<CommonApiResponse<Void>> deleteUserSelfCertificate(
+        @PathVariable Long certificateId
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        deleteUserSelfCertificate.execute(actor, certificateId);
+        return ResponseEntity.ok(CommonApiResponse.empty());
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
@@ -1,0 +1,34 @@
+package com.dreamteam.alter.adapter.inbound.general.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "마이페이지 사용자 정보")
+public interface UserSelfControllerSpec {
+
+    @Operation(summary = "사용자 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 조회 실패",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<UserSelfInfoResponseDto>> getUserSelfInfo();
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
@@ -2,7 +2,7 @@ package com.dreamteam.alter.adapter.inbound.general.user.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
 import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
-import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -10,7 +10,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "마이페이지 사용자 정보")
 public interface UserSelfControllerSpec {
@@ -30,5 +34,66 @@ public interface UserSelfControllerSpec {
                 }))
     })
     ResponseEntity<CommonApiResponse<UserSelfInfoResponseDto>> getUserSelfInfo();
+
+    @Operation(summary = "사용자 자격 정보 등록")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 자격 정보 등록 성공")
+    })
+    ResponseEntity<CommonApiResponse<Void>> addUserCertificate(@RequestBody @Valid CreateUserCertificateRequestDto request);
+
+    @Operation(summary = "사용자 자격 정보 목록 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 자격 정보 목록 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<List<UserSelfCertificateListResponseDto>>> getUserSelfCertificateList();
+
+    @Operation(summary = "사용자 자격 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 자격 정보 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<UserSelfCertificateResponseDto>> getUserSelfCertificate(Long certificateId);
+
+    @Operation(summary = "사용자 자격 정보 갱신")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 자격 정보 갱신 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 조회 실패",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "사용자 자격 정보 조회 실패",
+                        value = "{\"code\" : \"B014\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> updateUserSelfCertificate(
+        Long certificateId,
+        @RequestBody @Valid UpdateUserCertificateRequestDto request
+    );
+
+    @Operation(summary = "사용자 자격 정보 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 자격 정보 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 조회 실패",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "사용자 자격 정보 조회 실패",
+                        value = "{\"code\" : \"B014\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> deleteUserSelfCertificate(Long certificateId);
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserCertificateRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserCertificateRequestDto.java
@@ -1,0 +1,44 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.user.type.CertificateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 자격 정보 생성 요청 DTO")
+public class CreateUserCertificateRequestDto {
+
+    @NotNull
+    @Schema(description = "자격증 종류", example = "CERTIFICATE")
+    private CertificateType type;
+
+    @NotBlank
+    @Schema(description = "자격증 이름", example = "정보처리기사")
+    private String certificateName;
+
+    @Nullable
+    @Schema(description = "자격증 일련번호", example = "1234567890")
+    private String certificateId;
+
+    @NotBlank
+    @Schema(description = "발행 기관 이름", example = "한국산업인력공단")
+    private String publisherName;
+
+    @NotNull
+    @Schema(description = "취득일", example = "2023-10-01")
+    private LocalDate issuedAt;
+
+    @Nullable
+    @Schema(description = "만료일", example = "2025-10-01")
+    private LocalDate expiresAt;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UpdateUserCertificateRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UpdateUserCertificateRequestDto.java
@@ -1,0 +1,35 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.user.type.CertificateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 자격 정보 업데이트 요청 DTO")
+public class UpdateUserCertificateRequestDto {
+
+    @Schema(description = "자격증 종류", example = "CERTIFICATE")
+    private CertificateType type;
+
+    @Schema(description = "자격증 이름", example = "정보처리기사")
+    private String certificateName;
+
+    @Schema(description = "자격증 일련번호", example = "1234567890")
+    private String certificateId;
+
+    @Schema(description = "발행 기관 이름", example = "한국산업인력공단")
+    private String publisherName;
+
+    @Schema(description = "취득일", example = "2023-10-01")
+    private LocalDate issuedAt;
+
+    @Schema(description = "만료일", example = "2025-10-01")
+    private LocalDate expiresAt;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfCertificateListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfCertificateListResponseDto.java
@@ -1,0 +1,49 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.user.entity.UserCertificate;
+import com.dreamteam.alter.domain.user.type.CertificateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "사용자 자격 및 면허증 목록 응답 DTO")
+public class UserSelfCertificateListResponseDto {
+
+    @NotNull
+    @Schema(description = "등록 ID", example = "1")
+    private Long id;
+
+    @NotNull
+    @Schema(description = "자격증 종류", example = "CERTIFICATE")
+    private CertificateType type;
+
+    @NotBlank
+    @Schema(description = "자격 이름", example = "정보처리기사")
+    private String certificateName;
+
+    @NotBlank
+    @Schema(description = "발행기관", example = "한국산업인력공단")
+    private String publisherName;
+
+    @NotNull
+    @Schema(description = "취득일", example = "2023-10-01")
+    private LocalDate issuedAt;
+
+    public static UserSelfCertificateListResponseDto from(UserCertificate entity) {
+        return UserSelfCertificateListResponseDto.builder()
+                .id(entity.getId())
+                .type(entity.getType())
+                .certificateName(entity.getCertificateName())
+                .publisherName(entity.getPublisherName())
+                .issuedAt(entity.getIssuedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfCertificateResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfCertificateResponseDto.java
@@ -1,0 +1,66 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.user.entity.UserCertificate;
+import com.dreamteam.alter.domain.user.type.CertificateType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "사용자 자격증 응답 DTO")
+public class UserSelfCertificateResponseDto {
+
+    @NotNull
+    @Schema(description = "등록 ID", example = "1")
+    private Long id;
+
+    @NotNull
+    @Schema(description = "자격증 종류", example = "CERTIFICATE")
+    private CertificateType type;
+
+    @NotBlank
+    @Schema(description = "자격 이름", example = "정보처리기사")
+    private String certificateName;
+
+    @Nullable
+    @Schema(description = "자격증 ID", example = "1234567890")
+    private String certificateId;
+
+    @NotBlank
+    @Schema(description = "발행기관", example = "한국산업인력공단")
+    private String publisherName;
+
+    @NotNull
+    @Schema(description = "취득일", example = "2023-10-01")
+    private LocalDate issuedAt;
+
+    @Nullable
+    @Schema(description = "만료일", example = "2024-10-01")
+    private LocalDate expiresAt;
+
+    @NotNull
+    @Schema(description = "최종 수정일", example = "2023-10-01T12:00:00")
+    private LocalDateTime updatedAt;
+
+    public static UserSelfCertificateResponseDto from(UserCertificate entity) {
+        return UserSelfCertificateResponseDto.builder()
+                .id(entity.getId())
+                .type(entity.getType())
+                .certificateName(entity.getCertificateName())
+                .certificateId(entity.getCertificateId())
+                .publisherName(entity.getPublisherName())
+                .issuedAt(entity.getIssuedAt())
+                .expiresAt(entity.getExpiresAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfInfoResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfInfoResponseDto.java
@@ -1,0 +1,43 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserSelfInfoResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "마이페이지 사용자 간략 정보 응답 DTO")
+public class UserSelfInfoResponseDto {
+
+    @NotNull
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @NotBlank
+    @Schema(description = "사용자 이름", example = "김철수")
+    private String name;
+
+    @NotBlank
+    @Schema(description = "사용자 닉네임", example = "김땡땡")
+    private String nickname;
+
+    @NotNull
+    @Schema(description = "가입일", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static UserSelfInfoResponseDto from(UserSelfInfoResponse entity) {
+        return UserSelfInfoResponseDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .nickname(entity.getNickname())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.dreamteam.alter.adapter.outbound.user.persistence;
 
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserSelfInfoResponse;
 import com.dreamteam.alter.domain.user.entity.QUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import com.dreamteam.alter.domain.user.type.UserStatus;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
@@ -65,6 +67,29 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
                 user.status.eq(UserStatus.ACTIVE)
             )
             .fetchOne();
+    }
+
+    @Override
+    public Optional<UserSelfInfoResponse> getUserSelfInfoSummary(Long id) {
+        QUser qUser = QUser.user;
+
+        UserSelfInfoResponse userSelf = queryFactory.select(
+                Projections.fields(
+                    UserSelfInfoResponse.class,
+                    qUser.id,
+                    qUser.name,
+                    qUser.nickname,
+                    qUser.createdAt
+                )
+            )
+            .from(qUser)
+            .where(
+                qUser.id.eq(id),
+                qUser.status.eq(UserStatus.ACTIVE)
+            )
+            .fetchOne();
+
+        return ObjectUtils.isEmpty(userSelf) ? Optional.empty() : Optional.of(userSelf);
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserSelfInfoResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserSelfInfoResponse.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence.readonly;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSelfInfoResponse {
+
+    private Long id;
+
+    private String name;
+
+    private String nickname;
+
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/AddUserCertificate.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/AddUserCertificate.java
@@ -1,0 +1,29 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserCertificateRequestDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.entity.UserCertificate;
+import com.dreamteam.alter.domain.user.port.inbound.AddUserCertificateUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("addUserCertificate")
+@RequiredArgsConstructor
+@Transactional
+public class AddUserCertificate implements AddUserCertificateUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void execute(CreateUserCertificateRequestDto request, AppActor actor) {
+        User user = actor.getUser();
+        user.addCertificate(UserCertificate.create(request, user));
+
+        // 영속성에 관리되지 않으므로 직접 저장 처리
+        userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/DeleteUserSelfCertificate.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/DeleteUserSelfCertificate.java
@@ -1,0 +1,31 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.DeleteUserSelfCertificateUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("deleteUserSelfCertificate")
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserSelfCertificate implements DeleteUserSelfCertificateUseCase {
+
+    private final UserQueryRepository userQueryRepository;
+
+    @Override
+    public void execute(AppActor actor, Long certificateId) {
+        userQueryRepository.findById(actor.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+            .getCertificates()
+            .stream()
+            .filter(it -> it.getId().equals(certificateId))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_CERTIFICATE_NOT_FOUND))
+            .delete();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfCertificate.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfCertificate.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfCertificateResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfCertificateUseCase;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("getUserSelfCertificate")
+@RequiredArgsConstructor
+@Transactional
+public class GetUserSelfCertificate implements GetUserSelfCertificateUseCase {
+
+    @Override
+    public UserSelfCertificateResponseDto execute(AppActor actor, Long certificateId) {
+        return UserSelfCertificateResponseDto.from(actor.getUser().getCertificates()
+            .stream()
+            .filter(it -> it.getId().equals(certificateId))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_CERTIFICATE_NOT_FOUND)));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfCertificateList.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfCertificateList.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfCertificateListResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfCertificateListUseCase;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("getUserSelfCertificateList")
+@RequiredArgsConstructor
+@Transactional
+public class GetUserSelfCertificateList implements GetUserSelfCertificateListUseCase {
+
+    @Override
+    public List<UserSelfCertificateListResponseDto> execute(AppActor actor) {
+        return actor.getUser()
+            .getCertificates()
+            .stream()
+            .map(UserSelfCertificateListResponseDto::from)
+            .toList();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfInfo.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfInfo.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfInfoUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("getUserSelfInfo")
+@RequiredArgsConstructor
+@Transactional
+public class GetUserSelfInfo implements GetUserSelfInfoUseCase {
+
+    private final UserQueryRepository userQueryRepository;
+
+    @Override
+    public UserSelfInfoResponseDto execute(AppActor actor) {
+        return UserSelfInfoResponseDto.from(userQueryRepository.getUserSelfInfoSummary(actor.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND)));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/UpdateUserSelfCertificate.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/UpdateUserSelfCertificate.java
@@ -1,0 +1,32 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UpdateUserCertificateRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.UpdateUserSelfCertificateUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("updateUserSelfCertificate")
+@RequiredArgsConstructor
+@Transactional
+public class UpdateUserSelfCertificate implements UpdateUserSelfCertificateUseCase {
+
+    private final UserQueryRepository userQueryRepository;
+
+    @Override
+    public void execute(AppActor actor, Long certificateId, UpdateUserCertificateRequestDto request) {
+        userQueryRepository.findById(actor.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+            .getCertificates()
+            .stream()
+            .filter(it -> it.getId().equals(certificateId))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_CERTIFICATE_NOT_FOUND))
+            .update(request);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(400, "B011", "존재하지 않는 사용자입니다."),
     POSTING_APPLICATION_NOT_FOUND(400, "B012", "존재하지 않는 공고 지원서입니다."),
     POSTING_APPLICATION_ALREADY_CANCELLED(400, "B013", "이미 취소 처리된 공고 지원서입니다."),
+    USER_CERTIFICATE_NOT_FOUND(400, "B014", "존재하지 않는 사용자 자격 정보입니다."),
 
     INTERNAL_SERVER_ERROR(400, "C001", "서버 내부 오류입니다."),
     ;

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -14,6 +14,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -71,6 +72,11 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id DESC")
+    @SQLRestriction("status != 'DELETED'")
+    private List<UserCertificate> certificates;
+
     public static User create(
         CreateUserRequestDto request,
         SocialUserInfo socialUserInfo
@@ -87,6 +93,10 @@ public class User {
             .role(UserRole.ROLE_USER)
             .status(UserStatus.ACTIVE)
             .build();
+    }
+
+    public void addCertificate(UserCertificate userCertificate) {
+        certificates.add(userCertificate);
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.domain.user.type.UserRole;
 import com.dreamteam.alter.domain.user.type.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -59,6 +60,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
+    @SQLRestriction("status != 'DELETED'")
     private UserStatus status;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/UserCertificate.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/UserCertificate.java
@@ -1,9 +1,14 @@
 package com.dreamteam.alter.domain.user.entity;
 
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserCertificateRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UpdateUserCertificateRequestDto;
 import com.dreamteam.alter.domain.user.type.CertificateType;
+import com.dreamteam.alter.domain.user.type.UserCertificateStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
@@ -12,6 +17,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "user_certificates")
+@DynamicUpdate
 @Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -30,30 +36,57 @@ public class UserCertificate {
     @Column(name = "type", nullable = false)
     private CertificateType type;
 
-    @Column(name = "certificate_id", length = Integer.MAX_VALUE, nullable = false)
+    @Column(name = "certificate_name", length = 255, nullable = false)
+    private String certificateName;
+
+    @Column(name = "certificate_id", length = Integer.MAX_VALUE, nullable = true)
     private String certificateId;
+
+    @Column(name = "publisher_name", length = 255, nullable = false)
+    private String publisherName;
 
     @Column(name = "issued_at", nullable = false)
     private LocalDate issuedAt;
 
-    @Column(name = "expires_at", nullable = false)
+    @Column(name = "expires_at", nullable = true)
     private LocalDate expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private UserCertificateStatus status;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static UserCertificate create(User user, CertificateType type, String certificateId, LocalDate issuedAt, LocalDate expiresAt) {
+    public static UserCertificate create(CreateUserCertificateRequestDto request, User user) {
         return UserCertificate.builder()
             .user(user)
-            .type(type)
-            .certificateId(certificateId)
-            .issuedAt(issuedAt)
-            .expiresAt(expiresAt)
+            .type(request.getType())
+            .certificateName(request.getCertificateName())
+            .certificateId(request.getCertificateId())
+            .publisherName(request.getPublisherName())
+            .issuedAt(request.getIssuedAt())
+            .expiresAt(request.getExpiresAt())
+            .status(UserCertificateStatus.ACTIVATED)
             .build();
+    }
+
+    public void update(UpdateUserCertificateRequestDto request) {
+        this.type = request.getType();
+        this.certificateName = request.getCertificateName();
+        this.certificateId = request.getCertificateId();
+        this.publisherName = request.getPublisherName();
+        this.issuedAt = request.getIssuedAt();
+        this.expiresAt = request.getExpiresAt();
+    }
+
+    public void delete() {
+        this.status = UserCertificateStatus.DELETED;
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/AddUserCertificateUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/AddUserCertificateUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserCertificateRequestDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface AddUserCertificateUseCase {
+    void execute(CreateUserCertificateRequestDto request, AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/DeleteUserSelfCertificateUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/DeleteUserSelfCertificateUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface DeleteUserSelfCertificateUseCase {
+    void execute(AppActor actor, Long certificateId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfCertificateListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfCertificateListUseCase.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfCertificateListResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+import java.util.List;
+
+public interface GetUserSelfCertificateListUseCase {
+    List<UserSelfCertificateListResponseDto> execute(AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfCertificateUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfCertificateUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfCertificateResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface GetUserSelfCertificateUseCase {
+    UserSelfCertificateResponseDto execute(AppActor actor, Long certificateId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfInfoUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserSelfInfoUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserSelfInfoResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface GetUserSelfInfoUseCase {
+    UserSelfInfoResponseDto execute(AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/UpdateUserSelfCertificateUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/UpdateUserSelfCertificateUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UpdateUserCertificateRequestDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface UpdateUserSelfCertificateUseCase {
+    void execute(AppActor actor, Long certificateId, UpdateUserCertificateRequestDto request);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserQueryRepository.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.domain.user.port.outbound;
 
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserSelfInfoResponse;
 import com.dreamteam.alter.domain.user.entity.User;
 
 import java.util.Optional;
@@ -9,4 +10,5 @@ public interface UserQueryRepository {
     User findBySocialId(String socialId);
     User findByEmail(String email);
     User findByNickname(String nickname);
+    Optional<UserSelfInfoResponse> getUserSelfInfoSummary(Long id);
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/type/UserCertificateStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/type/UserCertificateStatus.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.type;
+
+public enum UserCertificateStatus {
+    ACTIVATED,
+    EXPIRED,
+    DELETED
+    ;
+}


### PR DESCRIPTION
## ID
- ALT-31

## 변경 내용
- 사용자의 기본 프로필 정보를 응답한다
- 사용자가 자신의 자격 사항을 등록한다
- 사용자의 자격 사항 목록 및 세부 내용을 조회한다
- 사용자의 자격 사항을 갱신/삭제한다

## 구현 사항
- User의 기본 정보 응답 구현
- 사용자의 자격 사항(UserCertificate)에 관한 CRUD 구현