### PR TITLE
feat: 공고 지원 목록 조회 필터 조건 개선

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingController.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.*;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UpdateUserPostingApplicationStatusRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserPostingApplicationListFilterDto;
 import com.dreamteam.alter.application.aop.AppActionContext;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.user.port.inbound.*;
@@ -39,11 +40,12 @@ public class UserPostingController implements UserPostingControllerSpec {
     @Override
     @GetMapping("/applications")
     public ResponseEntity<CursorPaginatedApiResponse<UserPostingApplicationListResponseDto>> getMyPostingApplications(
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        UserPostingApplicationListFilterDto filter
     ) {
         AppActor actor = AppActionContext.getInstance().getActor();
 
-        return ResponseEntity.ok(getUserPostingApplicationList.execute(actor, pageRequest));
+        return ResponseEntity.ok(getUserPostingApplicationList.execute(actor, pageRequest, filter));
     }
 
     @Override

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPostingControllerSpec.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.*;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UpdateUserPostingApplicationStatusRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.user.dto.UserFavoritePostingListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserPostingApplicationListFilterDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -24,7 +25,10 @@ public interface UserPostingControllerSpec {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "지원 목록 조회 성공")
     })
-    ResponseEntity<CursorPaginatedApiResponse<UserPostingApplicationListResponseDto>> getMyPostingApplications(CursorPageRequestDto pageRequest);
+    ResponseEntity<CursorPaginatedApiResponse<UserPostingApplicationListResponseDto>> getMyPostingApplications(
+        CursorPageRequestDto pageRequest,
+        UserPostingApplicationListFilterDto filter
+    );
 
     @Operation(summary = "사용자 공고 지원 상태 업데이트 (지원 취소)")
     @ApiResponses(value = {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserPostingApplicationListFilterDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserPostingApplicationListFilterDto.java
@@ -1,0 +1,23 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ParameterObject
+@Schema(description = "사용자 공고 지원 목록 필터 DTO")
+public class UserPostingApplicationListFilterDto {
+
+    @Parameter(description = "지원 상태 (in)")
+    private Set<PostingApplicationStatus> status;
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationListFilterDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationListFilterDto.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 
+import java.util.Set;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,7 +20,7 @@ public class PostingApplicationListFilterDto {
     @Parameter(description = "업장 ID (eq)")
     private Long workspaceId;
 
-    @Parameter(description = "지원 상태 (eq)")
-    private PostingApplicationStatus status;
+    @Parameter(description = "지원 상태 (in)")
+    private Set<PostingApplicationStatus> status;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
@@ -40,12 +40,7 @@ public class PostingApplicationQueryRepositoryImpl implements PostingApplication
     public long getCountByUser(User user, UserPostingApplicationListFilterDto filter) {
         QPostingApplication qPostingApplication = QPostingApplication.postingApplication;
 
-        BooleanExpression whereCondition = qPostingApplication.user.eq(user)
-            .and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED));
-
-        if (ObjectUtils.isNotEmpty(filter) && ObjectUtils.isNotEmpty(filter.getStatus())) {
-            whereCondition = whereCondition.and(qPostingApplication.status.in(filter.getStatus()));
-        }
+        BooleanExpression whereCondition = buildUserBaseConditions(qPostingApplication, user, filter);
 
         Long count = queryFactory
             .select(qPostingApplication.count())
@@ -67,12 +62,7 @@ public class PostingApplicationQueryRepositoryImpl implements PostingApplication
         QPosting qPosting = QPosting.posting;
         QWorkspace qWorkspace = QWorkspace.workspace;
 
-        BooleanExpression whereCondition = qPostingApplication.user.eq(user)
-            .and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED));
-
-        if (ObjectUtils.isNotEmpty(filter) && ObjectUtils.isNotEmpty(filter.getStatus())) {
-            whereCondition = whereCondition.and(qPostingApplication.status.in(filter.getStatus()));
-        }
+        BooleanExpression whereCondition = buildUserBaseConditions(qPostingApplication, user, filter);
 
         if (pageRequest.cursor() != null) {
             whereCondition = whereCondition.and(
@@ -298,6 +288,21 @@ public class PostingApplicationQueryRepositoryImpl implements PostingApplication
         return statusCondition != null 
             ? statusCondition.and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED))
             : qPostingApplication.status.ne(PostingApplicationStatus.DELETED);
+    }
+
+    private BooleanExpression buildUserBaseConditions(
+        QPostingApplication qPostingApplication,
+        User user,
+        UserPostingApplicationListFilterDto filter
+    ) {
+        BooleanExpression whereCondition = qPostingApplication.user.eq(user)
+            .and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED));
+
+        if (ObjectUtils.isNotEmpty(filter) && ObjectUtils.isNotEmpty(filter.getStatus())) {
+            whereCondition = whereCondition.and(qPostingApplication.status.in(filter.getStatus()));
+        }
+
+        return whereCondition;
     }
 
     private BooleanExpression getManagerPostingApplicationBaseConditions(

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import com.dreamteam.alter.domain.reputation.entity.QReputationSummary;
 import com.dreamteam.alter.domain.reputation.type.ReputationType;
 
@@ -285,16 +286,18 @@ public class PostingApplicationQueryRepositoryImpl implements PostingApplication
             : null;
     }
 
