### PR TITLE
feat: 자신의 평판 요약 정보 조회 및 요청 관리 기능 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/reputation/SelfReputationSummaryDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/reputation/SelfReputationSummaryDto.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.adapter.inbound.common.dto.reputation;
+
+import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "자신의 평판 요약 정보 DTO")
+public class SelfReputationSummaryDto {
+
+    @NotNull
+    @Schema(description = "주요 키워드 목록 (상위 5개)")
+    private List<TopKeywordDto> topKeywords;
+
+    public static SelfReputationSummaryDto from(ReputationSummary reputationSummary) {
+        if (ObjectUtils.isEmpty(reputationSummary)) {
+            return null;
+        }
+
+        List<TopKeywordDto> topKeywords = reputationSummary.getTopKeywords()
+            .stream()
+            .map(TopKeywordDto::from)
+            .toList();
+
+        return new SelfReputationSummaryDto(topKeywords);
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/UserReputationController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/UserReputationController.java
@@ -6,12 +6,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse
 import com.dreamteam.alter.adapter.inbound.general.reputation.dto.*;
 import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationRequestListResponseDto;
 import com.dreamteam.alter.application.aop.AppActionContext;
-import com.dreamteam.alter.domain.reputation.port.inbound.AppAcceptReputationRequestUseCase;
-import com.dreamteam.alter.domain.reputation.port.inbound.AppCreateReputationToUserUseCase;
-import com.dreamteam.alter.domain.reputation.port.inbound.AppCreateReputationToWorkspaceUseCase;
-import com.dreamteam.alter.domain.reputation.port.inbound.AppDeclineReputationRequestUseCase;
-import com.dreamteam.alter.domain.reputation.port.inbound.GetAvailableReputationKeywordListUseCase;
-import com.dreamteam.alter.domain.reputation.port.inbound.UserGetReputationRequestListUseCase;
+import com.dreamteam.alter.domain.reputation.port.inbound.*;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -45,6 +40,12 @@ public class UserReputationController implements UserReputationControllerSpec {
 
     @Resource(name = "appAcceptReputationRequest")
     private final AppAcceptReputationRequestUseCase appAcceptReputationRequest;
+
+    @Resource(name = "userGetSentReputationRequestList")
+    private final UserGetSentReputationRequestListUseCase userGetSentReputationRequestList;
+
+    @Resource(name = "userCancelReputationRequest")
+    private final UserCancelReputationRequestUseCase userCancelReputationRequest;
 
     @Override
     @GetMapping("/keywords")
@@ -105,6 +106,26 @@ public class UserReputationController implements UserReputationControllerSpec {
         AppActor actor = AppActionContext.getInstance().getActor();
 
         appAcceptReputationRequest.execute(actor, requestId, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/requests/sent")
+    public ResponseEntity<CursorPaginatedApiResponse<ReputationRequestListResponseDto>> getSentReputationRequestList(
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(userGetSentReputationRequestList.execute(actor, filter, pageRequest));
+    }
+
+    @Override
+    @PatchMapping("/requests/sent/{requestId}/cancel")
+    public ResponseEntity<CommonApiResponse<Void>> cancelSentReputationRequest(@PathVariable Long requestId) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        userCancelReputationRequest.execute(actor, requestId);
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/UserReputationControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/reputation/controller/UserReputationControllerSpec.java
@@ -148,4 +148,39 @@ public interface UserReputationControllerSpec {
         @Valid @RequestBody AcceptReputationRequestDto request
     );
 
+    @Operation(summary = "보낸 평판 요청 목록 조회", description = "사용자가 보낸 평판 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "보낸 평판 요청 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 커서 페이징 요청",
+                        value = "{\"code\" : \"B005\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CursorPaginatedApiResponse<ReputationRequestListResponseDto>> getSentReputationRequestList(
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    );
+
+    @Operation(summary = "보낸 평판 요청 취소", description = "사용자가 보낸 평판 요청을 취소합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "평판 요청 취소 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "요청한 리소스를 찾을 수 없음 (취소할 수 있는 평판 요청)",
+                        value = "{\"code\" : \"B019\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> cancelSentReputationRequest(@PathVariable Long requestId);
+
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfInfoResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserSelfInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.general.user.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.SelfReputationSummaryDto;
 import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserSelfInfoResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -31,13 +32,17 @@ public class UserSelfInfoResponseDto {
     @Schema(description = "가입일", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "자신의 평판 요약 정보")
+    private SelfReputationSummaryDto reputationSummary;
+
     public static UserSelfInfoResponseDto from(UserSelfInfoResponse entity) {
         return UserSelfInfoResponseDto.builder()
-                .id(entity.getId())
-                .name(entity.getName())
-                .nickname(entity.getNickname())
-                .createdAt(entity.getCreatedAt())
-                .build();
+            .id(entity.getId())
+            .name(entity.getName())
+            .nickname(entity.getNickname())
+            .createdAt(entity.getCreatedAt())
+            .reputationSummary(SelfReputationSummaryDto.from(entity.getReputationSummary()))
+            .build();
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/reputation/controller/WorkspaceReputationController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/reputation/controller/WorkspaceReputationController.java
@@ -11,6 +11,8 @@ import com.dreamteam.alter.domain.reputation.port.inbound.WorkspaceAcceptReputat
 import com.dreamteam.alter.domain.reputation.port.inbound.WorkspaceCreateReputationToUserUseCase;
 import com.dreamteam.alter.domain.reputation.port.inbound.WorkspaceDeclineReputationRequestUseCase;
 import com.dreamteam.alter.domain.reputation.port.inbound.WorkspaceGetReputationRequestListUseCase;
+import com.dreamteam.alter.domain.reputation.port.inbound.ManagerGetSentReputationRequestListUseCase;
+import com.dreamteam.alter.domain.reputation.port.inbound.ManagerCancelReputationRequestUseCase;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -41,6 +43,12 @@ public class WorkspaceReputationController implements WorkspaceReputationControl
 
     @Resource(name = "workspaceAcceptReputationRequest")
     private final WorkspaceAcceptReputationRequestUseCase workspaceAcceptReputationRequest;
+
+    @Resource(name = "managerGetSentReputationRequestList")
+    private final ManagerGetSentReputationRequestListUseCase managerGetSentReputationRequestList;
+
+    @Resource(name = "managerCancelReputationRequest")
+    private final ManagerCancelReputationRequestUseCase managerCancelReputationRequest;
 
     @Override
     @GetMapping("/keywords")
@@ -89,6 +97,26 @@ public class WorkspaceReputationController implements WorkspaceReputationControl
         ManagerActor actor = ManagerActionContext.getInstance().getActor();
 
         workspaceAcceptReputationRequest.execute(actor, requestId, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @GetMapping("/requests/sent")
+    public ResponseEntity<CursorPaginatedApiResponse<ReputationRequestListResponseDto>> getSentReputationRequestList(
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+
+        return ResponseEntity.ok(managerGetSentReputationRequestList.execute(actor, filter, pageRequest));
+    }
+
+    @Override
+    @PatchMapping("/requests/sent/{requestId}/cancel")
+    public ResponseEntity<CommonApiResponse<Void>> cancelSentReputationRequest(@PathVariable Long requestId) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+
+        managerCancelReputationRequest.execute(actor, requestId);
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/reputation/controller/WorkspaceReputationControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/reputation/controller/WorkspaceReputationControllerSpec.java
@@ -10,6 +10,7 @@ import com.dreamteam.alter.adapter.inbound.general.reputation.dto.AvailableReput
 import com.dreamteam.alter.adapter.inbound.general.reputation.dto.AcceptReputationRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.reputation.dto.CreateReputationToUserRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.reputation.dto.ReputationRequestFilterDto;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.UserReputationRequestFilterDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -160,5 +161,40 @@ public interface WorkspaceReputationControllerSpec {
         @PathVariable Long requestId,
         @Valid @RequestBody AcceptReputationRequestDto request
     );
+
+    @Operation(summary = "보낸 평판 요청 목록 조회", description = "매니저가 보낸 평판 요청 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "보낸 평판 요청 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 커서 페이징 요청",
+                        value = "{\"code\" : \"B005\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CursorPaginatedApiResponse<ReputationRequestListResponseDto>> getSentReputationRequestList(
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    );
+
+    @Operation(summary = "보낸 평판 요청 취소", description = "매니저가 보낸 평판 요청을 취소합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "평판 요청 취소 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "요청한 리소스를 찾을 수 없음 (취소할 수 있는 평판 요청)",
+                        value = "{\"code\" : \"B019\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> cancelSentReputationRequest(@PathVariable Long requestId);
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.manager.workspace.dto;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.SelfReputationSummaryDto;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.ManagerWorkspaceResponse;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -62,6 +63,9 @@ public class ManagerWorkspaceResponseDto {
     @Schema(description = "업장 등록 일시", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "업장 평판 요약 정보")
+    private SelfReputationSummaryDto reputationSummary;
+
     public static ManagerWorkspaceResponseDto of(ManagerWorkspaceResponse entity) {
         return ManagerWorkspaceResponseDto.builder()
             .id(entity.getId())
@@ -75,6 +79,7 @@ public class ManagerWorkspaceResponseDto {
             .latitude(entity.getLatitude())
             .longitude(entity.getLongitude())
             .createdAt(entity.getCreatedAt())
+            .reputationSummary(SelfReputationSummaryDto.from(entity.getReputationSummary()))
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.dreamteam.alter.adapter.outbound.user.persistence;
 
 import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserSelfInfoResponse;
+import com.dreamteam.alter.domain.reputation.entity.QReputationSummary;
+import com.dreamteam.alter.domain.reputation.type.ReputationType;
 import com.dreamteam.alter.domain.user.entity.QUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
@@ -77,17 +79,23 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
     @Override
     public Optional<UserSelfInfoResponse> getUserSelfInfoSummary(Long id) {
         QUser qUser = QUser.user;
+        QReputationSummary qReputationSummary = QReputationSummary.reputationSummary;
 
         UserSelfInfoResponse userSelf = queryFactory.select(
-                Projections.fields(
+                Projections.constructor(
                     UserSelfInfoResponse.class,
                     qUser.id,
                     qUser.name,
                     qUser.nickname,
-                    qUser.createdAt
+                    qUser.createdAt,
+                    qReputationSummary
                 )
             )
             .from(qUser)
+            .leftJoin(qReputationSummary).on(
+                qReputationSummary.targetType.eq(ReputationType.USER),
+                qReputationSummary.targetId.eq(qUser.id)
+            )
             .where(
                 qUser.id.eq(id),
                 qUser.status.eq(UserStatus.ACTIVE)

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserSelfInfoResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/readonly/UserSelfInfoResponse.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.outbound.user.persistence.readonly;
 
+import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,5 +19,7 @@ public class UserSelfInfoResponse {
     private String nickname;
 
     private LocalDateTime createdAt;
+
+    private ReputationSummary reputationSummary;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerWorkspaceResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerWorkspaceResponse.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly;
 
+import com.dreamteam.alter.domain.reputation.entity.ReputationSummary;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceStatus;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -37,5 +38,7 @@ public class ManagerWorkspaceResponse {
     private BigDecimal longitude;
 
     private LocalDateTime createdAt;
+
+    private ReputationSummary reputationSummary;
 
 }

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/AbstractGetSentReputationRequestList.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/AbstractGetSentReputationRequestList.java
@@ -1,0 +1,85 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationRequestListResponseDto;
+import com.dreamteam.alter.adapter.outbound.reputation.persistence.readonly.ReputationRequestListResponse;
+import com.dreamteam.alter.common.util.CursorUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.ObjectUtils;
+
+import java.util.List;
+
+public abstract class AbstractGetSentReputationRequestList<A, F, C> {
+
+    protected final ObjectMapper objectMapper;
+
+    protected AbstractGetSentReputationRequestList(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public final CursorPaginatedApiResponse<ReputationRequestListResponseDto> execute(
+        A actor,
+        F filter,
+        CursorPageRequestDto pageRequest
+    ) {
+        C context = prepare(actor, filter);
+
+        validate(actor, filter, context);
+
+        if (!canProceed(actor, filter, context)) {
+            return empty(pageRequest.pageSize(), 0);
+        }
+
+        CursorDto cursorDto = null;
+        if (ObjectUtils.isNotEmpty(pageRequest.cursor())) {
+            cursorDto = CursorUtil.decodeCursor(pageRequest.cursor(), CursorDto.class, objectMapper);
+        }
+        CursorPageRequest<CursorDto> cursorPageRequest = CursorPageRequest.of(cursorDto, pageRequest.pageSize());
+
+        long count = count(actor, filter, context);
+        if (count == 0) {
+            return empty(pageRequest.pageSize(), count);
+        }
+
+        List<ReputationRequestListResponse> rows = fetch(cursorPageRequest, actor, filter, context);
+        if (ObjectUtils.isEmpty(rows)) {
+            return empty(pageRequest.pageSize(), count);
+        }
+
+        ReputationRequestListResponse last = rows.getLast();
+        CursorPageResponseDto pageResponse = CursorPageResponseDto.of(
+            CursorUtil.encodeCursor(new CursorDto(last.getId(), last.getCreatedAt()), objectMapper),
+            cursorPageRequest.pageSize(),
+            (int) count
+        );
+
+        return CursorPaginatedApiResponse.of(
+            pageResponse,
+            rows.stream().map(ReputationRequestListResponseDto::of).toList()
+        );
+    }
+
+    protected CursorPaginatedApiResponse<ReputationRequestListResponseDto> empty(int pageSize, long count) {
+        return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageSize, (int) count));
+    }
+
+    protected abstract C prepare(A actor, F filter);
+
+    protected abstract void validate(A actor, F filter, C context);
+
+    protected boolean canProceed(A actor, F filter, C context) { return true; }
+
+    protected abstract long count(A actor, F filter, C context);
+
+    protected abstract List<ReputationRequestListResponse> fetch(
+        CursorPageRequest<CursorDto> pageRequest,
+        A actor,
+        F filter,
+        C context
+    );
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/ManagerCancelReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/ManagerCancelReputationRequest.java
@@ -1,0 +1,33 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.inbound.ManagerCancelReputationRequestUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("managerCancelReputationRequest")
+@RequiredArgsConstructor
+@Transactional
+public class ManagerCancelReputationRequest implements ManagerCancelReputationRequestUseCase {
+
+    private final ReputationRequestQueryRepository reputationRequestQueryRepository;
+
+    @Override
+    public void execute(ManagerActor actor, Long requestId) {
+        ReputationRequest reputationRequest = reputationRequestQueryRepository
+            .findSentReputationRequestByManager(actor.getManagerUser().getId(), requestId);
+
+        if (ObjectUtils.isEmpty(reputationRequest)) {
+            throw new CustomException(ErrorCode.NOT_FOUND, "취소할 수 있는 평판 요청을 찾을 수 없습니다.");
+        }
+
+        reputationRequest.cancel();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/ManagerGetSentReputationRequestList.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/ManagerGetSentReputationRequestList.java
@@ -1,0 +1,59 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.UserReputationRequestFilterDto;
+import com.dreamteam.alter.adapter.outbound.reputation.persistence.readonly.ReputationRequestListResponse;
+import com.dreamteam.alter.domain.reputation.port.inbound.ManagerGetSentReputationRequestListUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("managerGetSentReputationRequestList")
+public class ManagerGetSentReputationRequestList extends AbstractGetSentReputationRequestList<ManagerActor, UserReputationRequestFilterDto, Long>
+    implements ManagerGetSentReputationRequestListUseCase {
+
+    private final ReputationRequestQueryRepository reputationRequestQueryRepository;
+
+    public ManagerGetSentReputationRequestList(ReputationRequestQueryRepository reputationRequestQueryRepository, ObjectMapper objectMapper) {
+        super(objectMapper);
+        this.reputationRequestQueryRepository = reputationRequestQueryRepository;
+    }
+
+    @Override
+    protected Long prepare(ManagerActor actor, UserReputationRequestFilterDto filter) {
+        return actor.getManagerUser().getId();
+    }
+
+    @Override
+    protected void validate(ManagerActor actor, UserReputationRequestFilterDto filter, Long managerId) { }
+
+    @Override
+    protected long count(ManagerActor actor, UserReputationRequestFilterDto filter, Long managerId) {
+        ReputationRequestStatus status = (filter != null) ? filter.getStatus() : null;
+        return reputationRequestQueryRepository.getCountOfSentReputationRequestsByManager(
+            managerId,
+            status
+        );
+    }
+
+    @Override
+    protected List<ReputationRequestListResponse> fetch(
+        CursorPageRequest<CursorDto> pageRequest,
+        ManagerActor actor,
+        UserReputationRequestFilterDto filter,
+        Long managerId
+    ) {
+        ReputationRequestStatus status = (filter != null) ? filter.getStatus() : null;
+        return reputationRequestQueryRepository.getSentReputationRequestsWithCursorByManager(
+            pageRequest,
+            managerId,
+            status
+        );
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/UserCancelReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/UserCancelReputationRequest.java
@@ -1,0 +1,33 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.reputation.entity.ReputationRequest;
+import com.dreamteam.alter.domain.reputation.port.inbound.UserCancelReputationRequestUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("userCancelReputationRequest")
+@RequiredArgsConstructor
+@Transactional
+public class UserCancelReputationRequest implements UserCancelReputationRequestUseCase {
+
+    private final ReputationRequestQueryRepository reputationRequestQueryRepository;
+
+    @Override
+    public void execute(AppActor actor, Long requestId) {
+        ReputationRequest reputationRequest = reputationRequestQueryRepository
+            .findSentReputationRequestByUser(actor.getUserId(), requestId);
+
+        if (ObjectUtils.isEmpty(reputationRequest)) {
+            throw new CustomException(ErrorCode.NOT_FOUND, "취소할 수 있는 평판 요청을 찾을 수 없습니다.");
+        }
+
+        reputationRequest.cancel();
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/UserGetSentReputationRequestList.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/UserGetSentReputationRequestList.java
@@ -1,0 +1,59 @@
+package com.dreamteam.alter.application.reputation.usecase;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.UserReputationRequestFilterDto;
+import com.dreamteam.alter.adapter.outbound.reputation.persistence.readonly.ReputationRequestListResponse;
+import com.dreamteam.alter.domain.reputation.port.inbound.UserGetSentReputationRequestListUseCase;
+import com.dreamteam.alter.domain.reputation.port.outbound.ReputationRequestQueryRepository;
+import com.dreamteam.alter.domain.reputation.type.ReputationRequestStatus;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service("userGetSentReputationRequestList")
+public class UserGetSentReputationRequestList extends AbstractGetSentReputationRequestList<AppActor, UserReputationRequestFilterDto, Long>
+    implements UserGetSentReputationRequestListUseCase {
+
+    private final ReputationRequestQueryRepository reputationRequestQueryRepository;
+
+    public UserGetSentReputationRequestList(ReputationRequestQueryRepository reputationRequestQueryRepository, ObjectMapper objectMapper) {
+        super(objectMapper);
+        this.reputationRequestQueryRepository = reputationRequestQueryRepository;
+    }
+
+    @Override
+    protected Long prepare(AppActor actor, UserReputationRequestFilterDto filter) {
+        return actor.getUser().getId();
+    }
+
+    @Override
+    protected void validate(AppActor actor, UserReputationRequestFilterDto filter, Long userId) { }
+
+    @Override
+    protected long count(AppActor actor, UserReputationRequestFilterDto filter, Long userId) {
+        ReputationRequestStatus status = (filter != null) ? filter.getStatus() : null;
+        return reputationRequestQueryRepository.getCountOfSentReputationRequestsByUser(
+            userId,
+            status
+        );
+    }
+
+    @Override
+    protected List<ReputationRequestListResponse> fetch(
+        CursorPageRequest<CursorDto> pageRequest,
+        AppActor actor,
+        UserReputationRequestFilterDto filter,
+        Long userId
+    ) {
+        ReputationRequestStatus status = (filter != null) ? filter.getStatus() : null;
+        return reputationRequestQueryRepository.getSentReputationRequestsWithCursorByUser(
+            pageRequest,
+            userId,
+            status
+        );
+    }
+
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfInfo.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/GetUserSelfInfo.java
@@ -6,13 +6,13 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.user.port.inbound.GetUserSelfInfoUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service("getUserSelfInfo")
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class GetUserSelfInfo implements GetUserSelfInfoUseCase {
 
     private final UserQueryRepository userQueryRepository;

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkspace.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkspace.java
@@ -10,8 +10,7 @@ import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryReposito
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
+import org.springframework.util.ObjectUtils;
 
 @Service("managerGetWorkspace")
 @RequiredArgsConstructor
@@ -22,14 +21,14 @@ public class ManagerGetWorkspace implements ManagerGetWorkspaceUseCase {
 
     @Override
     public ManagerWorkspaceResponseDto execute(ManagerActor actor, Long workspaceId) {
-        Optional<ManagerWorkspaceResponse> workspace =
+        ManagerWorkspaceResponse workspace =
             workspaceQueryRepository.getByManagerUserAndId(actor.getManagerUser(), workspaceId);
 
-        if (workspace.isEmpty()) {
+        if (ObjectUtils.isEmpty(workspace)) {
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        return ManagerWorkspaceResponseDto.of(workspace.get());
+        return ManagerWorkspaceResponseDto.of(workspace);
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/Reputation.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/Reputation.java
@@ -108,4 +108,8 @@ public class Reputation {
         this.status = ReputationStatus.COMPLETED;
     }
 
+    public void cancel() {
+        this.status = ReputationStatus.CANCELED;
+    }
+
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
@@ -118,4 +118,16 @@ public class ReputationRequest {
         }
     }
 
+    public void cancel() {
+        this.status = ReputationRequestStatus.CANCELED;
+
+        if (ObjectUtils.isNotEmpty(this.reputations)) {
+            for (Reputation reputation : this.reputations) {
+                if (ReputationStatus.REQUESTED.equals(reputation.getStatus())) {
+                    reputation.cancel();
+                }
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ManagerCancelReputationRequestUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ManagerCancelReputationRequestUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerCancelReputationRequestUseCase {
+    void execute(ManagerActor actor, Long requestId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ManagerGetSentReputationRequestListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/ManagerGetSentReputationRequestListUseCase.java
@@ -1,0 +1,15 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationRequestListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.UserReputationRequestFilterDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerGetSentReputationRequestListUseCase {
+    CursorPaginatedApiResponse<ReputationRequestListResponseDto> execute(
+        ManagerActor actor,
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    );
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/UserCancelReputationRequestUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/UserCancelReputationRequestUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface UserCancelReputationRequestUseCase {
+    void execute(AppActor actor, Long requestId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/UserGetSentReputationRequestListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/inbound/UserGetSentReputationRequestListUseCase.java
@@ -1,0 +1,15 @@
+package com.dreamteam.alter.domain.reputation.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.common.dto.reputation.ReputationRequestListResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.reputation.dto.UserReputationRequestFilterDto;
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface UserGetSentReputationRequestListUseCase {
+    CursorPaginatedApiResponse<ReputationRequestListResponseDto> execute(
+        AppActor actor,
+        UserReputationRequestFilterDto filter,
+        CursorPageRequestDto pageRequest
+    );
+}

--- a/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/port/outbound/ReputationRequestQueryRepository.java
@@ -33,4 +33,24 @@ public interface ReputationRequestQueryRepository {
         List<Long> workspaceIds,
         ReputationRequestFilterDto filter
     );
+
+    long getCountOfSentReputationRequestsByUser(Long userId, ReputationRequestStatus status);
+
+    List<ReputationRequestListResponse> getSentReputationRequestsWithCursorByUser(
+        CursorPageRequest<CursorDto> pageRequest,
+        Long userId,
+        ReputationRequestStatus status
+    );
+
+    long getCountOfSentReputationRequestsByManager(Long managerId, ReputationRequestStatus status);
+
+    List<ReputationRequestListResponse> getSentReputationRequestsWithCursorByManager(
+        CursorPageRequest<CursorDto> pageRequest,
+        Long managerId,
+        ReputationRequestStatus status
+    );
+
+    ReputationRequest findSentReputationRequestByUser(Long userId, Long requestId);
+
+    ReputationRequest findSentReputationRequestByManager(Long managerId, Long requestId);
 }

--- a/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationRequestStatus.java
@@ -6,7 +6,8 @@ public enum ReputationRequestStatus {
     REQUESTED,
     EXPIRED,
     DECLINED,
-    COMPLETED
+    COMPLETED,
+    CANCELED
     ;
 
     public static Map<ReputationRequestStatus, String> describe() {
@@ -14,7 +15,8 @@ public enum ReputationRequestStatus {
             ReputationRequestStatus.REQUESTED, "요청됨",
             ReputationRequestStatus.EXPIRED, "만료됨",
             ReputationRequestStatus.DECLINED, "거절됨",
-            ReputationRequestStatus.COMPLETED, "작성 완료"
+            ReputationRequestStatus.COMPLETED, "작성 완료",
+            ReputationRequestStatus.CANCELED, "취소됨"
         );
     }
 

--- a/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationStatus.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/type/ReputationStatus.java
@@ -6,7 +6,8 @@ public enum ReputationStatus {
     REQUESTED,
     DECLINED,
     COMPLETED,
-    DELETED
+    DELETED,
+    CANCELED
     ;
 
     public static Map<ReputationStatus, String> describe() {
@@ -14,7 +15,8 @@ public enum ReputationStatus {
             ReputationStatus.REQUESTED, "요청됨",
             ReputationStatus.DECLINED, "거절됨",
             ReputationStatus.COMPLETED, "작성 완료",
-            ReputationStatus.DELETED, "삭제됨"
+            ReputationStatus.DELETED, "삭제됨",
+            ReputationStatus.CANCELED, "취소됨"
         );
     }
 

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceQueryRepository.java
@@ -20,7 +20,7 @@ public interface WorkspaceQueryRepository {
     Optional<Workspace> findById(Long id);
     List<ManagerWorkspaceListResponse> getManagerWorkspaceList(ManagerUser managerUser);
 
-    Optional<ManagerWorkspaceResponse> getByManagerUserAndId(ManagerUser managerUser, Long workspaceId);
+    ManagerWorkspaceResponse getByManagerUserAndId(ManagerUser managerUser, Long workspaceId);
 
     long getWorkspaceWorkerCount(
         ManagerUser managerUser,


### PR DESCRIPTION
## ID
- ALT-85

## 변경 내용
- 사용자/점주 자신이 보낸 평판 요청 조회 및 취소 API 구현
- 사용자 자신의 정보 조회 API에 평판 요약 정보 응답 추가
- 점주 관리중인 업장 상세 조회 API에 평판 요약 정보 응답 추가
- 평판 요청 상태 취소 속성 추가

## 구현 사항
- **평판 요청 관리 기능**
  - `UserGetSentReputationRequestList`: 사용자 자신이 보낸 평판 요청 목록 조회
  - `ManagerGetSentReputationRequestList`: 점주 자신이 보낸 평판 요청 목록 조회
  - `UserCancelReputationRequest`: 사용자 평판 요청 취소
  - `ManagerCancelReputationRequest`: 점주 평판 요청 취소
  - `ReputationRequestStatus` enum에 `CANCELLED` 상태 속성 추가

- **평판 요약 정보 응답 추가**
  - `UserSelfInfoResponseDto`: 사용자 정보 조회 시 평판 요약 정보 포함
  - `ManagerWorkspaceResponseDto`: 점주 업장 조회 시 평판 요약 정보 포함
  - `SelfReputationSummaryDto`: 평판 요약 정보 DTO 추가