### PR TITLE
fix: User 권한 관리 스펙 변경 및 매니저 사용자 로그인 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/LoginUserDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/auth/dto/LoginUserDto.java
@@ -20,21 +20,12 @@ public class LoginUserDto {
 
     private UserRole role;
 
-    public static LoginUserDto of(TokenScope scope, User user) {
-        return LoginUserDto.builder()
-            .scope(scope)
-            .id(user.getId())
-            .email(user.getEmail())
-            .role(user.getRole())
-            .build();
-    }
-
-    public static LoginUserDto of(Authorization authorization) {
+    public static LoginUserDto of(Authorization authorization, UserRole role) {
         return LoginUserDto.builder()
             .scope(authorization.getScope())
             .id(authorization.getUser().getId())
             .email(authorization.getUser().getEmail())
-            .role(authorization.getUser().getRole())
+            .role(role)
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantSummaryDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantSummaryDto.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerUserPublicController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerUserPublicController.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.adapter.inbound.manager.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.LoginUserRequestDto;
+import com.dreamteam.alter.domain.user.port.inbound.GenerateTokenUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/public/managers")
+@RequiredArgsConstructor
+@Validated
+public class ManagerUserPublicController implements ManagerUserPublicControllerSpec {
+
+    @Resource(name = "managerGenerateToken")
+    private final GenerateTokenUseCase generateToken;
+
+    @Override
+    @PostMapping("/login")
+    public ResponseEntity<CommonApiResponse<GenerateTokenResponseDto>> loginManagerUser(LoginUserRequestDto request) {
+        return ResponseEntity.ok(CommonApiResponse.of(generateToken.execute(request)));
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerUserPublicControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerUserPublicControllerSpec.java
@@ -1,0 +1,41 @@
+package com.dreamteam.alter.adapter.inbound.manager.user.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.LoginUserRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Public - 업장 매니저")
+public interface ManagerUserPublicControllerSpec {
+
+    @Operation(summary = "업장 매니저 로그인")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "로그인 성공 (JWT 응답)"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 사용자 계정",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "사용자 권한 없음",
+                        value = "{\"code\" : \"A002\"}"
+                    ),
+                }))
+    })
+    ResponseEntity<CommonApiResponse<GenerateTokenResponseDto>> loginManagerUser(@RequestBody @Valid LoginUserRequestDto request);
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/auth/external/AuthorizationRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/auth/external/AuthorizationRepositoryImpl.java
@@ -16,8 +16,8 @@ public class AuthorizationRepositoryImpl implements AuthorizationRepository {
     private final AuthorizationJpaRepository authorizationJpaRepository;
 
     @Override
-    public void save(Authorization authorization) {
-        authorizationJpaRepository.save(authorization);
+    public Authorization save(Authorization authorization) {
+        return authorizationJpaRepository.save(authorization);
     }
 
     @Override

--- a/src/main/java/com/dreamteam/alter/application/auth/provider/AccessTokenAuthenticationProvider.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/provider/AccessTokenAuthenticationProvider.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.general.auth.dto.LoginUserDto;
 import com.dreamteam.alter.adapter.outbound.auth.external.AuthorizationRepositoryImpl;
 import com.dreamteam.alter.application.auth.service.AuthService;
 import com.dreamteam.alter.application.auth.token.AccessTokenAuthentication;
+import com.dreamteam.alter.common.util.UserRoleUtil;
 import com.dreamteam.alter.domain.auth.entity.Authorization;
 import com.dreamteam.alter.domain.auth.exception.ExpiredAuthException;
 import com.dreamteam.alter.domain.auth.exception.InternalAuthException;
@@ -85,13 +86,14 @@ public class AccessTokenAuthenticationProvider extends AbstractJwtAuthentication
             throw new ExpiredAuthException();
         }
 
-        LoginUserDto userDetail = LoginUserDto.of(authorization);
+        LoginUserDto userDetail = LoginUserDto.of(
+            authorization,
+            UserRoleUtil.getRoleForScope(authorization)
+        );
         return new AccessTokenAuthentication(
             accessToken,
             userDetail,
-            Collections.singletonList(new SimpleGrantedAuthority(authorization.getUser()
-                .getRole()
-                .toString()))
+            Collections.singletonList(new SimpleGrantedAuthority(userDetail.getRole().toString()))
         );
     }
 