-    private BooleanExpression eqApplicationStatusOrDefault(QPostingApplication qPostingApplication, PostingApplicationStatus status) {
+    private BooleanExpression eqApplicationStatusOrDefault(QPostingApplication qPostingApplication, Set<PostingApplicationStatus> statuses) {
         BooleanExpression statusCondition;
-        if (ObjectUtils.isNotEmpty(status)) {
-            statusCondition = qPostingApplication.status.eq(status);
+        if (ObjectUtils.isNotEmpty(statuses)) {
+            statusCondition = qPostingApplication.status.in(statuses);
         } else {
-            statusCondition = qPostingApplication.status.in(PostingApplicationStatus.defaultInquirableStatuses());
+            statusCondition = null;
         }
         
         // DELETED 상태는 항상 제외
-        return statusCondition.and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED));
+        return statusCondition != null 
+            ? statusCondition.and(qPostingApplication.status.ne(PostingApplicationStatus.DELETED))
+            : qPostingApplication.status.ne(PostingApplicationStatus.DELETED);
     }
 
     private BooleanExpression getManagerPostingApplicationBaseConditions(

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserPostingApplicationList.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserPostingApplicationList.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserPostingApplicationListFilterDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.UserPostingApplicationListResponse;
 import com.dreamteam.alter.common.util.CursorUtil;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingApplicationQueryRepository;
@@ -31,7 +32,8 @@ public class GetUserPostingApplicationList implements GetUserPostingApplicationL
     @Override
     public CursorPaginatedApiResponse<UserPostingApplicationListResponseDto> execute(
         AppActor actor,
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        UserPostingApplicationListFilterDto filter
     ) {
         User user = actor.getUser();
 
@@ -41,13 +43,13 @@ public class GetUserPostingApplicationList implements GetUserPostingApplicationL
         }
         CursorPageRequest<CursorDto> cursorPageRequest = CursorPageRequest.of(cursorDto, pageRequest.pageSize());
 
-        long count = postingApplicationQueryRepository.getCountByUser(user);
+        long count = postingApplicationQueryRepository.getCountByUser(user, filter);
         if (count == 0) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));
         }
 
         List<UserPostingApplicationListResponse> result =
-            postingApplicationQueryRepository.getUserPostingApplicationListWithCursor(user, cursorPageRequest);
+            postingApplicationQueryRepository.getUserPostingApplicationListWithCursor(user, cursorPageRequest, filter);
         
         if (ObjectUtils.isEmpty(result)) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingApplicationQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingApplicationQueryRepository.java
@@ -3,6 +3,7 @@ package com.dreamteam.alter.domain.posting.port.outbound;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.inbound.manager.posting.dto.PostingApplicationListFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserPostingApplicationListFilterDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.ManagerPostingApplicationDetailResponse;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.UserPostingApplicationListResponse;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.ManagerPostingApplicationListResponse;
@@ -14,8 +15,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostingApplicationQueryRepository {
-    long getCountByUser(User user);
-    List<UserPostingApplicationListResponse> getUserPostingApplicationListWithCursor(User user, CursorPageRequest<CursorDto> pageRequest);
+    long getCountByUser(User user, UserPostingApplicationListFilterDto filter);
+    List<UserPostingApplicationListResponse> getUserPostingApplicationListWithCursor(User user, CursorPageRequest<CursorDto> pageRequest, UserPostingApplicationListFilterDto filter);
     Optional<PostingApplication> getUserPostingApplication(User user, Long applicationId);
 
     long getManagerPostingApplicationCount(

--- a/src/main/java/com/dreamteam/alter/domain/posting/type/PostingApplicationStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/type/PostingApplicationStatus.java
@@ -1,7 +1,6 @@
 package com.dreamteam.alter.domain.posting.type;
 
 import java.util.Map;
-import java.util.Set;
 
 public enum PostingApplicationStatus {
     SUBMITTED,
@@ -23,10 +22,6 @@ public enum PostingApplicationStatus {
             PostingApplicationStatus.EXPIRED, "만료됨",
             PostingApplicationStatus.DELETED, "삭제됨"
         );
-    }
-
-    public static Set<PostingApplicationStatus> defaultInquirableStatuses() {
-        return Set.of(SUBMITTED, SHORTLISTED);
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserPostingApplicationListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/GetUserPostingApplicationListUseCase.java
@@ -3,8 +3,13 @@ package com.dreamteam.alter.domain.user.port.inbound;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.UserPostingApplicationListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.UserPostingApplicationListFilterDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 
 public interface GetUserPostingApplicationListUseCase {
-    CursorPaginatedApiResponse<UserPostingApplicationListResponseDto> execute(AppActor actor, CursorPageRequestDto pageRequest);
+    CursorPaginatedApiResponse<UserPostingApplicationListResponseDto> execute(
+        AppActor actor, 
+        CursorPageRequestDto pageRequest,
+        UserPostingApplicationListFilterDto filter
+    );
 }


### PR DESCRIPTION
## ID
- ALT-64

## 변경 내용
- 사용자 공고 지원 목록 조회 시 status 조건 다중 선택 가능하도록 개선
- 점주 공고 지원자 목록 조회 시 기본 조회 조건 제거 및 status 조건 다중 선택 가능하도록 개선

## 구현 사항
- **사용자 공고 지원 목록 조회 필터 개선**
  - `UserPostingApplicationListFilterDto`에 status 필터 조건 추가
  - status 조건을 다중 선택 가능하도록 구현

- **점주 공고 지원자 목록 조회 필터 개선**
  - 기본 조회 조건 제거로 더 유연한 조회 가능
  - status 조건 다중 선택 기능 추가