### PR TITLE
fix: 근무일정 조회 API 개선 및 다음 근무일 응답 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleController.java
@@ -37,7 +37,7 @@ public class UserScheduleController implements UserScheduleControllerSpec {
     ) {
         AppActor actor = AppActionContext.getInstance().getActor();
 
-        return ResponseEntity.ok(CommonApiResponse.of(getMySchedule.execute(actor, request.getYear(), request.getMonth())));
+        return ResponseEntity.ok(CommonApiResponse.of(getMySchedule.execute(actor, request)));
     }
 
     @Override
@@ -48,6 +48,6 @@ public class UserScheduleController implements UserScheduleControllerSpec {
     ) {
         AppActor actor = AppActionContext.getInstance().getActor();
 
-        return ResponseEntity.ok(CommonApiResponse.of(getWorkspaceSchedule.execute(actor, workspaceId, request.getYear(), request.getMonth())));
+        return ResponseEntity.ok(CommonApiResponse.of(getWorkspaceSchedule.execute(actor, workspaceId, request)));
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleControllerSpec.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Tag(name = "APP - 근무 스케줄 관리 API")
 public interface UserScheduleControllerSpec {
 
-    @Operation(summary = "전체 근무 스케줄 조회")
+    @Operation(summary = "나의 근무 스케줄 조회", description = "특정 월의 스케줄을 조회하려면 year, month 값을 모두 포함해야합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "스케줄 조회 성공")
     })
@@ -29,7 +29,7 @@ public interface UserScheduleControllerSpec {
         WorkScheduleInquiryRequestDto request
     );
 
-    @Operation(summary = "업장별 근무 스케줄 조회")
+    @Operation(summary = "업장별 근무 스케줄 조회", description = "year, month 값을 모두 포함해야합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "스케줄 조회 성공"),
         @ApiResponse(responseCode = "400", description = "실패 케이스",

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/WorkScheduleInquiryRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/WorkScheduleInquiryRequestDto.java
@@ -12,9 +12,9 @@ import org.springdoc.core.annotations.ParameterObject;
 @Schema(description = "스케줄 조회 요청")
 public class WorkScheduleInquiryRequestDto {
 
-    @Parameter(description = "조회할 연도", example = "2024", required = true)
-    private int year;
+    @Parameter(description = "조회할 연도")
+    private Integer year;
 
-    @Parameter(description = "조회할 월", example = "1", required = true)
-    private int month;
+    @Parameter(description = "조회할 월")
+    private Integer month;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserWorkspaceListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserWorkspaceListResponseDto.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -22,11 +23,15 @@ public class UserWorkspaceListResponseDto {
     @Schema(description = "입사일", example = "2024-01-15")
     private LocalDate employedAt;
 
+    @Schema(description = "다음 근무 일정", example = "2024-01-20T09:00:00")
+    private LocalDateTime nextShiftDateTime;
+
     public static UserWorkspaceListResponseDto from(UserWorkspaceListResponse response) {
         return UserWorkspaceListResponseDto.builder()
             .workspaceId(response.getWorkspaceId())
             .businessName(response.getBusinessName())
             .employedAt(response.getEmployedAt())
+            .nextShiftDateTime(response.getNextShiftDateTime())
             .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,18 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
             .where(workspaceShift.assignedWorkspaceWorker.user.eq(user)
                 .and(workspaceShift.startDateTime.year().eq(year))
                 .and(workspaceShift.startDateTime.month().eq(month))
+                .and(workspaceShift.status.ne(WorkspaceShiftStatus.DELETED)))
+            .orderBy(workspaceShift.startDateTime.asc())
+            .fetch();
+    }
+
+    @Override
+    public List<WorkspaceShift> findByUserAndWeeklyRange(User user, LocalDate startDate, LocalDate endDate) {
+        return queryFactory
+            .selectFrom(workspaceShift)
+            .where(workspaceShift.assignedWorkspaceWorker.user.eq(user)
+                .and(workspaceShift.startDateTime.goe(startDate.atStartOfDay()))
+                .and(workspaceShift.startDateTime.lt(endDate.atStartOfDay()))
                 .and(workspaceShift.status.ne(WorkspaceShiftStatus.DELETED)))
             .orderBy(workspaceShift.startDateTime.asc())
             .fetch();

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/UserWorkspaceListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/UserWorkspaceListResponse.java
@@ -22,4 +22,6 @@ public class UserWorkspaceListResponse {
 
     private LocalDateTime createdAt;
 
+    private LocalDateTime nextShiftDateTime;
+
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMyWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMyWorkSchedule.java
@@ -1,14 +1,17 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.MyScheduleResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 import com.dreamteam.alter.domain.workspace.port.inbound.GetMyScheduleUseCase;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service("getMyWorkSchedule")
@@ -19,10 +22,20 @@ public class GetMyWorkSchedule implements GetMyScheduleUseCase {
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
 
     @Override
-    public List<MyScheduleResponseDto> execute(AppActor actor, int year, int month) {
-        List<WorkspaceShift> shifts = workspaceShiftQueryRepository
-            .findByUserAndDateRange(actor.getUser(), year, month);
-        
+    public List<MyScheduleResponseDto> execute(AppActor actor, WorkScheduleInquiryRequestDto request) {
+        List<WorkspaceShift> shifts;
+
+        if (ObjectUtils.isEmpty(request.getYear()) || ObjectUtils.isEmpty(request.getMonth())) {
+            // 날짜 정보가 null인 경우: 일주일 범위 조회
+            LocalDate startOfWeek = LocalDate.now();
+            LocalDate endOfWeek = startOfWeek.plusDays(7);
+
+            shifts = workspaceShiftQueryRepository.findByUserAndWeeklyRange(actor.getUser(), startOfWeek, endOfWeek);
+        } else {
+            // 날짜 정보가 제공된 경우: 해당 월의 일정 조회
+            shifts = workspaceShiftQueryRepository.findByUserAndDateRange(actor.getUser(), request.getYear(), request.getMonth());
+        }
+
         return shifts.stream()
             .map(MyScheduleResponseDto::of)
             .toList();

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkspaceScheduleResponseDto;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
@@ -29,8 +30,8 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
     private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
 
     @Override
-    public List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, int year, int month) {
-        if (ObjectUtils.isEmpty(year) || ObjectUtils.isEmpty(month)) {
+    public List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request) {
+        if (ObjectUtils.isEmpty(request.getYear()) || ObjectUtils.isEmpty(request.getMonth())) {
             throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "근무일정 조회 시 월, 일 파라미터는 필수입니다.");
         }
 
@@ -46,7 +47,7 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
         }
 
         List<WorkspaceShift> shifts = workspaceShiftQueryRepository
-            .findByWorkspaceAndDateRange(workspaceWorker.get().getWorkspace(), year, month);
+            .findByWorkspaceAndDateRange(workspaceWorker.get().getWorkspace(), request.getYear(), request.getMonth());
         
         return shifts.stream()
             .map(WorkspaceScheduleResponseDto::of)

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
@@ -32,7 +32,7 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
     @Override
     public List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request) {
         if (ObjectUtils.isEmpty(request.getYear()) || ObjectUtils.isEmpty(request.getMonth())) {
-            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "근무일정 조회 시 월, 일 파라미터는 필수입니다.");
+            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "근무일정 조회 시 연도, 월 파라미터는 필수입니다.");
         }
 
         // 워크스페이스 존재 확인 및 사용자가 해당 워크스페이스에 근무중인지 확인

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
@@ -12,6 +12,7 @@ import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryReposito
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,10 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
 
     @Override
     public List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, int year, int month) {
+        if (ObjectUtils.isEmpty(year) || ObjectUtils.isEmpty(month)) {
+            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "근무일정 조회 시 월, 일 파라미터는 필수입니다.");
+        }
+
         // 워크스페이스 존재 확인 및 사용자가 해당 워크스페이스에 근무중인지 확인
         Workspace workspace = workspaceQueryRepository.findById(workspaceId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetMyScheduleUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetMyScheduleUseCase.java
@@ -1,10 +1,11 @@
 package com.dreamteam.alter.domain.workspace.port.inbound;
 
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.MyScheduleResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 
 import java.util.List;
 
 public interface GetMyScheduleUseCase {
-    List<MyScheduleResponseDto> execute(AppActor actor, int year, int month);
+    List<MyScheduleResponseDto> execute(AppActor actor, WorkScheduleInquiryRequestDto request);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetWorkspaceScheduleUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetWorkspaceScheduleUseCase.java
@@ -1,10 +1,11 @@
 package com.dreamteam.alter.domain.workspace.port.inbound;
 
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkspaceScheduleResponseDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 
 import java.util.List;
 
 public interface GetWorkspaceScheduleUseCase {
-    List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, int year, int month);
+    List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
@@ -6,22 +6,16 @@ import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface WorkspaceShiftQueryRepository {
     List<WorkspaceShift> findByUserAndDateRange(User user, int year, int month);
+    List<WorkspaceShift> findByUserAndWeeklyRange(User user, LocalDate startDate, LocalDate endDate);
     List<WorkspaceShift> findByWorkspaceAndDateRange(Workspace workspace, int year, int month);
     List<WorkspaceShift> findByManagerAndDateRange(ManagerUser managerUser, Long workspaceId, int year, int month);
     Optional<WorkspaceShift> findById(Long id);
-    
-    /**
-     * 특정 근무자가 이미 배정된 스케줄이 있는지 확인
-     * @param workspaceWorker 확인할 근무자
-     * @param startDateTime 스케줄 시작 시간
-     * @param endDateTime 스케줄 종료 시간
-     * @return 이미 배정된 스케줄이 있으면 true
-     */
     boolean hasConflictingSchedule(WorkspaceWorker workspaceWorker, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }


### PR DESCRIPTION
## ID
- ALT-75

## 변경 내용
- 사용자 근무일정 조회 API 개선 (일주일/월별 조회 지원)
- 자신이 근무중인 알바 목록 조회 API 응답에 다음 근무일 응답 추가
- 근무일정 조회 시 파라미터 필수 조건 설정

## 구현 사항
- **근무일정 조회 API 개선**: 사용자 자신의 근무 일정 조회 시 일주일/월별 조회 기능 추가
- **다음 근무일 응답 추가**: 사용자가 근무중인 알바 목록 조회 시 다음 근무일 정보를 응답에 포함
- **파라미터 검증 강화**: 근무일정 조회 시 필수 파라미터 조건 설정으로 API 안정성 향상

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Self schedule API now supports weekly (default) or monthly queries via nullable year/month; workspace schedule requires year/month; user workspace list includes nextShiftDateTime.
> 
> - **Schedule APIs**:
>   - `UserScheduleController`: pass `WorkScheduleInquiryRequestDto` directly to use cases for `/self` and `/workspace/{workspaceId}`.
>   - Specs: clarify `/self` is "my schedule" with optional `year/month` (monthly when provided); workspace schedule requires both.
>   - `WorkScheduleInquiryRequestDto`: make `year`/`month` nullable (`Integer`) and not required.
> - **Use Cases**:
>   - `GetMyWorkSchedule`: accept request DTO; if `year/month` absent, fetch next 7 days via new weekly query; else monthly.
>   - `GetWorkspaceWorkSchedule`: accept request DTO; validate `year/month` required; query monthly.
>   - Ports (`GetMyScheduleUseCase`, `GetWorkspaceScheduleUseCase`): method signatures updated to use request DTO.
> - **Persistence/Queries**:
>   - `WorkspaceShiftQueryRepository`/Impl: add `findByUserAndWeeklyRange(User, LocalDate, LocalDate)`.
>   - `WorkspaceWorkerQueryRepositoryImpl`: enrich user workspace list with subquery for min future confirmed `startDateTime` as `nextShiftDateTime`.
> - **DTOs**:
>   - `UserWorkspaceListResponse`/`UserWorkspaceListResponseDto`: add `nextShiftDateTime` and map it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c9fdcd390cb0b573ae47815c08e5ac2a80d9646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->