--- a/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/service/AuthService.java
@@ -106,6 +106,9 @@ public class AuthService {
     }
 
     public void saveAuthorization(Authorization authorization) throws JsonProcessingException {
+        // DB
+        Authorization savedAuthorization = authorizationRepository.save(authorization);
+
         String key = buildKey(
             authorization.getScope(),
             authorization.getUser().getId(),
@@ -115,13 +118,10 @@ public class AuthService {
         // Redis
         redisTemplate.opsForValue().set(
             key,
-            objectMapper.writeValueAsString(authorization),
+            objectMapper.writeValueAsString(savedAuthorization),
             accessTokenExpirationTime,
             TimeUnit.MILLISECONDS
         );
-
-        // DB
-        authorizationRepository.save(authorization);
     }
 
     public String buildKey(TokenScope scope, Long userId, String authorizationId) {

--- a/src/main/java/com/dreamteam/alter/application/auth/token/RefreshTokenAuthentication.java
+++ b/src/main/java/com/dreamteam/alter/application/auth/token/RefreshTokenAuthentication.java
@@ -1,6 +1,8 @@
 package com.dreamteam.alter.application.auth.token;
 
+import com.dreamteam.alter.common.util.UserRoleUtil;
 import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.user.type.UserRole;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -50,7 +52,8 @@ public class RefreshTokenAuthentication extends AbstractAuthenticationToken {
     }
 
     private static SimpleGrantedAuthority getAuthority(Authorization authorization) {
-        return new SimpleGrantedAuthority(authorization.getUser().getRole().toString());
+        UserRole role = UserRoleUtil.getRoleForScope(authorization);
+        return new SimpleGrantedAuthority(role.toString());
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GenerateToken.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GenerateToken.java
@@ -59,13 +59,11 @@ public class GenerateToken implements GenerateTokenUseCase {
             }
         }
 
-        TokenScope tokenScope = switch (user.getRole()) {
-            case UserRole.ROLE_USER -> TokenScope.APP;
-            case UserRole.ROLE_MANAGER -> TokenScope.MANAGER;
-            case UserRole.ROLE_ADMIN -> TokenScope.ADMIN;
-        };
+        if (!user.getRoles().contains(UserRole.ROLE_USER)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
-        return GenerateTokenResponseDto.of(authService.generateAuthorization(user, tokenScope));
+        return GenerateTokenResponseDto.of(authService.generateAuthorization(user, TokenScope.APP));
     }
 
     private SocialUserInfo authenticateSocialUser(LoginUserRequestDto request) {

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/ManagerGenerateToken.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/ManagerGenerateToken.java
@@ -1,0 +1,48 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.auth.dto.SocialUserInfo;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.LoginUserRequestDto;
+import com.dreamteam.alter.application.auth.manager.SocialAuthenticationManager;
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.GenerateTokenUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import com.dreamteam.alter.domain.user.type.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+
+@Service("managerGenerateToken")
+@RequiredArgsConstructor
+public class ManagerGenerateToken implements GenerateTokenUseCase {
+
+    private final AuthService authService;
+    private final UserQueryRepository userQueryRepository;
+    private final SocialAuthenticationManager socialAuthenticationManager;
+
+    @Override
+    public GenerateTokenResponseDto execute(LoginUserRequestDto request) {
+        SocialUserInfo socialUserInfo = authenticateSocialUser(request);
+
+        User user = userQueryRepository.findBySocialId(socialUserInfo.getSocialId());
+
+        if (ObjectUtils.isEmpty(user)) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        if (!user.getRoles().contains(UserRole.ROLE_MANAGER)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return GenerateTokenResponseDto.of(authService.generateAuthorization(user, TokenScope.MANAGER));
+    }
+
+    private SocialUserInfo authenticateSocialUser(LoginUserRequestDto request) {
+        return socialAuthenticationManager.authenticate(request);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/ReissueToken.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/ReissueToken.java
@@ -42,15 +42,9 @@ public class ReissueToken implements ReissueTokenUseCase {
         authorization.expire();
         authorizationRepository.save(authorization); // 영속성으로 관리되지 않으므로 직접 저장
 
-        TokenScope tokenScope = switch (user.getRole()) {
-            case UserRole.ROLE_USER -> TokenScope.APP;
-            case UserRole.ROLE_MANAGER -> TokenScope.MANAGER;
-            case UserRole.ROLE_ADMIN -> TokenScope.ADMIN;
-        };
-
         Authorization newAuthorization;
         try {
-            newAuthorization = authService.generateAuthorization(user, tokenScope);
+            newAuthorization = authService.generateAuthorization(user, authorization.getScope());
             authService.saveAuthorization(newAuthorization);
         } catch (JsonProcessingException e) {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/dreamteam/alter/common/util/UserRoleUtil.java
+++ b/src/main/java/com/dreamteam/alter/common/util/UserRoleUtil.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.common.util;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.auth.entity.Authorization;
+import com.dreamteam.alter.domain.user.type.UserRole;
+
+public class UserRoleUtil {
+
+    public static UserRole getRoleForScope(Authorization authorization) {
+        UserRole requiredRole = switch (authorization.getScope()) {
+            case MANAGER -> UserRole.ROLE_MANAGER;
+            case ADMIN -> UserRole.ROLE_ADMIN;
+            default -> UserRole.ROLE_USER;
+        };
+        if (!authorization.getUser().getRoles().contains(requiredRole)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        return requiredRole;
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/domain/auth/port/outbound/AuthorizationRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/auth/port/outbound/AuthorizationRepository.java
@@ -5,6 +5,6 @@ import com.dreamteam.alter.domain.auth.entity.Authorization;
 import java.util.Optional;
 
 public interface AuthorizationRepository {
-    void save(Authorization authorization);
+    Authorization save(Authorization authorization);
     Optional<Authorization> findById(String id);
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -9,7 +9,9 @@ import com.dreamteam.alter.domain.user.type.UserStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -56,9 +58,9 @@ public class User {
     @Column(name = "social_id", length = Integer.MAX_VALUE, nullable = false, unique = true)
     private String socialId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", length = 20, nullable = false)
-    private UserRole role;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "roles", columnDefinition = "jsonb", nullable = false)
+    private List<UserRole> roles;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
@@ -92,7 +94,7 @@ public class User {
             .gender(request.getGender())
             .provider(socialUserInfo.getProvider())
             .socialId(socialUserInfo.getSocialId())
-            .role(UserRole.ROLE_USER)
+            .roles(List.of(UserRole.ROLE_USER))
             .status(UserStatus.ACTIVE)
             .build();
     }


### PR DESCRIPTION
## ID
- ALT-44

## 변경 내용
- 매니저 사용자 로그인 엔드포인트 분리
- User가 다중 Role을 가질 수 있도록 구현

## 구현 사항
- User Role을 List로 관리, DB상에서는 jsonb 타입으로 관리
- 수정된 스펙에 맞게 인증 객체, JWT 토큰 발급 로직 수정
- 업장 매니저 사용자용 로그인 엔드포인트 구현