### PR TITLE
refactor: Response DTO 상태 응답 필드 스펙 변경

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/UserPostingApplicationListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/UserPostingApplicationListResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.UserPostingApplicationListResponse;
 import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,8 +34,8 @@ public class UserPostingApplicationListResponseDto {
     private String description;
 
     @NotNull
-    @Schema(description = "지원 상태", example = "SUBMITTED")
-    private PostingApplicationStatus status;
+    @Schema(description = "지원 상태")
+    private DescribedEnumDto<PostingApplicationStatus> status;
 
     @NotNull
     @Schema(description = "생성일시", example = "2023-10-01T12:00:00")
@@ -54,7 +55,7 @@ public class UserPostingApplicationListResponseDto {
                 UserPostingApplicationPostingSummaryResponseDto.from(entity.getPosting())
             )
             .description(entity.getDescription())
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), PostingApplicationStatus.describe()))
             .createdAt(entity.getCreatedAt())
             .updatedAt(entity.getUpdatedAt())
             .build();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingKeywordListResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.workspace.dto.PostingDetailWorkspaceResponseDto;
@@ -46,8 +47,8 @@ public class ManagerPostingDetailResponseDto {
     private PaymentType paymentType;
 
     @NotNull
-    @Schema(description = "공고 상태", example = "OPEN")
-    private PostingStatus status;
+    @Schema(description = "공고 상태")
+    private DescribedEnumDto<PostingStatus> status;
 
     @NotNull
     @Schema(description = "생성일", example = "2023-10-01T12:00:00")
@@ -73,7 +74,7 @@ public class ManagerPostingDetailResponseDto {
             .description(entity.getDescription())
             .payAmount(entity.getPayAmount())
             .paymentType(entity.getPaymentType())
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), PostingStatus.describe()))
             .createdAt(entity.getCreatedAt())
             .updatedAt(entity.getUpdatedAt())
             .schedules(entity.getSchedules().stream()

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.posting.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationSummaryDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.ManagerPostingApplicationDetailResponse;
 import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
@@ -33,9 +34,9 @@ public class PostingApplicationResponseDto {
     @NotBlank
     private String description;
 
-    @Schema(description = "지원 상태", example = "ACCEPTED")
+    @Schema(description = "지원 상태")
     @NotNull
-    private PostingApplicationStatus status;
+    private DescribedEnumDto<PostingApplicationStatus> status;
 
     @Schema(description = "지원자 요약 정보")
     @NotNull
@@ -51,7 +52,7 @@ public class PostingApplicationResponseDto {
             .workspace(PostingApplicationWorkspaceResponseDto.from(entity.getWorkspace()))
             .schedule(PostingApplicationResponsePostingScheduleSummaryDto.from(entity.getSchedule()))
             .description(entity.getDescription())
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), PostingApplicationStatus.describe()))
             .applicant(PostingApplicationResponseApplicantDetailDto.from(entity.getUser()))
             .createdAt(entity.getCreatedAt())
             .build();
