### PR TITLE
feat: 신고 시스템 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/controller/AdminReportController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/controller/AdminReportController.java
@@ -1,0 +1,79 @@
+package com.dreamteam.alter.adapter.inbound.admin.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.admin.report.dto.AdminUpdateReportStatusRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import com.dreamteam.alter.application.aop.AdminActionContext;
+import com.dreamteam.alter.domain.report.port.inbound.*;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/reports")
+@PreAuthorize("hasAnyRole('ADMIN')")
+@RequiredArgsConstructor
+@Validated
+public class AdminReportController implements AdminReportControllerSpec {
+
+    @Resource(name = "adminGetReportList")
+    private final AdminGetReportListUseCase adminGetReportList;
+
+    @Resource(name = "adminGetReportDetail")
+    private final AdminGetReportDetailUseCase adminGetReportDetail;
+
+    @Resource(name = "adminUpdateReportStatus")
+    private final AdminUpdateReportStatusUseCase adminUpdateReportStatus;
+
+    @Resource(name = "adminDeleteReport")
+    private final AdminDeleteReportUseCase adminDeleteReport;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getReportList(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter
+    ) {
+        AdminActor actor = AdminActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(adminGetReportList.execute(request, filter, actor));
+    }
+
+    @Override
+    @GetMapping("/{reportId}")
+    public ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getReportDetail(
+        @PathVariable Long reportId
+    ) {
+        AdminActor actor = AdminActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(CommonApiResponse.of(adminGetReportDetail.execute(reportId, actor)));
+    }
+
+    @Override
+    @PutMapping("/{reportId}/status")
+    public ResponseEntity<CommonApiResponse<Void>> updateReportStatus(
+        @PathVariable Long reportId,
+        @Valid @RequestBody AdminUpdateReportStatusRequestDto request
+    ) {
+        AdminActor actor = AdminActionContext.getInstance().getActor();
+
+        adminUpdateReportStatus.execute(reportId, request, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @DeleteMapping("/{reportId}")
+    public ResponseEntity<CommonApiResponse<Void>> deleteReport(
+        @PathVariable Long reportId
+    ) {
+        adminDeleteReport.execute(reportId);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/controller/AdminReportControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/controller/AdminReportControllerSpec.java
@@ -1,0 +1,102 @@
+package com.dreamteam.alter.adapter.inbound.admin.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.admin.report.dto.AdminUpdateReportStatusRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "ADMIN - 관리자 신고 관리 API")
+public interface AdminReportControllerSpec {
+
+    @Operation(summary = "전체 신고 목록 조회", description = "관리자가 모든 신고 목록을 커서 페이징으로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 커서, 페이지 크기 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getReportList(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter
+    );
+
+    @Operation(summary = "신고 상세 조회", description = "관리자가 신고 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getReportDetail(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+
+    @Operation(summary = "신고 상태 변경", description = "관리자가 신고 상태를 변경하고 코멘트를 남깁니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 상태 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 상태 값 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> updateReportStatus(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId,
+        @Valid @RequestBody AdminUpdateReportStatusRequestDto request
+    );
+
+    @Operation(summary = "신고 삭제", description = "관리자가 신고를 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> deleteReport(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/dto/AdminUpdateReportStatusRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/report/dto/AdminUpdateReportStatusRequestDto.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.adapter.inbound.admin.report.dto;
+
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자 신고 상태 변경 요청 DTO")
+public class AdminUpdateReportStatusRequestDto {
+
+    @NotNull
+    @Schema(description = "신고 상태", example = "PROCESSING")
+    private ReportStatus status;
+
+    @Schema(description = "관리자 코멘트", example = "신고 내용을 검토하여 처리하겠습니다.")
+    private String adminComment;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/controller/ReportController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/controller/ReportController.java
@@ -1,0 +1,75 @@
+package com.dreamteam.alter.adapter.inbound.general.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import com.dreamteam.alter.application.aop.AppActionContext;
+import com.dreamteam.alter.domain.report.port.inbound.*;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/app/reports")
+@PreAuthorize("hasAnyRole('USER')")
+@RequiredArgsConstructor
+@Validated
+public class ReportController implements ReportControllerSpec {
+
+    @Resource(name = "createReport")
+    private final CreateReportUseCase createReport;
+
+    @Resource(name = "getMyReportList")
+    private final GetMyReportListUseCase getMyReportList;
+
+    @Resource(name = "getReportDetail")
+    private final GetReportDetailUseCase getReportDetail;
+
+    @Resource(name = "cancelReport")
+    private final CancelReportUseCase cancelReport;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> createReport(
+            @Valid @RequestBody CreateReportRequestDto request
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        createReport.execute(request, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getMyReportList(
+            CursorPageRequestDto request,
+            ReportListFilterDto filter
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        return ResponseEntity.ok(getMyReportList.execute(request, filter, actor));
+    }
+
+    @Override
+    @GetMapping("/me/{reportId}")
+    public ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getMyReportDetail(
+            @PathVariable Long reportId
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        return ResponseEntity.ok(CommonApiResponse.of(getReportDetail.execute(reportId, actor)));
+    }
+
+    @Override
+    @DeleteMapping("/me/{reportId}")
+    public ResponseEntity<CommonApiResponse<Void>> cancelMyReport(
+            @PathVariable Long reportId
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        cancelReport.execute(reportId, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/controller/ReportControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/controller/ReportControllerSpec.java
@@ -1,0 +1,112 @@
+package com.dreamteam.alter.adapter.inbound.general.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "APP - 신고 관련 API")
+public interface ReportControllerSpec {
+
+    @Operation(summary = "신고 생성", description = "사용자가 신고를 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 신고 타입, targetId 누락 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    ),
+                    @ExampleObject(
+                        name = "존재하지 않는 대상",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> createReport(
+        @Valid @RequestBody CreateReportRequestDto request
+    );
+
+    @Operation(summary = "내 신고 목록 조회", description = "사용자의 신고 목록을 커서 페이징으로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 커서, 페이지 크기 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getMyReportList(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter
+    );
+
+    @Operation(summary = "내 신고 상세 조회", description = "사용자의 신고 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "권한이 없는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getMyReportDetail(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+
+    @Operation(summary = "내 신고 취소", description = "사용자의 신고를 취소합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 취소 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "권한이 없는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "취소할 수 없는 신고 상태",
+                        value = "{\"code\" : \"B012\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> cancelMyReport(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/CreateReportRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/CreateReportRequestDto.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.adapter.inbound.general.report.dto;
+
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "신고 생성 요청 DTO")
+public class CreateReportRequestDto {
+
+    @NotNull
+    @Schema(description = "신고 대상 유형", example = "USER")
+    private ReportTargetType targetType;
+
+    @NotNull
+    @Schema(description = "신고 대상 ID", example = "1")
+    private Long targetId;
+
+    @NotBlank
+    @Schema(description = "신고 사유", example = "부적절한 행동")
+    private String reason;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportDetailResponseDto.java
@@ -1,0 +1,55 @@
+package com.dreamteam.alter.adapter.inbound.general.report.dto;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "신고 상세 조회 응답 DTO")
+public class ReportDetailResponseDto {
+
+    @Schema(description = "신고 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "신고 대상 유형", example = "USER")
+    private DescribedEnumDto<ReportTargetType> targetType;
+
+    @Schema(description = "신고 대상 정보")
+    private ReportTargetDto target;
+
+    @Schema(description = "신고 사유", example = "부적절한 행동")
+    private String reason;
+
+    @Schema(description = "신고 상태", example = "PENDING")
+    private DescribedEnumDto<ReportStatus> status;
+
+    @Schema(description = "관리자 코멘트", example = "신고 내용을 검토하여 처리하겠습니다.")
+    private String adminComment;
+
+    @Schema(description = "생성일", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일", example = "2023-10-01T12:00:00")
+    private LocalDateTime updatedAt;
+
+    public static ReportDetailResponseDto from(ReportDetailResponse response) {
+        return ReportDetailResponseDto.builder()
+            .id(response.getId())
+            .targetType(DescribedEnumDto.of(response.getTargetType(), ReportTargetType.describe()))
+            .target(ReportTargetDto.of(response.getTargetId(), response.getTargetName()))
+            .reason(response.getReason())
+            .status(DescribedEnumDto.of(response.getStatus(), ReportStatus.describe()))
+            .adminComment(response.getAdminComment())
+            .createdAt(response.getCreatedAt())
+            .updatedAt(response.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportListFilterDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportListFilterDto.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.adapter.inbound.general.report.dto;
+
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springdoc.core.annotations.ParameterObject;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ParameterObject
+@Schema(description = "신고 목록 필터 DTO")
+public class ReportListFilterDto {
+
+    @Schema(description = "신고 대상 유형", example = "USER")
+    private ReportTargetType targetType;
+
+    @Schema(description = "신고 상태", example = "PENDING")
+    private ReportStatus status;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportListResponseDto.java
@@ -1,0 +1,43 @@
+package com.dreamteam.alter.adapter.inbound.general.report.dto;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Schema(description = "신고 목록 조회 응답 DTO")
+public class ReportListResponseDto {
+
+    @Schema(description = "신고 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "신고 대상 유형", example = "USER")
+    private DescribedEnumDto<ReportTargetType> targetType;
+
+    @Schema(description = "신고 대상 이름", example = "홍길동")
+    private String targetName;
+
+    @Schema(description = "신고 상태", example = "PENDING")
+    private DescribedEnumDto<ReportStatus> status;
+
+    @Schema(description = "생성일", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+    public static ReportListResponseDto from(ReportListResponse response) {
+        return ReportListResponseDto.builder()
+                .id(response.getId())
+                .targetType(DescribedEnumDto.of(response.getTargetType(), ReportTargetType.describe()))
+                .targetName(response.getTargetName())
+                .status(DescribedEnumDto.of(response.getStatus(), ReportStatus.describe()))
+                .createdAt(response.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportTargetDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/report/dto/ReportTargetDto.java
@@ -1,0 +1,25 @@
+package com.dreamteam.alter.adapter.inbound.general.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "신고 대상 정보 DTO")
+public class ReportTargetDto {
+
+    @Schema(description = "신고 대상 ID", example = "1")
+    private Long targetId;
+
+    @Schema(description = "신고 대상 이름", example = "홍길동")
+    private String targetName;
+
+    public static ReportTargetDto of(Long targetId, String targetName) {
+        return ReportTargetDto.builder()
+                .targetId(targetId)
+                .targetName(targetName)
+                .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/report/controller/ManagerReportController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/report/controller/ManagerReportController.java
@@ -1,0 +1,78 @@
+package com.dreamteam.alter.adapter.inbound.manager.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import com.dreamteam.alter.application.aop.ManagerActionContext;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerCreateReportUseCase;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerGetMyReportListUseCase;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerGetReportDetailUseCase;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerCancelReportUseCase;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/manager/reports")
+@PreAuthorize("hasAnyRole('MANAGER')")
+@RequiredArgsConstructor
+@Validated
+public class ManagerReportController implements ManagerReportControllerSpec {
+
+    @Resource(name = "managerCreateReport")
+    private final ManagerCreateReportUseCase createReport;
+
+    @Resource(name = "managerGetMyReportList")
+    private final ManagerGetMyReportListUseCase getMyReportList;
+
+    @Resource(name = "managerGetReportDetail")
+    private final ManagerGetReportDetailUseCase getReportDetail;
+
+    @Resource(name = "managerCancelReport")
+    private final ManagerCancelReportUseCase cancelReport;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> createReport(
+            @Valid @RequestBody CreateReportRequestDto request
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        createReport.execute(request, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getMyReportList(
+            CursorPageRequestDto request,
+            ReportListFilterDto filter
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        return ResponseEntity.ok(getMyReportList.execute(request, filter, actor));
+    }
+
+    @Override
+    @GetMapping("/me/{reportId}")
+    public ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getMyReportDetail(
+            @PathVariable Long reportId
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        return ResponseEntity.ok(CommonApiResponse.of(getReportDetail.execute(reportId, actor)));
+    }
+
+    @Override
+    @DeleteMapping("/me/{reportId}")
+    public ResponseEntity<CommonApiResponse<Void>> cancelMyReport(
+            @PathVariable Long reportId
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        cancelReport.execute(reportId, actor);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/report/controller/ManagerReportControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/report/controller/ManagerReportControllerSpec.java
@@ -1,0 +1,112 @@
+package com.dreamteam.alter.adapter.inbound.manager.report.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "MANAGER - 점주 신고 관련 API")
+public interface ManagerReportControllerSpec {
+
+    @Operation(summary = "신고 생성", description = "점주가 신고를 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 신고 타입, targetId 누락 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    ),
+                    @ExampleObject(
+                        name = "존재하지 않는 대상",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> createReport(
+        @Valid @RequestBody CreateReportRequestDto request
+    );
+
+    @Operation(summary = "내 신고 목록 조회", description = "점주의 신고 목록을 커서 페이징으로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청 (유효하지 않은 커서, 페이지 크기 등)",
+                        value = "{\"code\" : \"B001\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CursorPaginatedApiResponse<ReportListResponseDto>> getMyReportList(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter
+    );
+
+    @Operation(summary = "내 신고 상세 조회", description = "점주의 신고 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "권한이 없는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<ReportDetailResponseDto>> getMyReportDetail(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+
+    @Operation(summary = "내 신고 취소", description = "점주의 신고를 취소합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 취소 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "권한이 없는 신고",
+                        value = "{\"code\" : \"B011\"}"
+                    ),
+                    @ExampleObject(
+                        name = "취소할 수 없는 신고 상태",
+                        value = "{\"code\" : \"B012\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> cancelMyReport(
+        @Parameter(description = "신고 ID", example = "1") @PathVariable Long reportId
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/ReportQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/ReportQueryRepositoryImpl.java
@@ -47,27 +47,33 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
     public Optional<ReportDetailResponse> findByIdWithTarget(Long id) {
         return Optional.ofNullable(
             queryFactory
-                .select(Projections.constructor(ReportDetailResponse.class,
-                        report.id,
-                        report.targetType,
-                        report.targetId,
-                        getTargetName(),
-                        report.reason,
-                        report.status,
-                        report.adminComment,
-                        report.createdAt,
-                        report.updatedAt
+                .select(Projections.constructor(
+                    ReportDetailResponse.class,
+                    report.id,
+                    report.targetType,
+                    report.targetId,
+                    getTargetName(),
+                    report.reason,
+                    report.status,
+                    report.adminComment,
+                    report.createdAt,
+                    report.updatedAt
                 ))
                 .from(report)
-                .leftJoin(user).on(
-                        report.targetType.eq(ReportTargetType.USER)
+                .leftJoin(user)
+                .on(
+                    report.targetType.eq(ReportTargetType.USER)
                         .and(report.targetId.eq(user.id))
                 )
-                .leftJoin(workspace).on(
+                .leftJoin(workspace)
+                .on(
+                    (
                         report.targetType.eq(ReportTargetType.POSTING)
-                        .and(report.targetId.eq(workspace.id))
-                        .or(report.targetType.eq(ReportTargetType.WORKSPACE)
-                        .and(report.targetId.eq(workspace.id)))
+                            .and(report.targetId.eq(workspace.id))
+                    ).or(
+                        report.targetType.eq(ReportTargetType.WORKSPACE)
+                            .and(report.targetId.eq(workspace.id))
+                    )
                 )
                 .where(report.id.eq(id))
                 .fetchOne()
@@ -128,10 +134,13 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
             )
             .leftJoin(workspace)
             .on(
-                report.targetType.eq(ReportTargetType.POSTING)
-                    .and(report.targetId.eq(workspace.id))
-                    .or(report.targetType.eq(ReportTargetType.WORKSPACE)
-                    .and(report.targetId.eq(workspace.id)))
+                (
+                    report.targetType.eq(ReportTargetType.POSTING)
+                        .and(report.targetId.eq(workspace.id))
+                ).or(
+                    report.targetType.eq(ReportTargetType.WORKSPACE)
+                        .and(report.targetId.eq(workspace.id))
+                )
             )
             .where(
                 report.reporterType.eq(reporterType),
@@ -181,10 +190,13 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
             )
             .leftJoin(workspace)
             .on(
-                report.targetType.eq(ReportTargetType.POSTING)
-                    .and(report.targetId.eq(workspace.id))
-                    .or(report.targetType.eq(ReportTargetType.WORKSPACE)
-                    .and(report.targetId.eq(workspace.id)))
+                (
+                    report.targetType.eq(ReportTargetType.POSTING)
+                        .and(report.targetId.eq(workspace.id))
+                ).or(
+                    report.targetType.eq(ReportTargetType.WORKSPACE)
+                        .and(report.targetId.eq(workspace.id))
+                )
             )
             .where(
                 report.status.ne(ReportStatus.DELETED),

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/ReportQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/ReportQueryRepositoryImpl.java
@@ -1,0 +1,225 @@
+package com.dreamteam.alter.adapter.outbound.report.persistence;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.dreamteam.alter.domain.report.entity.QReport.report;
+import static com.dreamteam.alter.domain.user.entity.QUser.user;
+import static com.dreamteam.alter.domain.workspace.entity.QWorkspace.workspace;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportQueryRepositoryImpl implements ReportQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Report> findById(Long id) {
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(report)
+                .where(report.id.eq(id))
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<ReportDetailResponse> findByIdWithTarget(Long id) {
+        return Optional.ofNullable(
+            queryFactory
+                .select(Projections.constructor(ReportDetailResponse.class,
+                        report.id,
+                        report.targetType,
+                        report.targetId,
+                        getTargetName(),
+                        report.reason,
+                        report.status,
+                        report.adminComment,
+                        report.createdAt,
+                        report.updatedAt
+                ))
+                .from(report)
+                .leftJoin(user).on(
+                        report.targetType.eq(ReportTargetType.USER)
+                        .and(report.targetId.eq(user.id))
+                )
+                .leftJoin(workspace).on(
+                        report.targetType.eq(ReportTargetType.POSTING)
+                        .and(report.targetId.eq(workspace.id))
+                        .or(report.targetType.eq(ReportTargetType.WORKSPACE)
+                        .and(report.targetId.eq(workspace.id)))
+                )
+                .where(report.id.eq(id))
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Report> findByIdAndReporter(Long id, ReporterType reporterType, Long reporterId) {
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(report)
+                .where(
+                    report.id.eq(id),
+                    report.reporterType.eq(reporterType),
+                    report.reporterId.eq(reporterId),
+                    report.status.ne(ReportStatus.DELETED)
+                )
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public long getCountOfReports(ReportListFilterDto filter, ReporterType reporterType, Long reporterId) {
+        return queryFactory
+            .selectFrom(report)
+            .where(
+                report.reporterType.eq(reporterType),
+                report.reporterId.eq(reporterId),
+                report.status.ne(ReportStatus.DELETED),
+                eqReportType(filter.getTargetType()),
+                eqStatus(filter.getStatus())
+            )
+            .fetch()
+            .size();
+    }
+
+    @Override
+    public List<ReportListResponse> getReportsWithCursor(
+        CursorPageRequest<CursorDto> pageRequest,
+        ReportListFilterDto filter,
+        ReporterType reporterType,
+        Long reporterId
+    ) {
+        return queryFactory
+            .select(Projections.constructor(
+                ReportListResponse.class,
+                report.id,
+                report.targetType,
+                getTargetName(),
+                report.status,
+                report.createdAt
+            ))
+            .from(report)
+            .leftJoin(user)
+            .on(
+                report.targetType.eq(ReportTargetType.USER)
+                    .and(report.targetId.eq(user.id))
+            )
+            .leftJoin(workspace)
+            .on(
+                report.targetType.eq(ReportTargetType.POSTING)
+                    .and(report.targetId.eq(workspace.id))
+                    .or(report.targetType.eq(ReportTargetType.WORKSPACE)
+                    .and(report.targetId.eq(workspace.id)))
+            )
+            .where(
+                report.reporterType.eq(reporterType),
+                report.reporterId.eq(reporterId),
+                report.status.ne(ReportStatus.DELETED),
+                eqReportType(filter.getTargetType()),
+                eqStatus(filter.getStatus()),
+                cursorCondition(pageRequest.cursor())
+            )
+            .orderBy(report.createdAt.desc(), report.id.desc())
+            .limit(pageRequest.pageSize())
+            .fetch();
+    }
+
+    @Override
+    public long getAdminCountOfReports(ReportListFilterDto filter) {
+        return queryFactory
+            .selectFrom(report)
+            .where(
+                report.status.ne(ReportStatus.DELETED),
+                eqReportType(filter.getTargetType()),
+                eqStatus(filter.getStatus())
+            )
+            .fetch()
+            .size();
+    }
+
+    @Override
+    public List<ReportListResponse> getAdminReportsWithCursor(
+        CursorPageRequest<CursorDto> pageRequest,
+        ReportListFilterDto filter
+    ) {
+        return queryFactory
+            .select(Projections.constructor(
+                ReportListResponse.class,
+                report.id,
+                report.targetType,
+                getTargetName(),
+                report.status,
+                report.createdAt
+            ))
+            .from(report)
+            .leftJoin(user)
+            .on(
+                report.targetType.eq(ReportTargetType.USER)
+                    .and(report.targetId.eq(user.id))
+            )
+            .leftJoin(workspace)
+            .on(
+                report.targetType.eq(ReportTargetType.POSTING)
+                    .and(report.targetId.eq(workspace.id))
+                    .or(report.targetType.eq(ReportTargetType.WORKSPACE)
+                    .and(report.targetId.eq(workspace.id)))
+            )
+            .where(
+                report.status.ne(ReportStatus.DELETED),
+                eqReportType(filter.getTargetType()),
+                eqStatus(filter.getStatus()),
+                cursorCondition(pageRequest.cursor())
+            )
+            .orderBy(report.createdAt.desc(), report.id.desc())
+            .limit(pageRequest.pageSize())
+            .fetch();
+    }
+
+    private BooleanExpression eqReportType(ReportTargetType reportType) {
+        return ObjectUtils.isNotEmpty(reportType) ? report.targetType.eq(reportType) : null;
+    }
+
+    private BooleanExpression eqStatus(ReportStatus status) {
+        return ObjectUtils.isNotEmpty(status) ? report.status.eq(status) : null;
+    }
+
+    private BooleanExpression cursorCondition(CursorDto cursor) {
+        if (ObjectUtils.isEmpty(cursor)) {
+            return null;
+        }
+        return report.createdAt.lt(cursor.getCreatedAt())
+            .or(report.createdAt.eq(cursor.getCreatedAt())
+                .and(report.id.lt(cursor.getId())));
+    }
+
+    private SimpleExpression<String> getTargetName() {
+        return new CaseBuilder()
+            .when(report.targetType.eq(ReportTargetType.USER)).then(user.name)
+            .when(report.targetType.eq(ReportTargetType.POSTING)).then(workspace.businessName)
+            .when(report.targetType.eq(ReportTargetType.WORKSPACE)).then(workspace.businessName)
+            .when(report.targetType.eq(ReportTargetType.REPUTATION)).then(Expressions.constant(""))
+            .otherwise("알 수 없음");
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/readonly/ReportDetailResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/readonly/ReportDetailResponse.java
@@ -1,0 +1,24 @@
+package com.dreamteam.alter.adapter.outbound.report.persistence.readonly;
+
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportDetailResponse {
+    private Long id;
+    private ReportTargetType targetType;
+    private Long targetId;
+    private String targetName;
+    private String reason;
+    private ReportStatus status;
+    private String adminComment;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/readonly/ReportListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/report/persistence/readonly/ReportListResponse.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.outbound.report.persistence.readonly;
+
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportListResponse {
+    private Long id;
+    private ReportTargetType targetType;
+    private String targetName;
+    private ReportStatus status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/AdminDeleteReport.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/AdminDeleteReport.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.AdminDeleteReportUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminDeleteReport")
+@RequiredArgsConstructor
+@Transactional
+public class AdminDeleteReport implements AdminDeleteReportUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public void execute(Long reportId) {
+        Report report = reportQueryRepository.findById(reportId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        report.delete();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/AdminGetReportDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/AdminGetReportDetail.java
@@ -1,0 +1,29 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.port.inbound.AdminGetReportDetailUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminGetReportDetail")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGetReportDetail implements AdminGetReportDetailUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public ReportDetailResponseDto execute(Long reportId, AdminActor actor) {
+        ReportDetailResponse reportDetail =
+            reportQueryRepository.findByIdWithTarget(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        return ReportDetailResponseDto.from(reportDetail);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/AdminGetReportList.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/AdminGetReportList.java
@@ -1,0 +1,69 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.common.util.CursorUtil;
+import com.dreamteam.alter.domain.report.port.inbound.AdminGetReportListUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service("adminGetReportList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGetReportList implements AdminGetReportListUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public CursorPaginatedApiResponse<ReportListResponseDto> execute(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter,
+        AdminActor actor
+    ) {
+        CursorDto cursorDto = null;
+        if (ObjectUtils.isNotEmpty(request.cursor())) {
+            cursorDto = CursorUtil.decodeCursor(request.cursor(), CursorDto.class, objectMapper);
+        }
+        CursorPageRequest<CursorDto> pageRequest = CursorPageRequest.of(cursorDto, request.pageSize());
+
+        long count = reportQueryRepository.getAdminCountOfReports(filter);
+        if (count == 0) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        List<ReportListResponse> reports = reportQueryRepository.getAdminReportsWithCursor(pageRequest, filter);
+        if (ObjectUtils.isEmpty(reports)) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        ReportListResponse last = reports.getLast();
+        CursorPageResponseDto pageResponseDto = CursorPageResponseDto.of(
+            CursorUtil.encodeCursor(new CursorDto(last.getId(), last.getCreatedAt()), objectMapper),
+            pageRequest.pageSize(),
+            (int) count
+        );
+
+        return CursorPaginatedApiResponse.of(
+            pageResponseDto,
+            reports.stream()
+                .map(ReportListResponseDto::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/AdminUpdateReportStatus.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/AdminUpdateReportStatus.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.admin.report.dto.AdminUpdateReportStatusRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.AdminUpdateReportStatusUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminUpdateReportStatus")
+@RequiredArgsConstructor
+@Transactional
+public class AdminUpdateReportStatus implements AdminUpdateReportStatusUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public void execute(Long reportId, AdminUpdateReportStatusRequestDto request, AdminActor actor) {
+        Report report = reportQueryRepository.findById(reportId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        report.updateStatus(request.getStatus(), request.getAdminComment());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/CancelReport.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/CancelReport.java
@@ -1,0 +1,33 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.CancelReportUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("cancelReport")
+@RequiredArgsConstructor
+@Transactional
+public class CancelReport implements CancelReportUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public void execute(Long reportId, AppActor actor) {
+        Report report = reportQueryRepository.findByIdAndReporter(reportId, ReporterType.USER, actor.getUser().getId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        if (!ReportStatus.cancellableStatuses().contains(report.getStatus())) {
+            throw new CustomException(ErrorCode.CONFLICT, "취소할 수 없는 신고입니다.");
+        }
+
+        report.cancel();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/CreateReport.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/CreateReport.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.CreateReportRequestDto;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.CreateReportUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportRepository;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("createReport")
+@RequiredArgsConstructor
+@Transactional
+public class CreateReport implements CreateReportUseCase {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public void execute(CreateReportRequestDto request, AppActor actor) {
+        reportRepository.save(Report.create(
+            ReporterType.USER,
+            actor.getUser().getId(),
+            request.getTargetType(),
+            request.getTargetId(),
+            request.getReason()
+        ));
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/GetMyReportList.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/GetMyReportList.java
@@ -1,0 +1,69 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.common.util.CursorUtil;
+import com.dreamteam.alter.domain.report.port.inbound.GetMyReportListUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service("getMyReportList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetMyReportList implements GetMyReportListUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public CursorPaginatedApiResponse<ReportListResponseDto> execute(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter,
+        AppActor actor
+    ) {
+        CursorDto cursorDto = null;
+        if (ObjectUtils.isNotEmpty(request.cursor())) {
+            cursorDto = CursorUtil.decodeCursor(request.cursor(), CursorDto.class, objectMapper);
+        }
+        CursorPageRequest<CursorDto> pageRequest = CursorPageRequest.of(cursorDto, request.pageSize());
+
+        long count = reportQueryRepository.getCountOfReports(filter, ReporterType.USER, actor.getUser().getId());
+        if (count == 0) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        List<ReportListResponse> reports =
+            reportQueryRepository.getReportsWithCursor(pageRequest, filter, ReporterType.USER, actor.getUser().getId());
+        if (ObjectUtils.isEmpty(reports)) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        ReportListResponse last = reports.getLast();
+        CursorPageResponseDto pageResponseDto = CursorPageResponseDto.of(
+            CursorUtil.encodeCursor(new CursorDto(last.getId(), last.getCreatedAt()), objectMapper),
+            pageRequest.pageSize(),
+            (int) count
+        );
+
+        return CursorPaginatedApiResponse.of(
+            pageResponseDto,
+            reports.stream()
+                .map(ReportListResponseDto::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/GetReportDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/GetReportDetail.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.GetReportDetailUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("getReportDetail")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetReportDetail implements GetReportDetailUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public ReportDetailResponseDto execute(Long reportId, AppActor actor) {
+        // 신고자 권한 확인
+        reportQueryRepository.findByIdAndReporter(reportId, ReporterType.USER, actor.getUser().getId())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        // target 정보와 함께 조회
+        ReportDetailResponse reportDetail =
+            reportQueryRepository.findByIdWithTarget(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        return ReportDetailResponseDto.from(reportDetail);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerCancelReport.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerCancelReport.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerCancelReportUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("managerCancelReport")
+@RequiredArgsConstructor
+@Transactional
+public class ManagerCancelReport implements ManagerCancelReportUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public void execute(Long reportId, ManagerActor actor) {
+        Report report = reportQueryRepository.findByIdAndReporter(
+                reportId,
+                ReporterType.MANAGER,
+                actor.getManagerUser().getId()
+            )
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        if (!ReportStatus.cancellableStatuses().contains(report.getStatus())) {
+            throw new CustomException(ErrorCode.CONFLICT, "취소할 수 없는 신고입니다.");
+        }
+
+        report.cancel();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerCreateReport.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerCreateReport.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.CreateReportRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerCreateReportUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportRepository;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("managerCreateReport")
+@RequiredArgsConstructor
+@Transactional
+public class ManagerCreateReport implements ManagerCreateReportUseCase {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public void execute(CreateReportRequestDto request, ManagerActor actor) {
+        if (ReportTargetType.WORKSPACE.equals(request.getTargetType())) {
+            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "매니저는 업장에 대한 신고를 작성할 수 없습니다.");
+        }
+        
+        reportRepository.save(Report.create(
+            ReporterType.MANAGER,
+            actor.getManagerUser().getId(),
+            request.getTargetType(),
+            request.getTargetId(),
+            request.getReason()
+        ));
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerGetMyReportList.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerGetMyReportList.java
@@ -1,0 +1,85 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.common.util.CursorUtil;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerGetMyReportListUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service("managerGetMyReportList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerGetMyReportList implements ManagerGetMyReportListUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public CursorPaginatedApiResponse<ReportListResponseDto> execute(
+        CursorPageRequestDto request,
+        ReportListFilterDto filter,
+        ManagerActor actor
+    ) {
+        // 매니저는 workspace 필터를 사용할 수 없음
+        if (ReportTargetType.WORKSPACE.equals(filter.getTargetType())) {
+            throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "매니저는 업장 신고를 조회할 수 없습니다.");
+        }
+        
+        CursorDto cursorDto = null;
+        if (ObjectUtils.isNotEmpty(request.cursor())) {
+            cursorDto = CursorUtil.decodeCursor(request.cursor(), CursorDto.class, objectMapper);
+        }
+        CursorPageRequest<CursorDto> pageRequest = CursorPageRequest.of(cursorDto, request.pageSize());
+
+        long count = reportQueryRepository.getCountOfReports(
+            filter,
+            ReporterType.MANAGER,
+            actor.getManagerUser().getId()
+        );
+        if (count == 0) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        List<ReportListResponse> reports = reportQueryRepository.getReportsWithCursor(
+            pageRequest,
+            filter,
+            ReporterType.MANAGER,
+            actor.getManagerUser().getId()
+        );
+        if (ObjectUtils.isEmpty(reports)) {
+            return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(request.pageSize(), (int) count));
+        }
+
+        ReportListResponse last = reports.getLast();
+        CursorPageResponseDto pageResponseDto = CursorPageResponseDto.of(
+            CursorUtil.encodeCursor(new CursorDto(last.getId(), last.getCreatedAt()), objectMapper),
+            pageRequest.pageSize(),
+            (int) count
+        );
+
+        return CursorPaginatedApiResponse.of(
+            pageResponseDto,
+            reports.stream()
+                .map(ReportListResponseDto::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerGetReportDetail.java
+++ b/src/main/java/com/dreamteam/alter/application/report/usecase/ManagerGetReportDetail.java
@@ -1,0 +1,40 @@
+package com.dreamteam.alter.application.report.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.port.inbound.ManagerGetReportDetailUseCase;
+import com.dreamteam.alter.domain.report.port.outbound.ReportQueryRepository;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("managerGetReportDetail")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerGetReportDetail implements ManagerGetReportDetailUseCase {
+
+    private final ReportQueryRepository reportQueryRepository;
+
+    @Override
+    public ReportDetailResponseDto execute(Long reportId, ManagerActor actor) {
+        // 신고자 권한 확인
+        reportQueryRepository.findByIdAndReporter(
+                reportId,
+                ReporterType.MANAGER,
+                actor.getManagerUser().getId()
+            )
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        // target 정보와 함께 조회
+        ReportDetailResponse reportDetail =
+            reportQueryRepository.findByIdWithTarget(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        return ReportDetailResponseDto.from(reportDetail);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/entity/Report.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/entity/Report.java
@@ -1,0 +1,90 @@
+package com.dreamteam.alter.domain.report.entity;
+
+import com.dreamteam.alter.domain.report.type.ReporterType;
+import com.dreamteam.alter.domain.report.type.ReportStatus;
+import com.dreamteam.alter.domain.report.type.ReportTargetType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "reports")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reporter_type", length = 20, nullable = false)
+    private ReporterType reporterType;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", length = 20, nullable = false)
+    private ReportTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "reason", length = 500, nullable = false)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private ReportStatus status;
+
+    @Column(name = "admin_comment", length = 500)
+    private String adminComment;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Report create(
+        ReporterType reporterType,
+        Long reporterId,
+        ReportTargetType targetType,
+        Long targetId,
+        String reason
+    ) {
+        return Report.builder()
+            .reporterType(reporterType)
+            .reporterId(reporterId)
+            .targetType(targetType)
+            .targetId(targetId)
+            .reason(reason)
+            .status(ReportStatus.PENDING)
+            .build();
+    }
+
+
+    public void updateStatus(ReportStatus status, String adminComment) {
+        this.status = status;
+        this.adminComment = adminComment;
+    }
+
+    public void cancel() {
+        this.status = ReportStatus.CANCELLED;
+    }
+
+    public void delete() {
+        this.status = ReportStatus.DELETED;
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminDeleteReportUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminDeleteReportUseCase.java
@@ -1,0 +1,5 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+public interface AdminDeleteReportUseCase {
+    void execute(Long reportId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminGetReportDetailUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminGetReportDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+
+public interface AdminGetReportDetailUseCase {
+    ReportDetailResponseDto execute(Long reportId, AdminActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminGetReportListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminGetReportListUseCase.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+
+public interface AdminGetReportListUseCase {
+    CursorPaginatedApiResponse<ReportListResponseDto> execute(CursorPageRequestDto request, ReportListFilterDto filter, AdminActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminUpdateReportStatusUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/AdminUpdateReportStatusUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.admin.report.dto.AdminUpdateReportStatusRequestDto;
+import com.dreamteam.alter.domain.user.context.AdminActor;
+
+public interface AdminUpdateReportStatusUseCase {
+    void execute(Long reportId, AdminUpdateReportStatusRequestDto request, AdminActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/CancelReportUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/CancelReportUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface CancelReportUseCase {
+    void execute(Long reportId, AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/CreateReportUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/CreateReportUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.CreateReportRequestDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface CreateReportUseCase {
+    void execute(CreateReportRequestDto request, AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/GetMyReportListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/GetMyReportListUseCase.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface GetMyReportListUseCase {
+    CursorPaginatedApiResponse<ReportListResponseDto> execute(CursorPageRequestDto request, ReportListFilterDto filter, AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/GetReportDetailUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/GetReportDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface GetReportDetailUseCase {
+    ReportDetailResponseDto execute(Long reportId, AppActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerCancelReportUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerCancelReportUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerCancelReportUseCase {
+    void execute(Long reportId, ManagerActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerCreateReportUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerCreateReportUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.CreateReportRequestDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerCreateReportUseCase {
+    void execute(CreateReportRequestDto request, ManagerActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerGetMyReportListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerGetMyReportListUseCase.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListResponseDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerGetMyReportListUseCase {
+    CursorPaginatedApiResponse<ReportListResponseDto> execute(CursorPageRequestDto request, ReportListFilterDto filter, ManagerActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerGetReportDetailUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/inbound/ManagerGetReportDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.report.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportDetailResponseDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerGetReportDetailUseCase {
+    ReportDetailResponseDto execute(Long reportId, ManagerActor actor);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/outbound/ReportQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/outbound/ReportQueryRepository.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.domain.report.port.outbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.general.report.dto.ReportListFilterDto;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportDetailResponse;
+import com.dreamteam.alter.adapter.outbound.report.persistence.readonly.ReportListResponse;
+import com.dreamteam.alter.domain.report.entity.Report;
+import com.dreamteam.alter.domain.report.type.ReporterType;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReportQueryRepository {
+
+    Optional<Report> findById(Long id);
+
+    Optional<ReportDetailResponse> findByIdWithTarget(Long id);
+
+    Optional<Report> findByIdAndReporter(Long id, ReporterType reporterType, Long reporterId);
+
+    long getCountOfReports(ReportListFilterDto filter, ReporterType reporterType, Long reporterId);
+
+    List<ReportListResponse> getReportsWithCursor(CursorPageRequest<com.dreamteam.alter.adapter.inbound.common.dto.CursorDto> pageRequest, ReportListFilterDto filter, ReporterType reporterType, Long reporterId);
+
+    long getAdminCountOfReports(ReportListFilterDto filter);
+
+    List<ReportListResponse> getAdminReportsWithCursor(CursorPageRequest<com.dreamteam.alter.adapter.inbound.common.dto.CursorDto> pageRequest, ReportListFilterDto filter);
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/port/outbound/ReportRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/port/outbound/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.report.port.outbound;
+
+import com.dreamteam.alter.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/type/ReportStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/type/ReportStatus.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.domain.report.type;
+
+import java.util.Map;
+import java.util.Set;
+
+public enum ReportStatus {
+    PENDING,
+    PROCESSING,
+    RESOLVED,
+    REJECTED,
+    CANCELLED,
+    DELETED;
+
+    public static Map<ReportStatus, String> describe() {
+        return Map.of(
+            ReportStatus.PENDING, "대기중",
+            ReportStatus.PROCESSING, "처리중",
+            ReportStatus.RESOLVED, "완료",
+            ReportStatus.REJECTED, "거부됨",
+            ReportStatus.CANCELLED, "취소됨",
+            ReportStatus.DELETED, "삭제됨"
+        );
+    }
+
+    public static Set<ReportStatus> cancellableStatuses() {
+        return Set.of(PENDING, PROCESSING);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/type/ReportTargetType.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/type/ReportTargetType.java
@@ -1,0 +1,19 @@
+package com.dreamteam.alter.domain.report.type;
+
+import java.util.Map;
+
+public enum ReportTargetType {
+    USER,
+    REPUTATION,
+    POSTING,
+    WORKSPACE;
+
+    public static Map<ReportTargetType, String> describe() {
+        return Map.of(
+            ReportTargetType.USER, "사용자",
+            ReportTargetType.REPUTATION, "평판",
+            ReportTargetType.POSTING, "공고",
+            ReportTargetType.WORKSPACE, "업장"
+        );
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/report/type/ReporterType.java
+++ b/src/main/java/com/dreamteam/alter/domain/report/type/ReporterType.java
@@ -1,0 +1,15 @@
+package com.dreamteam.alter.domain.report.type;
+
+import java.util.Map;
+
+public enum ReporterType {
+    USER,
+    MANAGER;
+
+    public static Map<ReporterType, String> describe() {
+        return Map.of(
+            ReporterType.USER, "사용자",
+            ReporterType.MANAGER, "매니저"
+        );
+    }
+}


### PR DESCRIPTION
## ID
- ALT-73

## 변경 내용
- 서비스 내 사용자 간 갈등 해결 및 서비스 품질 향상을 위한 신고 시스템 구현
- 사용자, 점주, 관리자별 신고 기능 및 관리 기능 제공

## 구현 사항
- **신고 생성 기능**
  - 단일 Report 테이블로 모든 신고 유형 관리 (USER, REPUTATION, POSTING, WORKSPACE)
  - ReporterType과 reporterId를 통한 신고자 구분 (USER, MANAGER)
  - 점주는 WORKSPACE를 대상으로 한 신고 제한
  - 신고 생성 시 PENDING 상태로 자동 설정

- **신고 조회 기능**
  - 커서 페이징을 통한 신고 목록 조회
  - 권한별 신고 조회 제한 (본인 신고만 조회 가능)

- **신고 상태 관리**
  - 취소 가능 상태 제한 (PENDING, PROCESSING만 취소 가능)
  - 관리자 전용 신고 삭제 기능
  - 신고 상태 변경 시 관리자 코멘트 추가 가능