### PR TITLE
feat: 사용자 공고 스크랩 관련 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
@@ -1,14 +1,12 @@
 package com.dreamteam.alter.adapter.inbound.general.user.controller;
 
-import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
-import com.dreamteam.alter.adapter.inbound.common.dto.PageRequestDto;
-import com.dreamteam.alter.adapter.inbound.common.dto.PaginatedResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.*;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UpdateUserPostingApplicationStatusRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
 import com.dreamteam.alter.application.aop.AppActionContext;
 import com.dreamteam.alter.domain.user.context.AppActor;
-import com.dreamteam.alter.domain.user.port.inbound.GetUserPostingApplicationListUseCase;
-import com.dreamteam.alter.domain.user.port.inbound.UpdateUserPostingApplicationStatusUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.*;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +15,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/app/users/me/postings/applications")
+@RequestMapping("/app/users/me/postings")
 @PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
 @RequiredArgsConstructor
 @Validated
@@ -29,8 +27,17 @@ public class UserPostingController implements UserPostingControllerSpec {
     @Resource(name = "updateUserPostingApplicationStatus")
     private final UpdateUserPostingApplicationStatusUseCase updateUserPostingApplicationStatus;
 
+    @Resource(name = "createUserFavoritePosting")
+    private final CreateUserFavoritePostingUseCase createUserFavoritePosting;
+
+    @Resource(name = "getUserFavoritePostingList")
+    private final GetUserFavoritePostingListUseCase getUserFavoritePostingList;
+
+    @Resource(name = "deleteUserFavoritePosting")
+    private final DeleteUserFavoritePostingUseCase deleteUserFavoritePosting;
+
     @Override
-    @GetMapping
+    @GetMapping("/applications")
     public ResponseEntity<PaginatedResponseDto<UserPostingApplicationListResponseDto>> getMyPostingApplications(
         PageRequestDto pageRequest
     ) {
@@ -40,7 +47,7 @@ public class UserPostingController implements UserPostingControllerSpec {
     }
 
     @Override
-    @PatchMapping("/{applicationId}/status")
+    @PatchMapping("/applications/{applicationId}/status")
     public ResponseEntity<CommonApiResponse<Void>> updateMyPostingApplicationStatus(
         @PathVariable Long applicationId,
         UpdateUserPostingApplicationStatusRequestDto request
@@ -48,6 +55,34 @@ public class UserPostingController implements UserPostingControllerSpec {
         AppActor actor = AppActionContext.getInstance().getActor();
 
         updateUserPostingApplicationStatus.execute(actor, applicationId, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @PostMapping("/favorites/{postingId}")
+    public ResponseEntity<CommonApiResponse<Void>> addUserFavoritePosting(@PathVariable Long postingId) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        createUserFavoritePosting.execute(actor, postingId);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/favorites")
+    public ResponseEntity<CursorPaginatedApiResponse<UserFavoritePostingListResponseDto>> getUserFavoritePostingList(
+        CursorPageRequestDto pageRequest
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(getUserFavoritePostingList.execute(actor, pageRequest));
+    }
+
+    @Override
+    @DeleteMapping("/favorites/{favoritePostingId}")
+    public ResponseEntity<CommonApiResponse<Void>> deleteUserFavoritePosting(@PathVariable Long favoritePostingId) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        deleteUserFavoritePosting.execute(actor, favoritePostingId);
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingControllerSpec.java
@@ -1,11 +1,9 @@
 package com.dreamteam.alter.adapter.inbound.general.user.controller;
 
-import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
-import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
-import com.dreamteam.alter.adapter.inbound.common.dto.PageRequestDto;
-import com.dreamteam.alter.adapter.inbound.common.dto.PaginatedResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.*;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UpdateUserPostingApplicationStatusRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -19,7 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "APP - 사용자 지원한 공고 관련 API")
+@Tag(name = "APP - 사용자 공고 관련 API")
 public interface UserPostingControllerSpec {
 
     @Operation(summary = "사용자 공고 지원 목록 조회")
@@ -53,6 +51,52 @@ public interface UserPostingControllerSpec {
     ResponseEntity<CommonApiResponse<Void>> updateMyPostingApplicationStatus(
         @PathVariable @Min(1) Long applicationId,
         @RequestBody @Valid UpdateUserPostingApplicationStatusRequestDto request
+    );
+
+    @Operation(summary = "사용자 공고 스크랩 등록")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 공고 스크랩 등록 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "사용자가 이미 스크랩한 공고인 경우",
+                        value = "{\"code\" : \"B016\"}"
+                    ),
+                    @ExampleObject(
+                        name = "존재하지 않는 공고인 경우",
+                        value = "{\"code\" : \"B007\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> addUserFavoritePosting(@PathVariable @Min(1) Long postingId);
+
+    @Operation(summary = "사용자 공고 스크랩 목록 조회 (커서 페이징)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 공고 스크랩 목록 조회 성공")
+    })
+    ResponseEntity<CursorPaginatedApiResponse<UserFavoritePostingListResponseDto>> getUserFavoritePostingList(
+        CursorPageRequestDto pageRequest
+    );
+
+    @Operation(summary = "사용자 공고 스크랩 삭제")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "사용자 공고 스크랩 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 스크랩 공고인 경우",
+                        value = "{\"code\" : \"B015\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> deleteUserFavoritePosting(
+        @PathVariable @Min(1) Long favoritePostingId
     );
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserFavoritePostingListPostingSummaryResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserFavoritePostingListPostingSummaryResponseDto.java
@@ -1,0 +1,47 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import com.dreamteam.alter.domain.posting.type.PaymentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "사용자 스크랩한 공고 요약 정보 DTO")
+public class UserFavoritePostingListPostingSummaryResponseDto {
+
+    @NotNull
+    @Schema(description = "공고 ID", example = "1")
+    private Long id;
+
+    @NotBlank
+    @Schema(description = "업장 이름", example = "카페 드림")
+    private String businessName;
+
+    @NotBlank
+    @Schema(description = "공고 제목", example = "홀서빙 구합니다")
+    private String title;
+
+    @NotNull
+    @Schema(description = "급여", example = "10000")
+    private int payAmount;
+
+    @NotNull
+    @Schema(description = "급여 타입", example = "HOURLY")
+    private PaymentType paymentType;
+
+    public static UserFavoritePostingListPostingSummaryResponseDto from (Posting entity) {
+        return UserFavoritePostingListPostingSummaryResponseDto.builder()
+            .id(entity.getId())
+            .businessName(entity.getWorkspace().getBusinessName())
+            .title(entity.getTitle())
+            .payAmount(entity.getPayAmount())
+            .paymentType(entity.getPaymentType())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserFavoritePostingListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserFavoritePostingListResponseDto.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFavoritePostingListResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "사용자 스크랩한 공고 목록 응답 DTO")
+public class UserFavoritePostingListResponseDto {
+
+    @NotNull
+    @Schema(description = "스크랩 ID", example = "1")
+    private Long id;
+
+    @NotNull
+    @Schema(description = "스크랩한 공고 정보")
+    private UserFavoritePostingListPostingSummaryResponseDto posting;
+
+    @NotNull
+    @Schema(description = "스크랩한 날짜", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static UserFavoritePostingListResponseDto from(UserFavoritePostingListResponse entity) {
+        return com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto.builder()
+            .id(entity.getId())
+            .posting(UserFavoritePostingListPostingSummaryResponseDto.from(entity.getPosting()))
+            .createdAt(entity.getCreatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -113,6 +114,22 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
             .fetch();
 
         return PostingDetailResponse.of(posting, postingKeywords);
+    }
+
+    @Override
+    public Optional<Posting> findById(Long postingId) {
+        QPosting qPosting = QPosting.posting;
+
+        Posting posting = queryFactory
+            .select(qPosting)
+            .from(qPosting)
+            .where(
+                qPosting.id.eq(postingId),
+                qPosting.status.eq(PostingStatus.OPEN)
+            )
+            .fetchOne();
+
+        return ObjectUtils.isEmpty(posting) ? Optional.empty() : Optional.of(posting);
     }
 
     private BooleanExpression cursorConditions(QPosting qPosting, CursorDto cursor) {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence;
+
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserFavoritePostingJpaRepository extends JpaRepository<UserFavoritePosting, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingQueryRepositoryImpl.java
@@ -1,0 +1,107 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFavoritePostingListResponse;
+import com.dreamteam.alter.domain.posting.entity.QPosting;
+import com.dreamteam.alter.domain.user.entity.QUserFavoritePosting;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingQueryRepository;
+import com.dreamteam.alter.domain.workspace.entity.QWorkspace;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserFavoritePostingQueryRepositoryImpl implements UserFavoritePostingQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long getCountByUser(User user) {
+        QUserFavoritePosting qUserFavoritePosting = QUserFavoritePosting.userFavoritePosting;
+
+        Long count = queryFactory
+            .select(qUserFavoritePosting.count())
+            .from(qUserFavoritePosting)
+            .where(qUserFavoritePosting.user.eq(user))
+            .fetchOne();
+
+        return ObjectUtils.isEmpty(count) ? 0 : count;
+    }
+
+    @Override
+    public List<UserFavoritePostingListResponse> findUserFavoritePostingListWithCursor(
+        User user,
+        CursorPageRequest<CursorDto> request
+    ) {
+        QUserFavoritePosting qUserFavoritePosting = QUserFavoritePosting.userFavoritePosting;
+        QPosting qPosting = QPosting.posting;
+        QWorkspace qWorkspace = QWorkspace.workspace;
+
+        return queryFactory
+            .select(Projections.constructor(
+                UserFavoritePostingListResponse.class,
+                qUserFavoritePosting.id,
+                qUserFavoritePosting.posting,
+                qUserFavoritePosting.createdAt
+            ))
+            .from(qUserFavoritePosting)
+            .join(qUserFavoritePosting.posting, qPosting)
+            .join(qPosting.workspace, qWorkspace)
+            .fetchJoin()
+            .where(
+                qUserFavoritePosting.user.eq(user),
+                cursorConditions(qUserFavoritePosting, request.cursor())
+            )
+            .orderBy(qUserFavoritePosting.createdAt.desc(), qUserFavoritePosting.id.desc())
+            .limit(request.pageSize())
+            .fetch();
+    }
+
+    @Override
+    public Optional<UserFavoritePosting> findByIdAndUser(Long favoritePostingId, User user) {
+        QUserFavoritePosting qUserFavoritePosting = QUserFavoritePosting.userFavoritePosting;
+
+        return Optional.ofNullable(
+            queryFactory
+                .select(qUserFavoritePosting)
+                .from(qUserFavoritePosting)
+                .where(
+                    qUserFavoritePosting.id.eq(favoritePostingId),
+                    qUserFavoritePosting.user.eq(user)
+                )
+                .fetchOne()
+        );
+    }
+
+    private BooleanExpression cursorConditions(QUserFavoritePosting qUserFavoritePosting, CursorDto cursor) {
+        return ObjectUtils.isEmpty(cursor)
+            ? null
+            : ltCreatedAt(qUserFavoritePosting, cursor.getCreatedAt())
+                .or(eqCreatedAt(qUserFavoritePosting, cursor.getCreatedAt())
+                    .and(ltUserFavoritePostingId(qUserFavoritePosting, cursor.getId())));
+    }
+
+    private BooleanExpression ltCreatedAt(QUserFavoritePosting qUserFavoritePosting, LocalDateTime createdAt) {
+        return createdAt != null ? qUserFavoritePosting.createdAt.lt(createdAt) : null;
+    }
+
+    private BooleanExpression eqCreatedAt(QUserFavoritePosting qUserFavoritePosting, LocalDateTime createdAt) {
+        return createdAt != null ? qUserFavoritePosting.createdAt.eq(createdAt) : null;
+    }
+
+    private BooleanExpression ltUserFavoritePostingId(QUserFavoritePosting qUserFavoritePosting, Long favoritePostingId) {
+        return favoritePostingId != null ? qUserFavoritePosting.id.lt(favoritePostingId) : null;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserFavoritePostingRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence;
+
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class UserFavoritePostingRepositoryImpl implements UserFavoritePostingRepository {
+
+    private final UserFavoritePostingJpaRepository userFavoritePostingJpaRepository;
+
+    @Override
+    public void save(UserFavoritePosting favoritePosting) {
+        userFavoritePostingJpaRepository.save(favoritePosting);
+    }
+
+    @Override
+    public void delete(UserFavoritePosting favoritePosting) {
+        userFavoritePostingJpaRepository.delete(favoritePosting);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserFavoritePostingListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserFavoritePostingListResponse.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence.readonly;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserFavoritePostingListResponse {
+
+    private Long id;
+
+    private Posting posting;
+
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserFavoritePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserFavoritePosting.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingQueryRepository;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+import com.dreamteam.alter.domain.user.port.inbound.CreateUserFavoritePostingUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service("createUserFavoritePosting")
+@RequiredArgsConstructor
+@Transactional
+public class CreateUserFavoritePosting implements CreateUserFavoritePostingUseCase {
+
+    private final UserFavoritePostingRepository userFavoritePostingRepository;
+    private final PostingQueryRepository postingQueryRepository;
+
+    @Override
+    public void execute(AppActor actor, Long postingId) {
+        try {
+            userFavoritePostingRepository.save(UserFavoritePosting.create(
+                actor.getUser(),
+                postingQueryRepository.findById(postingId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.POSTING_NOT_FOUND))
+            ));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.USER_FAVORITE_POSTING_DUPLICATED);
+        }
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/DeleteUserFavoritePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/DeleteUserFavoritePosting.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.port.inbound.DeleteUserFavoritePostingUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingQueryRepository;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service("deleteUserFavoritePosting")
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserFavoritePosting implements DeleteUserFavoritePostingUseCase {
+
+    private final UserFavoritePostingQueryRepository userFavoritePostingQueryRepository;
+    private final UserFavoritePostingRepository userFavoritePostingRepository;
+
+    @Override
+    public void execute(AppActor actor, Long favoritePostingId) {
+        userFavoritePostingRepository.delete(
+            userFavoritePostingQueryRepository.findByIdAndUser(favoritePostingId, actor.getUser())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_FAVORITE_POSTING_NOT_FOUND)));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserFavoritePostingList.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserFavoritePostingList.java
@@ -1,0 +1,65 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.*;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFavoritePostingListResponse;
+import com.dreamteam.alter.common.util.CursorUtil;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.GetUserFavoritePostingListUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserFavoritePostingQueryRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("getUserFavoritePostingList")
+@RequiredArgsConstructor
+@Transactional
+public class GetUserFavoritePostingList implements GetUserFavoritePostingListUseCase {
+
+    private final UserFavoritePostingQueryRepository userFavoritePostingQueryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public CursorPaginatedApiResponse<UserFavoritePostingListResponseDto> execute(
+        AppActor actor,
+        CursorPageRequestDto request
+    ) {
+        User user = actor.getUser();
+
+        CursorDto cursorDto = null;
+        if (ObjectUtils.isNotEmpty(request.cursor())) {
+            cursorDto = CursorUtil.decodeCursor(request.cursor(), CursorDto.class, objectMapper);
+        }
+        CursorPageRequest<CursorDto> pageRequest = CursorPageRequest.of(cursorDto, request.pageSize());
+
+        long count = userFavoritePostingQueryRepository.getCountByUser(user);
+        if (count == 0) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        List<UserFavoritePostingListResponse> favoritePostings = userFavoritePostingQueryRepository.findUserFavoritePostingListWithCursor(user, pageRequest);
+        if (ObjectUtils.isEmpty(favoritePostings)) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        UserFavoritePostingListResponse last = favoritePostings.getLast();
+        CursorPageResponseDto pageResponseDto = CursorPageResponseDto.of(
+            CursorUtil.encodeCursor(new CursorDto(last.getId(), last.getCreatedAt()), objectMapper),
+            pageRequest.pageSize(),
+            (int) count
+        );
+
+        return CursorPaginatedApiResponse.of(
+            pageResponseDto,
+            favoritePostings.stream()
+                .map(com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto::from)
+                .toList()
+        );
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     POSTING_APPLICATION_NOT_FOUND(400, "B012", "존재하지 않는 공고 지원서입니다."),
     POSTING_APPLICATION_ALREADY_CANCELLED(400, "B013", "이미 취소 처리된 공고 지원서입니다."),
     USER_CERTIFICATE_NOT_FOUND(400, "B014", "존재하지 않는 사용자 자격 정보입니다."),
+    USER_FAVORITE_POSTING_NOT_FOUND(400, "B015", "존재하지 않는 사용자 스크랩 공고입니다."),
+    USER_FAVORITE_POSTING_DUPLICATED(400, "B016", "이미 스크랩한 공고입니다."),
 
     INTERNAL_SERVER_ERROR(400, "C001", "서버 내부 오류입니다."),
     ;

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingQueryRepository.java
@@ -4,11 +4,14 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingDetailResponse;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingListResponse;
+import com.dreamteam.alter.domain.posting.entity.Posting;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostingQueryRepository {
     long getCountOfPostings();
     List<PostingListResponse> getPostingsWithCursor(CursorPageRequest<CursorDto> request);
     PostingDetailResponse getPostingDetail(Long postingId);
+    Optional<Posting> findById(Long postingId);
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/UserFavoritePosting.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/UserFavoritePosting.java
@@ -1,0 +1,47 @@
+package com.dreamteam.alter.domain.user.entity;
+
+import com.dreamteam.alter.domain.posting.entity.Posting;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(
+    name = "user_favorite_postings",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "posting_id"})
+)
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class UserFavoritePosting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "posting_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Posting posting;
+
+    @LastModifiedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static UserFavoritePosting create(User user, Posting posting) {
+        return UserFavoritePosting.builder()
+            .user(user)
+            .posting(posting)
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/CreateUserFavoritePostingUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/CreateUserFavoritePostingUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface CreateUserFavoritePostingUseCase {
+    void execute(AppActor actor, Long postingId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/DeleteUserFavoritePostingUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/DeleteUserFavoritePostingUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface DeleteUserFavoritePostingUseCase {
+    void execute(AppActor actor, Long userFavoritePostingId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserFavoritePostingListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserFavoritePostingListUseCase.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface GetUserFavoritePostingListUseCase {
+    CursorPaginatedApiResponse<UserFavoritePostingListResponseDto> execute(AppActor actor, CursorPageRequestDto pageRequest);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserFavoritePostingQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserFavoritePostingQueryRepository.java
@@ -1,0 +1,16 @@
+package com.dreamteam.alter.domain.user.port.outbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFavoritePostingListResponse;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserFavoritePostingQueryRepository {
+    long getCountByUser(User user);
+    List<UserFavoritePostingListResponse> findUserFavoritePostingListWithCursor(User user, CursorPageRequest<CursorDto> request);
+    Optional<UserFavoritePosting> findByIdAndUser(Long favoritePostingId, User user);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserFavoritePostingRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserFavoritePostingRepository.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.outbound;
+
+import com.dreamteam.alter.domain.user.entity.UserFavoritePosting;
+
+public interface UserFavoritePostingRepository {
+    void save(UserFavoritePosting favoritePosting);
+    void delete(UserFavoritePosting favoritePosting);
+}


### PR DESCRIPTION
## ID
- ALT-31

## 변경 내용
- 사용자가 공고를 스크랩(북마크)한다
- 사용자가 스크랩한 공고 목록을 조회한다
- 사용자가 스크랩한 공고를 삭제한다

## 구현 사항
- 사용자 공고 스크랩(UserFavoritePosting) 엔티티 구현
- User와 Posting으로 Unique 제약조건 설정, 스크랩 등록 시 제약조건 위반 확인 후 예외처리
- 커서 페이징으로 스크랩 목록 조회
- 스크랩 삭제 요청 시 삭제 방식은 Hard Delete로 구현