@@ -66,7 +67,7 @@ public class PostingApplicationResponseDto {
             .workspace(PostingApplicationWorkspaceResponseDto.from(entity.getWorkspace()))
             .schedule(PostingApplicationResponsePostingScheduleSummaryDto.from(entity.getSchedule()))
             .description(entity.getDescription())
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), PostingApplicationStatus.describe()))
             .applicant(PostingApplicationResponseApplicantDetailDto.from(entity.getUser(), applicantReputationSummary))
             .createdAt(entity.getCreatedAt())
             .build();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceListResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.workspace.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.ManagerWorkspaceListResponse;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,7 +35,7 @@ public class ManagerWorkspaceListResponseDto {
 
     @NotNull
     @Schema(description = "업장 상태")
-    private WorkspaceStatus status;
+    private DescribedEnumDto<WorkspaceStatus> status;
 
     public static ManagerWorkspaceListResponseDto of(ManagerWorkspaceListResponse entity) {
         return ManagerWorkspaceListResponseDto.builder()
@@ -42,7 +43,7 @@ public class ManagerWorkspaceListResponseDto {
                 .businessName(entity.getBusinessName())
                 .fullAddress(entity.getFullAddress())
                 .createdAt(entity.getCreatedAt())
-                .status(entity.getStatus())
+                .status(DescribedEnumDto.of(entity.getStatus(), WorkspaceStatus.describe()))
                 .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.workspace.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.ManagerWorkspaceResponse;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,8 +43,8 @@ public class ManagerWorkspaceResponseDto {
     private String description;
 
     @NotNull
-    @Schema(description = "업장 등록 상태", example = "ACTIVE")
-    private WorkspaceStatus status;
+    @Schema(description = "업장 등록 상태")
+    private DescribedEnumDto<WorkspaceStatus> status;
 
     @NotBlank
     @Schema(description = "업장 전체 주소", example = "서울특별시 강남구 테헤란로 123")
@@ -69,7 +70,7 @@ public class ManagerWorkspaceResponseDto {
             .businessType(entity.getBusinessType())
             .contact(entity.getContact())
             .description(entity.getDescription())
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), WorkspaceStatus.describe()))
             .fullAddress(entity.getFullAddress())
             .latitude(entity.getLatitude())
             .longitude(entity.getLongitude())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceWorkerListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceWorkerListResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.manager.workspace.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.ManagerWorkspaceWorkerListResponse;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceWorkerStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,8 +25,8 @@ public class ManagerWorkspaceWorkerListResponseDto {
     private WorkspaceWorkerUserResponseDto user;
 
     @NotNull
-    @Schema(description = "근무자 상태", example = "ACTIVATED")
-    private WorkspaceWorkerStatus status;
+    @Schema(description = "근무자 상태")
+    private DescribedEnumDto<WorkspaceWorkerStatus> status;
 
     @NotNull
     @Schema(description = "채용일자", example = "2023-10-01T12:00:00")
@@ -39,7 +40,7 @@ public class ManagerWorkspaceWorkerListResponseDto {
         return ManagerWorkspaceWorkerListResponseDto.builder()
             .id(entity.getId())
             .user(WorkspaceWorkerUserResponseDto.of(entity.getUser()))
-            .status(entity.getStatus())
+            .status(DescribedEnumDto.of(entity.getStatus(), WorkspaceWorkerStatus.describe()))
             .employedAt(entity.getEmployedAt())
             .resignedAt(entity.getResignedAt())
             .build();

--- a/src/main/java/com/dreamteam/alter/domain/posting/type/PostingStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/type/PostingStatus.java
@@ -1,9 +1,20 @@
 package com.dreamteam.alter.domain.posting.type;
 
+import java.util.Map;
+
 public enum PostingStatus {
     OPEN,
     CLOSED,
     CANCELLED,
     DELETED,
     ;
+
+    public static Map<PostingStatus, String> describe() {
+        return Map.of(
+            PostingStatus.OPEN, "모집 중",
+            PostingStatus.CLOSED, "모집 완료",
+            PostingStatus.CANCELLED, "취소됨",
+            PostingStatus.DELETED, "삭제됨"
+        );
+    }
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/type/WorkspaceStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/type/WorkspaceStatus.java
@@ -1,5 +1,7 @@
 package com.dreamteam.alter.domain.workspace.type;
 
+import java.util.Map;
+
 public enum WorkspaceStatus {
     PENDING,
     ACTIVATED,
@@ -7,4 +9,14 @@ public enum WorkspaceStatus {
     REVOKED,
     DELETED
     ;
+
+    public static Map<WorkspaceStatus, String> describe() {
+        return Map.of(
+            WorkspaceStatus.PENDING, "승인 대기",
+            WorkspaceStatus.ACTIVATED, "활성화",
+            WorkspaceStatus.CLOSED, "폐업",
+            WorkspaceStatus.REVOKED, "승인 취소",
+            WorkspaceStatus.DELETED, "삭제됨"
+        );
+    }
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/type/WorkspaceWorkerStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/type/WorkspaceWorkerStatus.java
@@ -1,7 +1,16 @@
 package com.dreamteam.alter.domain.workspace.type;
 
+import java.util.Map;
+
 public enum WorkspaceWorkerStatus {
     ACTIVATED,
     RESIGNED,
     ;
+
+    public static Map<WorkspaceWorkerStatus, String> describe() {
+        return Map.of(
+            WorkspaceWorkerStatus.ACTIVATED, "재직 중",
+            WorkspaceWorkerStatus.RESIGNED, "퇴사"
+        );
+    }
 }


### PR DESCRIPTION
## ID
- ALT-63

## 변경 내용
- 특정 API들의 응답 DTO에서 객체의 상태(status) 필드를 DescribedEnum 타입으로 응답하도록 변경
- 기존 단일 enum 값 응답에서 `{"value": "ENUM_VALUE", "description": "한글 설명"}` 구조로 응답 스펙 변경

## 구현 사항

### 1. Enum에 describe() 메서드 추가
- `PostingStatus` - describe() 메서드 추가
- `WorkspaceStatus` - describe() 메서드 추가  
- `WorkspaceWorkerStatus` - describe() 메서드 추가

### 2. ResponseDto의 status 필드를 DescribedEnum으로 변경
- `ManagerPostingDetailResponseDto.status` - `PostingStatus` → `DescribedEnumDto<PostingStatus>`
- `ManagerWorkspaceResponseDto.status` - `WorkspaceStatus` → `DescribedEnumDto<WorkspaceStatus>`
- `ManagerWorkspaceListResponseDto.status` - `WorkspaceStatus` → `DescribedEnumDto<WorkspaceStatus>`
- `ManagerWorkspaceWorkerListResponseDto.status` - `WorkspaceWorkerStatus` → `DescribedEnumDto<WorkspaceWorkerStatus>`
- `UserPostingApplicationListResponseDto.status` - `PostingApplicationStatus` → `DescribedEnumDto<PostingApplicationStatus>`

### 3. 영향받는 엔드포인트 (5개)
- `GET /manager/postings/{postingId}` - 공고 상태
- `GET /manager/workspaces` - 업장 목록 상태  
- `GET /manager/workspaces/{workspaceId}` - 업장 상세 상태
- `GET /manager/workspaces/{workspaceId}/workers` - 근무자 상태
- `GET /app/users/me/postings/applications` - 사용자 지원 상태