### PR TITLE
feat: 평판 작성 요청 API 구현 및 자동 만료 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.8.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.8.0'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/ReputationController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/ReputationController.java
@@ -1,0 +1,42 @@
+package com.dreamteam.alter.adapter.inbound.general.reputation.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationRequestDto;
+import com.dreamteam.alter.application.aop.AppActionContext;
+import com.dreamteam.alter.domain.reputation.port.inbound.CreateReputationRequestUseCase;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/reputations")
+@PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')") // TODO: 권한 세부 설정
+@RequiredArgsConstructor
+@Validated
+public class ReputationController implements ReputationControllerSpec {
+
+    @Resource(name = "createReputationRequest")
+    private final CreateReputationRequestUseCase createReputationRequest;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> createReputationRequest(CreateReputationRequestDto request) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        createReputationRequest.execute(actor, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    // 자신에게 온 평판 작성 요청 목록 조회 (사용자)
+
+    // 평판 요청 취소 (요청자)
+
+    // 평판 요청 승인/거절 (요청받은 사람)
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/ReputationControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/ReputationControllerSpec.java
@@ -1,0 +1,15 @@
+package com.dreamteam.alter.adapter.inbound.general.reputation.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationRequestDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "APP - 평판 관련 API")
+public interface ReputationControllerSpec {
+
+    ResponseEntity<CommonApiResponse<Void>> createReputationRequest(@Valid @RequestBody CreateReputationRequestDto request);
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/dto/CreateReputationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/dto/CreateReputationRequestDto.java
@@ -1,0 +1,29 @@
+package com.dreamteam.alter.adapter.inbound.general.reputation.dto;
+
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "평판 작성 요청 생성 DTO")
+public class CreateReputationRequestDto {
+
+    @Nullable
+    @Schema(description = "업장 ID (null일 경우 외부 근무 이력에 대한 사용자 간 평판 요청)", example = "12345")
+    private Long workspaceId;
+
+    @NotNull
+    @Schema(description = "요청 유형 (사용자 간 평판, 사용자-업장 평판 등)", example = "USER_TO_USER_INTERNAL")
+    private ReputationRequestType requestType;
+
+    @NotNull
+    @Schema(description = "대상자 ID", example = "67890")
+    private Long targetId;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.adapter.outbound.reputation.persistence;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReputationRequestJpaRepository extends JpaRepository<ReputationRequest, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestQueryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.dreamteam.alter.adapter.outbound.reputation.persistence;
+
+import com.dreamteam.alter.domain.reputation.entity.QReputationRequest;
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReputationRequestQueryRepositoryImpl implements ReputationRequestQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ReputationRequest> findAllByStatusAndExpiredAtBefore(
+        ReputationRequestStatus status,
+        LocalDateTime now
+    ) {
+        QReputationRequest reputationRequest = QReputationRequest.reputationRequest;
+
+        return queryFactory.selectFrom(reputationRequest)
+            .where(reputationRequest.status.eq(status)
+                .and(reputationRequest.expiredAt.before(now)))
+            .fetch();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/reputation/persistence/ReputationRequestRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.dreamteam.alter.adapter.outbound.reputation.persistence;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReputationRequestRepositoryImpl implements ReputationRequestRepository {
+
+    private final ReputationRequestJpaRepository reputationRequestJpaRepository;
+
+    @Override
+    public void save(ReputationRequest request) {
+        reputationRequestJpaRepository.save(request);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/CreateReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/CreateReputationRequest.java
@@ -1,0 +1,76 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.inbound.CreateReputationRequestUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestRepository;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestType;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import com.dreamteam.alter.domain.user.type.UserStatus;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+
+@Service("createReputationRequest")
+@RequiredArgsConstructor
+@Transactional
+public class CreateReputationRequest implements CreateReputationRequestUseCase {
+
+    private final ReputationRequestRepository reputationRequestRepository;
+    private final WorkspaceQueryRepository workspaceQueryRepository;
+    private final UserQueryRepository userQueryRepository;
+
+    @Override
+    public void execute(AppActor actor, CreateReputationRequestDto request) {
+        ReputationRequestType type = request.getRequestType();
+        Workspace workspace = null;
+        User targetUser = null;
+
+        switch (type) {
+            case USER_TO_WORKSPACE:
+                if (ObjectUtils.isEmpty(request.getWorkspaceId())) {
+                    throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND); // TODO: fix
+                }
+                workspace = workspaceQueryRepository.findById(request.getWorkspaceId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.WORKSPACE_NOT_FOUND));
+                break;
+            case USER_TO_USER_INTERNAL:
+            case WORKSPACE_TO_USER:
+                if (ObjectUtils.isEmpty(request.getWorkspaceId())) {
+                    throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND); // TODO: fix
+                }
+            case USER_TO_USER_EXTERNAL:
+                targetUser = userQueryRepository.findById(request.getTargetId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                if (!targetUser.getStatus().equals(UserStatus.ACTIVE)) {
+                    throw new CustomException(ErrorCode.USER_NOT_FOUND);
+                }
+
+                // USER_TO_USER_EXTERNAL은 workspace 정보 불필요
+                if (!type.equals(ReputationRequestType.USER_TO_USER_EXTERNAL)) {
+                    workspace = workspaceQueryRepository.findById(request.getWorkspaceId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.WORKSPACE_NOT_FOUND));
+                }
+                break;
+            default:
+                throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT);
+        }
+
+        reputationRequestRepository.save(
+            ReputationRequest.create(
+                type.equals(ReputationRequestType.USER_TO_USER_EXTERNAL) ? null : workspace,
+                actor.getUserId(),
+                request
+            )
+        );
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/ExpireReputationRequests.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/ExpireReputationRequests.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.inbound.ExpireReputationRequestsUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service("expireReputationRequests")
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ExpireReputationRequests implements ExpireReputationRequestsUseCase {
+
+    private final ReputationRequestQueryRepository reputationRequestQueryRepository;
+
+    @Override
+    public void execute() {
+        List<ReputationRequest> requestsToExpire = reputationRequestQueryRepository.findAllByStatusAndExpiredAtBefore(
+            ReputationRequestStatus.REQUESTED, LocalDateTime.now()
+        );
+
+        if (ObjectUtils.isNotEmpty(requestsToExpire)) {
+            requestsToExpire.forEach(ReputationRequest::expire);
+        }
+
+        log.info("ExpireReputationRequests: {} ReputationRequests have been expired.", requestsToExpire.size());
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/common/config/ShedLockConfig.java
+++ b/src/main/java/com/dreamteam/alter/common/config/ShedLockConfig.java
@@ -1,0 +1,27 @@
+package com.dreamteam.alter.common.config;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+@RequiredArgsConstructor
+public class ShedLockConfig {
+
+    private final Environment environment;
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        String lockEnv = environment.getProperty("spring.profiles.active", "default");
+        return new RedisLockProvider(connectionFactory, lockEnv);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.domain.reputation.entity;
 
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationRequestDto;
 import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
 import com.dreamteam.alter.domain.reputation.type.ReputationRequestType;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
@@ -7,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 public class ReputationRequest {
 
     @Id
@@ -44,23 +47,30 @@ public class ReputationRequest {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "expired_at", nullable = false, updatable = false)
+    private LocalDateTime expiredAt;
+
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     public static ReputationRequest create(
-        Workspace workspace,
-        ReputationRequestType requesterType,
+        Workspace workspace, // nullable
         Long requesterId,
-        Long targetId
+        CreateReputationRequestDto request
     ) {
         return ReputationRequest.builder()
             .workspace(workspace)
-            .requestType(requesterType)
+            .requestType(request.getRequestType())
             .requesterId(requesterId)
-            .targetId(targetId)
+            .targetId(request.getTargetId())
             .status(ReputationRequestStatus.REQUESTED)
+            .expiredAt(LocalDateTime.now().plusDays(7))
             .build();
+    }
+
+    public void expire() {
+        this.status = ReputationRequestStatus.EXPIRED;
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/CreateReputationRequestUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/CreateReputationRequestUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationRequestDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface CreateReputationRequestUseCase {
+    void execute(AppActor actor, CreateReputationRequestDto request);
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ExpireReputationRequestsUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ExpireReputationRequestsUseCase.java
@@ -1,0 +1,5 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+public interface ExpireReputationRequestsUseCase {
+    void execute();
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/service/ReputationService.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/service/ReputationService.java
@@ -1,0 +1,5 @@
+package com.dreamteam.alter.domain.reputation.port.inbound.service;
+
+public interface ReputationService {
+    void expireReputationRequests();
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/service/ReputationServiceImpl.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/service/ReputationServiceImpl.java
@@ -1,0 +1,23 @@
+package com.dreamteam.alter.domain.reputation.port.inbound.service;
+
+import com.dreamteam.alter.domain.reputation.port.inbound.ExpireReputationRequestsUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service("reputationService")
+@RequiredArgsConstructor
+public class ReputationServiceImpl implements ReputationService {
+
+    @Resource(name = "expireReputationRequests")
+    private final ExpireReputationRequestsUseCase expireReputationRequests;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(name = "expireReputationRequests", lockAtMostFor = "5m")
+    public void expireReputationRequests() {
+        expireReputationRequests.execute();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestQueryRepository.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.reputation.port.outbound;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ReputationRequestQueryRepository {
+    List<ReputationRequest> findAllByStatusAndExpiredAtBefore(ReputationRequestStatus status, LocalDateTime now);
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.reputation.port.outbound;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+
+public interface ReputationRequestRepository {
+    void save(ReputationRequest request);
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestStatus.java
@@ -2,7 +2,9 @@ package com.dreamteam.alter.domain.reputation.type;
 
 public enum ReputationRequestStatus {
     REQUESTED,
+    EXPIRED,
     DECLINED,
-    WRITTEN
+    ACCEPTED,
+    COMPLETED
     ;
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestType.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestType.java
@@ -1,7 +1,8 @@
 package com.dreamteam.alter.domain.reputation.type;
 
 public enum ReputationRequestType {
-    USER_TO_USER,
+    USER_TO_USER_INTERNAL,
+    USER_TO_USER_EXTERNAL,
     USER_TO_WORKSPACE,
     WORKSPACE_TO_USER
     ;


### PR DESCRIPTION
## ID
- ALT-22

## 변경 내용
- 사용자 혹은 업장 관리자 사용자가 평판 작성을 요청한다
- 유효기간이 만료된 요청은 자동으로 만료 처리된다

## 구현 사항
- 평판 작성 요청 타입별 인자 null check 및 유효성 검증
- 유효기간이 만료된 요청의 경우 자동으로 스케줄러를 통해 만료 처리, 다중 인스턴스 실행 환경에서 중복 작업 수행 방지를 위해 분산 락 도입
- 분산 락은 ShedLock을 통해 구현함
- 평판 작성 관련 기능 추가 구현 예정