### PR TITLE
fix: 공고 조회 API 스펙 변경

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/controller/PostingController.java
@@ -52,7 +52,9 @@ public class PostingController implements PostingControllerSpec {
     public ResponseEntity<CursorPaginatedApiResponse<PostingListResponseDto>> getPostingsWithCursor(
         CursorPageRequestDto request
     ) {
-        return ResponseEntity.ok(getPostingsWithCursor.execute(request));
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(getPostingsWithCursor.execute(request, actor));
     }
 
     @Override
@@ -60,7 +62,9 @@ public class PostingController implements PostingControllerSpec {
     public ResponseEntity<CommonApiResponse<PostingDetailResponseDto>> getPostingDetail(
         @PathVariable Long postingId
     ) {
-        return ResponseEntity.ok(CommonApiResponse.of(getPostingDetail.execute(postingId)));
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(CommonApiResponse.of(getPostingDetail.execute(postingId, actor)));
     }
 
     @Override

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
@@ -23,7 +23,7 @@ public class PostingDetailResponseDto {
     private Long id;
 
     @NotNull
-    @Schema(description = "업장 정보", example = "1")
+    @Schema(description = "업장 정보")
     private PostingDetailWorkspaceResponseDto workspace;
 
     @NotBlank
@@ -51,15 +51,12 @@ public class PostingDetailResponseDto {
     private List<PostingKeywordListResponseDto> keywords;
 
     @NotNull
-    @Schema(description = "공고 스케줄", example = "[" +
-        "{" +
-        "\"workingDays\": [\"MONDAY\", \"WEDNESDAY\"], \"startTime\": \"09:00\", \"endTime\": \"18:00\", \"positionsNeeded\": 3, \"position\": 3" +
-        "}," +
-        "{" +
-        "\"workingDays\": [\"FRIDAY\"], \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": 2" +
-        "}" +
-        "]")
+    @Schema(description = "공고 스케줄", example = "[{\"id\":1,\"workingDays\":[\"MONDAY\",\"WEDNESDAY\"],\"startTime\":\"09:00\",\"endTime\":\"18:00\",\"positionsNeeded\":3,\"positionsAvailable\":2,\"position\":\"홀서빙\"}]")
     private List<PostingScheduleResponseDto> schedules;
+
+    @NotNull
+    @Schema(description = "스크랩 여부", example = "true")
+    private boolean scrapped;
 
     public static PostingDetailResponseDto from(PostingDetailResponse entity) {
         return PostingDetailResponseDto.builder()
@@ -76,6 +73,7 @@ public class PostingDetailResponseDto {
             .keywords(entity.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .scrapped(entity.isScrapped())
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
@@ -52,6 +52,14 @@ public class PostingListResponseDto {
         "]")
     private List<PostingScheduleResponseDto> schedules;
 
+    @NotNull
+    @Schema(description = "업장 정보")
+    private PostingListWorkspaceResponseDto workspace;
+
+    @NotNull
+    @Schema(description = "스크랩 여부", example = "true")
+    private boolean scrapped;
+
     public static PostingListResponseDto from(PostingListResponse entity) {
         return PostingListResponseDto.builder()
             .id(entity.getId())
@@ -65,6 +73,8 @@ public class PostingListResponseDto {
             .keywords(entity.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .workspace(PostingListWorkspaceResponseDto.from(entity.getWorkspace()))
+            .scrapped(entity.isScrapped())
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListWorkspaceResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListWorkspaceResponseDto.java
@@ -1,0 +1,31 @@
+package com.dreamteam.alter.adapter.inbound.general.posting.dto;
+
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "공고 리스트 조회 업장 정보 응답 DTO")
+public class PostingListWorkspaceResponseDto {
+
+    @NotNull
+    @Schema(description = "업장 ID", example = "1")
+    private Long id;
+
+    @NotBlank
+    @Schema(description = "업장 이름", example = "카페 알터")
+    private String businessName;
+
+    public static PostingListWorkspaceResponseDto from(Workspace entity) {
+        return PostingListWorkspaceResponseDto.builder()
+            .id(entity.getId())
+            .businessName(entity.getBusinessName())
+            .build();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingScheduleResponseDto.java
@@ -18,6 +18,10 @@ import java.util.List;
 public class PostingScheduleResponseDto {
 
     @NotNull
+    @Schema(description = "공고 스케줄 ID", example = "1")
+    private Long id;
+
+    @NotNull
     @Schema(description = "근무 요일", example = "['MONDAY', 'WEDNESDAY']")
     private List<DayOfWeek> workingDays;
 
@@ -43,13 +47,14 @@ public class PostingScheduleResponseDto {
 
     public static PostingScheduleResponseDto from(PostingSchedule entity) {
         return PostingScheduleResponseDto.builder()
-                .workingDays(entity.getWorkingDays())
-                .startTime(entity.getStartTime())
-                .endTime(entity.getEndTime())
-                .positionsNeeded(entity.getPositionsNeeded())
-                .positionsAvailable(entity.getPositionsAvailable())
-                .position(entity.getPosition())
-                .build();
+            .id(entity.getId())
+            .workingDays(entity.getWorkingDays())
+            .startTime(entity.getStartTime())
+            .endTime(entity.getEndTime())
+            .positionsNeeded(entity.getPositionsNeeded())
+            .positionsAvailable(entity.getPositionsAvailable())
+            .position(entity.getPosition())
+            .build();
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingDetailResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingDetailResponse.java
@@ -33,7 +33,13 @@ public class PostingDetailResponse {
 
     private List<PostingSchedule> schedules;
 
-    public static PostingDetailResponse of(Posting posting, List<PostingKeyword> postingKeywords) {
+    private boolean scrapped;
+
+    public static PostingDetailResponse of(
+        Posting posting,
+        List<PostingKeyword> postingKeywords,
+        boolean scrapped
+    ) {
         return new PostingDetailResponse(
             posting.getId(),
             posting.getWorkspace(),
@@ -43,7 +49,8 @@ public class PostingDetailResponse {
             posting.getPaymentType(),
             posting.getCreatedAt(),
             postingKeywords,
-            posting.getSchedules()
+            posting.getSchedules(),
+            scrapped
         );
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingListResponse.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.entity.Posting;
 import com.dreamteam.alter.domain.posting.entity.PostingSchedule;
 import com.dreamteam.alter.domain.posting.type.PaymentType;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -30,7 +31,11 @@ public class PostingListResponse {
 
     private List<PostingSchedule> schedules;
 
-    public static PostingListResponse of(Posting posting, Map<Long, List<PostingKeyword>> keywordsMap) {
+    private Workspace workspace;
+
+    private boolean scrapped;
+
+    public static PostingListResponse of(Posting posting, Map<Long, List<PostingKeyword>> keywordsMap, boolean scrapped) {
         return PostingListResponse.builder()
             .id(posting.getId())
             .title(posting.getTitle())
@@ -39,6 +44,8 @@ public class PostingListResponse {
             .createdAt(posting.getCreatedAt())
             .schedules(posting.getSchedules())
             .postingKeywords(keywordsMap.get(posting.getId()))
+            .workspace(posting.getWorkspace())
+            .scrapped(scrapped)
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingDetail.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.port.inbound.GetPostingDetailUseCase;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingQueryRepository;
+import com.dreamteam.alter.domain.user.context.AppActor;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
@@ -19,8 +20,8 @@ public class GetPostingDetail implements GetPostingDetailUseCase {
     private final PostingQueryRepository postingQueryRepository;
 
     @Override
-    public PostingDetailResponseDto execute(Long postingId) {
-        PostingDetailResponse postingDetail = postingQueryRepository.getPostingDetail(postingId);
+    public PostingDetailResponseDto execute(Long postingId, AppActor actor) {
+        PostingDetailResponse postingDetail = postingQueryRepository.getPostingDetail(postingId, actor.getUser());
         if (ObjectUtils.isEmpty(postingDetail)) {
             throw new CustomException(ErrorCode.POSTING_NOT_FOUND);
         }

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingsWithCursor.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingsWithCursor.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.Posting
 import com.dreamteam.alter.common.util.CursorUtil;
 import com.dreamteam.alter.domain.posting.port.inbound.GetPostingsWithCursorUseCase;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingQueryRepository;
+import com.dreamteam.alter.domain.user.context.AppActor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
@@ -23,7 +24,7 @@ public class GetPostingsWithCursor implements GetPostingsWithCursorUseCase {
     private final ObjectMapper objectMapper;
 
     @Override
-    public CursorPaginatedApiResponse<PostingListResponseDto> execute(CursorPageRequestDto request) {
+    public CursorPaginatedApiResponse<PostingListResponseDto> execute(CursorPageRequestDto request, AppActor actor) {
         CursorDto cursorDto = null;
         if (ObjectUtils.isNotEmpty(request.cursor())) {
             cursorDto = CursorUtil.decodeCursor(request.cursor(), CursorDto.class, objectMapper);
@@ -35,7 +36,7 @@ public class GetPostingsWithCursor implements GetPostingsWithCursorUseCase {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
         }
 
-        List<PostingListResponse> postings = postingQueryRepository.getPostingsWithCursor(pageRequest);
+        List<PostingListResponse> postings = postingQueryRepository.getPostingsWithCursor(pageRequest, actor.getUser());
         if (ObjectUtils.isEmpty(postings)) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
         }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingDetailUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingDetailUseCase.java
@@ -1,7 +1,8 @@
 package com.dreamteam.alter.domain.posting.port.inbound;
 
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingDetailResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
 
 public interface GetPostingDetailUseCase {
-    PostingDetailResponseDto execute(Long postingId);
+    PostingDetailResponseDto execute(Long postingId, AppActor actor);
 }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingsWithCursorUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/GetPostingsWithCursorUseCase.java
@@ -3,7 +3,8 @@ package com.dreamteam.alter.domain.posting.port.inbound;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingListResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
 
 public interface GetPostingsWithCursorUseCase {
-    CursorPaginatedApiResponse<PostingListResponseDto> execute(CursorPageRequestDto request);
+    CursorPaginatedApiResponse<PostingListResponseDto> execute(CursorPageRequestDto request, AppActor actor);
 }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingQueryRepository.java
@@ -5,13 +5,14 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingDetailResponse;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingListResponse;
 import com.dreamteam.alter.domain.posting.entity.Posting;
+import com.dreamteam.alter.domain.user.entity.User;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PostingQueryRepository {
     long getCountOfPostings();
-    List<PostingListResponse> getPostingsWithCursor(CursorPageRequest<CursorDto> request);
-    PostingDetailResponse getPostingDetail(Long postingId);
+    List<PostingListResponse> getPostingsWithCursor(CursorPageRequest<CursorDto> request, User user);
+    PostingDetailResponse getPostingDetail(Long postingId, User user);
     Optional<Posting> findById(Long postingId);
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.domain.user.type.SocialProvider;
 import com.dreamteam.alter.domain.user.type.UserGender;
 import com.dreamteam.alter.domain.user.type.UserRole;
 import com.dreamteam.alter.domain.user.type.UserStatus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
@@ -72,7 +73,8 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @OrderBy("id DESC")
     @SQLRestriction("status != 'DELETED'")
     private List<UserCertificate> certificates;


### PR DESCRIPTION
## ID
- ALT-42

## 변경 내용
- 공고 목록 조회 시 업장 이름 응답 추가
- 공고 목록 조회, 상세 조회 시 사용자 스크랩 여부 응답 추가

## 구현 사항
- User 정보를 바탕으로 Posting 스크랩 여부를 확인
- 공고 목록 조회 API에서 누락되었던 업장(Workspace) 관련 필수 정보 응답 구현