### PR TITLE
fix: 공고 지원자 목록 조회 API 스펙 변경

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/ErrorResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/ErrorResponse.java
@@ -29,6 +29,15 @@ public record ErrorResponse<T>(
         );
     }
 
+    public static <T> ErrorResponse<T> of(ErrorCode errorCode, String message) {
+        return new ErrorResponse<>(
+            String.valueOf(LocalDateTime.now()),
+            errorCode.getCode(),
+            message,
+            null
+        );
+    }
+
     public static <T> ErrorResponse<T> of(ErrorCode errorCode, T data) {
         return new ErrorResponse<>(
             String.valueOf(LocalDateTime.now()),

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/reputation/ReputationSummaryBriefDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/reputation/ReputationSummaryBriefDto.java
@@ -2,7 +2,6 @@ package com.dreamteam.alter.adapter.inbound.common.dto.reputation;
 
 import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,35 +15,25 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@Schema(description = "평판 요약 정보 DTO")
-public class ReputationSummaryDto {
+@Schema(description = "평판 요약 간략 정보 DTO")
+public class ReputationSummaryBriefDto {
 
-    @NotNull
-    @Schema(description = "총 평판 개수", example = "25")
-    private Integer totalReputationCount;
-
-    @NotNull
-    @Schema(description = "주요 키워드 목록 (상위 5개)")
+    @Schema(description = "주요 키워드 목록 (상위 3개)")
     private List<TopKeywordDto> topKeywords;
 
-    @NotNull
-    @Schema(description = "평판 요약 설명", example = "성실하고 책임감 있는 근무자로 평가받고 있습니다.")
-    private String summaryDescription;
-
-    public static ReputationSummaryDto from(ReputationSummary reputationSummary) {
+    public static ReputationSummaryBriefDto from(ReputationSummary reputationSummary) {
         if (ObjectUtils.isEmpty(reputationSummary)) {
             return null;
         }
 
         List<TopKeywordDto> topKeywords = reputationSummary.getTopKeywords()
             .stream()
+            .limit(3)
             .map(TopKeywordDto::from)
             .toList();
 
-        return ReputationSummaryDto.builder()
-            .totalReputationCount(reputationSummary.getTotalReputationCount())
+        return ReputationSummaryBriefDto.builder()
             .topKeywords(topKeywords)
-            .summaryDescription(reputationSummary.getSummaryDescription())
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationListResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.ManagerPostingApplicationListResponse;
 import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,9 +28,9 @@ public class PostingApplicationListResponseDto {
     @NotNull
     private PostingApplicationResponsePostingScheduleSummaryDto schedule;
 
-    @Schema(description = "지원 상태", example = "ACCEPTED")
+    @Schema(description = "지원 상태")
     @NotNull
-    private PostingApplicationStatus status;
+    private DescribedEnumDto<PostingApplicationStatus> status;
 
     @Schema(description = "지원자 요약 정보")
     @NotNull
@@ -44,8 +45,11 @@ public class PostingApplicationListResponseDto {
             .id(entity.getId())
             .workspace(PostingApplicationWorkspaceResponseDto.from(entity.getWorkspace()))
             .schedule(PostingApplicationResponsePostingScheduleSummaryDto.from(entity.getSchedule()))
-            .status(entity.getStatus())
-            .applicant(PostingApplicationResponseApplicantSummaryDto.from(entity.getUser()))
+            .status(DescribedEnumDto.of(entity.getStatus(), PostingApplicationStatus.describe()))
+            .applicant(PostingApplicationResponseApplicantSummaryDto.from(
+                entity.getUser(),
+                entity.getReputationSummary()
+            ))
             .createdAt(entity.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantSummaryDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantSummaryDto.java
@@ -1,5 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.manager.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationSummaryBriefDto;
+import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
 import com.dreamteam.alter.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -16,9 +18,13 @@ public class PostingApplicationResponseApplicantSummaryDto {
     @Schema(description = "이름", example = "홍길동")
     private String name;
 
-    public static PostingApplicationResponseApplicantSummaryDto from(User entity) {
+    @Schema(description = "평판 요약 간략 정보")
+    private ReputationSummaryBriefDto reputationSummary;
+
+    public static PostingApplicationResponseApplicantSummaryDto from(User entity, ReputationSummary reputationSummary) {
         return PostingApplicationResponseApplicantSummaryDto.builder()
             .name(entity.getName())
+            .reputationSummary(ReputationSummaryBriefDto.from(reputationSummary))
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingApplicationListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingApplicationListResponse.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.outbound.posting.persistence.readonly;
 
 import com.dreamteam.alter.domain.posting.entity.PostingSchedule;
 import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
+import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
 import com.dreamteam.alter.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,5 +26,7 @@ public class ManagerPostingApplicationListResponse {
     private User user;
 
     private LocalDateTime createdAt;
+
+    private ReputationSummary reputationSummary;
 
 }

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerGetPostingApplicationDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerGetPostingApplicationDetail.java
@@ -11,13 +11,13 @@ import com.dreamteam.alter.domain.reputation.port.outbound.ReputationSummaryQuer
 import com.dreamteam.alter.domain.reputation.type.ReputationType;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service("managerGetPostingApplicationDetail")
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ManagerGetPostingApplicationDetail implements ManagerGetPostingApplicationDetailUseCase {
 
     private final PostingApplicationQueryRepository postingApplicationQueryRepository;

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerGetPostingApplicationListWithCursor.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerGetPostingApplicationListWithCursor.java
@@ -10,16 +10,16 @@ import com.dreamteam.alter.domain.posting.port.outbound.PostingApplicationQueryR
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service("managerGetPostingApplicationListWithCursor")
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ManagerGetPostingApplicationListWithCursor implements ManagerGetPostingApplicationListWithCursorUseCase {
 
     private final PostingApplicationQueryRepository postingApplicationQueryRepository;

--- a/src/main/java/com/dreamteam/alter/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/handler/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse<Void>> handleCustomException(CustomException e) {
         return ResponseEntity.status(e.getErrorCode().getStatus())
-            .body(ErrorResponse.of(e.getErrorCode()));
+            .body(ErrorResponse.of(e.getErrorCode(), e.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/dreamteam/alter/domain/posting/type/PostingApplicationStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/type/PostingApplicationStatus.java
@@ -1,5 +1,8 @@
 package com.dreamteam.alter.domain.posting.type;
 
+import java.util.Map;
+import java.util.Set;
+
 public enum PostingApplicationStatus {
     SUBMITTED,
     SHORTLISTED,
@@ -9,4 +12,21 @@ public enum PostingApplicationStatus {
     EXPIRED,
     DELETED
     ;
+
+    public static Map<PostingApplicationStatus, String> describe() {
+        return Map.of(
+            PostingApplicationStatus.SUBMITTED, "지원 완료",
+            PostingApplicationStatus.SHORTLISTED, "서류 합격",
+            PostingApplicationStatus.ACCEPTED, "최종 합격",
+            PostingApplicationStatus.REJECTED, "불합격",
+            PostingApplicationStatus.CANCELLED, "지원 취소",
+            PostingApplicationStatus.EXPIRED, "만료됨",
+            PostingApplicationStatus.DELETED, "삭제됨"
+        );
+    }
+
+    public static Set<PostingApplicationStatus> defaultInquirableStatuses() {
+        return Set.of(SUBMITTED, SHORTLISTED);
+    }
+
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationSummary.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationSummary.java
@@ -6,7 +6,6 @@ import com.dreamteam.alter.adapter.inbound.common.dto.reputation.KeywordSummaryD
 import com.dreamteam.alter.domain.reputation.type.ReputationType;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,7 +19,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@DynamicUpdate
 @EntityListeners(AuditingEntityListener.class)
 public class ReputationSummary {
 


### PR DESCRIPTION
## ID
- ALT-58

## 변경 내용
- 지원자의 평판 키워드 상위 3개를 함께 응답한다
- 지원 상태 응답 방식 수정
- 특정 ErrorCode의 사전 정의된 메시지 뿐만이 아닌 커스텀 메시지도 지원

## 구현 사항
- 지원자 응답 DTO에 평판 키워드 응답 필드 추가
- 지원 상태 응답 시 ENUM 값과 설명 함께 응답
- 에러 응답 객체 팩토리 메소드 추가(커스텀 메시지 지원)