### PR TITLE
feat: 회원정보 찾기 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicController.java
@@ -9,6 +9,9 @@ import com.dreamteam.alter.domain.user.port.inbound.CreateUserUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.CheckContactDuplicationUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.CheckNicknameDuplicationUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.CheckEmailDuplicationUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.FindEmailByContactUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.CreatePasswordResetSessionUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.ResetPasswordUseCase;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,15 @@ public class UserPublicController implements UserPublicControllerSpec {
 
     @Resource(name = "checkEmailDuplication")
     private final CheckEmailDuplicationUseCase checkEmailDuplication;
+
+    @Resource(name = "findEmailByContact")
+    private final FindEmailByContactUseCase findEmailByContact;
+
+    @Resource(name = "createPasswordResetSession")
+    private final CreatePasswordResetSessionUseCase createPasswordResetSession;
+
+    @Resource(name = "resetPassword")
+    private final ResetPasswordUseCase resetPassword;
 
     @Override
     @PostMapping("/signup-session")
@@ -99,4 +111,28 @@ public class UserPublicController implements UserPublicControllerSpec {
         return ResponseEntity.ok(CommonApiResponse.of(checkEmailDuplication.execute(request)));
     }
 
+    @Override
+    @PostMapping("/find-email")
+    public ResponseEntity<CommonApiResponse<FindEmailResponseDto>> findEmailByContact(
+        @Valid @RequestBody FindEmailRequestDto request
+    ) {
+        return ResponseEntity.ok(CommonApiResponse.of(findEmailByContact.execute(request)));
+    }
+
+    @Override
+    @PostMapping("/password-reset/session")
+    public ResponseEntity<CommonApiResponse<CreatePasswordResetSessionResponseDto>> createPasswordResetSession(
+        @Valid @RequestBody CreatePasswordResetSessionRequestDto request
+    ) {
+        return ResponseEntity.ok(CommonApiResponse.of(createPasswordResetSession.execute(request)));
+    }
+
+    @Override
+    @PostMapping("/password-reset")
+    public ResponseEntity<CommonApiResponse<Void>> resetPassword(
+        @Valid @RequestBody ResetPasswordRequestDto request
+    ) {
+        resetPassword.execute(request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicControllerSpec.java
@@ -122,7 +122,7 @@ public interface UserPublicControllerSpec {
                 examples = {
                     @ExampleObject(
                         name = "성공 응답",
-                        value = "{\"success\": true, \"data\": {\"maskedEmail\": \"user@exa****\"}}"
+                        value = "{\"success\": true, \"data\": {\"maskedEmail\": \"us**@example.com\"}}"
                     )
                 }
             )

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserPublicControllerSpec.java
@@ -108,4 +108,103 @@ public interface UserPublicControllerSpec {
     })
     ResponseEntity<CommonApiResponse<CheckEmailDuplicationResponseDto>> checkEmailDuplication(@Valid CheckEmailDuplicationRequestDto request);
 
+    @Operation(
+        summary = "이메일 찾기",
+        description = "전화번호를 입력받아 해당하는 사용자의 마스킹된 이메일을 반환합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "이메일 찾기 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = FindEmailResponseDto.class),
+                examples = {
+                    @ExampleObject(
+                        name = "성공 응답",
+                        value = "{\"success\": true, \"data\": {\"maskedEmail\": \"user@exa****\"}}"
+                    )
+                }
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 사용자",
+                        value = "{\"success\": false, \"code\" : \"B011\", \"message\" : \"존재하지 않는 사용자입니다.\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<FindEmailResponseDto>> findEmailByContact(@Valid FindEmailRequestDto request);
+
+    @Operation(
+        summary = "비밀번호 재설정 세션 생성",
+        description = "이메일과 전화번호를 입력받아 사용자 유효성을 확인한 후, 비밀번호 재설정 세션을 생성합니다. 세션은 5분간 유효합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "비밀번호 재설정 세션 생성 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = CreatePasswordResetSessionResponseDto.class),
+                examples = {
+                    @ExampleObject(
+                        name = "성공 응답",
+                        value = "{\"success\": true, \"data\": {\"sessionId\": \"550e8400-e29b-41d4-a716-446655440000\"}}"
+                    )
+                }
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 사용자",
+                        value = "{\"success\": false, \"code\" : \"B011\", \"message\" : \"존재하지 않는 사용자입니다.\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<CreatePasswordResetSessionResponseDto>> createPasswordResetSession(@Valid CreatePasswordResetSessionRequestDto request);
+
+    @Operation(
+        summary = "비밀번호 재설정",
+        description = "비밀번호 재설정 세션 ID와 새로운 비밀번호를 입력받아 사용자의 비밀번호를 재설정합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "비밀번호 재설정 성공",
+            content = @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "성공 응답",
+                        value = "{\"success\": true, \"data\": null}"
+                    )
+                }
+            )
+        ),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "비밀번호 재설정 세션이 존재하지 않거나 만료됨",
+                        value = "{\"success\": false, \"code\" : \"A013\", \"message\" : \"비밀번호 재설정 세션이 존재하지 않거나 만료되었습니다.\"}"
+                    ),
+                    @ExampleObject(
+                        name = "존재하지 않는 사용자",
+                        value = "{\"success\": false, \"code\" : \"B011\", \"message\" : \"존재하지 않는 사용자입니다.\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> resetPassword(@Valid ResetPasswordRequestDto request);
+
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationRequestDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "휴대폰 번호 중복 확인 요청 DTO")
 public class CheckContactDuplicationRequestDto {
 
-    @Size(max = 11)
+    @Size(min = 10, max = 11)
     @Schema(description = "휴대폰 번호", example = "01012345678")
     private String contact;
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationRequestDto.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 @Schema(description = "휴대폰 번호 중복 확인 요청 DTO")
 public class CheckContactDuplicationRequestDto {
 
-    @Size(max = 13)
-    @Schema(description = "휴대폰 번호", example = "010-1234-5678")
+    @Size(max = 11)
+    @Schema(description = "휴대폰 번호", example = "01012345678")
     private String contact;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CheckContactDuplicationResponseDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Schema(description = "휴대폰 번호 중복 확인 응답 DTO")
 public class CheckContactDuplicationResponseDto {
 
-    @Schema(description = "휴대폰 번호", example = "010-1234-5678")
+    @Schema(description = "휴대폰 번호", example = "01012345678")
     private String contact;
 
     @Schema(description = "중복 여부", example = "true")

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionRequestDto.java
@@ -21,7 +21,7 @@ public class CreatePasswordResetSessionRequestDto {
     private String email;
 
     @NotBlank
-    @Size(max = 13)
+    @Size(min = 10, max = 11)
     @Schema(description = "전화번호", example = "01012345678")
     private String contact;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionRequestDto.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "비밀번호 재설정 세션 생성 요청 DTO")
+public class CreatePasswordResetSessionRequestDto {
+
+    @NotBlank
+    @Email
+    @Size(max = 255)
+    @Schema(description = "이메일", example = "user@example.com")
+    private String email;
+
+    @NotBlank
+    @Size(max = 13)
+    @Schema(description = "전화번호", example = "01012345678")
+    private String contact;
+}
+

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreatePasswordResetSessionResponseDto.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "비밀번호 재설정 세션 생성 응답 DTO")
+public class CreatePasswordResetSessionResponseDto {
+
+    @Schema(description = "비밀번호 재설정 세션 ID", example = "UUID")
+    private String sessionId;
+
+    public static CreatePasswordResetSessionResponseDto of(String sessionId) {
+        return new CreatePasswordResetSessionResponseDto(sessionId);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateSignupSessionRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateSignupSessionRequestDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class CreateSignupSessionRequestDto {
 
     @NotBlank
-    @Size(min = 13, max = 13)
-    @Schema(description = "휴대폰번호", example = "010-1234-5678")
+    @Size(min = 11, max = 11)
+    @Schema(description = "휴대폰번호", example = "01012345678")
     private String contact;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailRequestDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class FindEmailRequestDto {
 
     @NotBlank
-    @Size(max = 13)
+    @Size(min = 10, max = 11)
     @Schema(description = "전화번호 (하이픈 미포함)")
     private String contact;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailRequestDto.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "이메일 찾기 요청 DTO")
+public class FindEmailRequestDto {
+
+    @NotBlank
+    @Size(max = 13)
+    @Schema(description = "전화번호 (하이픈 미포함)")
+    private String contact;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailResponseDto.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "이메일 찾기 응답 DTO")
+public class FindEmailResponseDto {
+
+    @Schema(description = "마스킹된 이메일 (전체 길이의 절반 기준 후반부 마스킹)")
+    private String maskedEmail;
+
+    public static FindEmailResponseDto of(String maskedEmail) {
+        return new FindEmailResponseDto(maskedEmail);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/FindEmailResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Schema(description = "이메일 찾기 응답 DTO")
 public class FindEmailResponseDto {
 
-    @Schema(description = "마스킹된 이메일 (전체 길이의 절반 기준 후반부 마스킹)")
+    @Schema(description = "마스킹된 이메일 (로컬 파트(@ 앞부분)의 절반 기준 후반부 마스킹, 도메인은 마스킹하지 않음)")
     private String maskedEmail;
 
     public static FindEmailResponseDto of(String maskedEmail) {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/ResetPasswordRequestDto.java
@@ -1,0 +1,24 @@
+package com.dreamteam.alter.adapter.inbound.general.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "비밀번호 재설정 요청 DTO")
+public class ResetPasswordRequestDto {
+
+    @NotBlank
+    @Schema(description = "비밀번호 재설정 세션 ID", example = "UUID")
+    private String sessionId;
+
+    @NotBlank
+    @Size(min = 8, max = 100)
+    @Schema(description = "새 비밀번호", example = "newPassword123")
+    private String newPassword;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantDetailDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/PostingApplicationResponseApplicantDetailDto.java
@@ -30,7 +30,7 @@ public class PostingApplicationResponseApplicantDetailDto {
     private String email;
 
     @NotBlank
-    @Schema(description = "연락처", example = "010-1234-5678")
+    @Schema(description = "연락처", example = "01012345678")
     private String contact;
 
     @NotBlank

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceResponseDto.java
@@ -36,7 +36,7 @@ public class ManagerWorkspaceResponseDto {
     private String businessType;
 
     @NotBlank
-    @Schema(description = "연락처", example = "010-1234-5678")
+    @Schema(description = "연락처", example = "01012345678")
     private String contact;
 
     @NotBlank

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/WorkspaceWorkerResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/WorkspaceWorkerResponseDto.java
@@ -23,7 +23,7 @@ public class WorkspaceWorkerResponseDto {
     private String name;
 
     @NotBlank
-    @Schema(description = "근무자 연락처", example = "010-1234-5678")
+    @Schema(description = "근무자 연락처", example = "01012345678")
     private String contact;
 
     @NotNull

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserQueryRepositoryImpl.java
@@ -78,6 +78,21 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
     }
 
     @Override
+    public Optional<User> findByEmailAndContact(String email, String contact) {
+        QUser qUser = QUser.user;
+        User foundUser = queryFactory
+            .selectFrom(qUser)
+            .where(
+                qUser.email.eq(email),
+                qUser.contact.eq(contact),
+                qUser.status.eq(UserStatus.ACTIVE)
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(foundUser);
+    }
+
+    @Override
     public Optional<UserSelfInfoResponse> getUserSelfInfoSummary(Long id) {
         QUser qUser = QUser.user;
         QReputationSummary qReputationSummary = QReputationSummary.reputationSummary;

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreatePasswordResetSession.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreatePasswordResetSession.java
@@ -1,0 +1,71 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreatePasswordResetSessionRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreatePasswordResetSessionResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.CreatePasswordResetSessionUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service("createPasswordResetSession")
+@RequiredArgsConstructor
+@Transactional
+public class CreatePasswordResetSession implements CreatePasswordResetSessionUseCase {
+
+    private static final String SESSION_KEY_PREFIX = "PASSWORD_RESET:PENDING:";
+    private static final String USER_INDEX_KEY_PREFIX = "PASSWORD_RESET:USER:";
+    private static final long SESSION_EXPIRATION_MINUTES = 5; // 5분 후 만료
+
+    private final UserQueryRepository userQueryRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public CreatePasswordResetSessionResponseDto execute(CreatePasswordResetSessionRequestDto request) {
+        // 이메일과 전화번호로 사용자 확인
+        User user = userQueryRepository.findByEmailAndContact(request.getEmail(), request.getContact())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 기존 세션 확인 및 삭제
+        String userIndexKey = USER_INDEX_KEY_PREFIX + user.getId();
+        String existingSessionId = redisTemplate.opsForValue().get(userIndexKey);
+
+        if (ObjectUtils.isNotEmpty(existingSessionId)) {
+            // 기존 세션 키 삭제
+            String existingSessionKey = SESSION_KEY_PREFIX + existingSessionId;
+            redisTemplate.delete(existingSessionKey);
+            // 기존 인덱스 키 삭제
+            redisTemplate.delete(userIndexKey);
+        }
+
+        // 새 비밀번호 재설정 세션 생성
+        String sessionId = UUID.randomUUID().toString();
+        String sessionKey = SESSION_KEY_PREFIX + sessionId;
+
+        // 세션 키 저장: 세션 ID -> 사용자 ID (5분 후 만료)
+        redisTemplate.opsForValue().set(
+            sessionKey,
+            String.valueOf(user.getId()),
+            SESSION_EXPIRATION_MINUTES,
+            TimeUnit.MINUTES
+        );
+
+        // 인덱스 키 저장: 사용자 ID -> 세션 ID (5분 후 만료)
+        redisTemplate.opsForValue().set(
+            userIndexKey,
+            sessionId,
+            SESSION_EXPIRATION_MINUTES,
+            TimeUnit.MINUTES
+        );
+
+        return CreatePasswordResetSessionResponseDto.of(sessionId);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/FindEmailByContact.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/FindEmailByContact.java
@@ -1,0 +1,31 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.FindEmailRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.FindEmailResponseDto;
+import com.dreamteam.alter.common.util.MaskUtil;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.FindEmailByContactUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("findEmailByContact")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindEmailByContact implements FindEmailByContactUseCase {
+
+    private final UserQueryRepository userQueryRepository;
+
+    @Override
+    public FindEmailResponseDto execute(FindEmailRequestDto request) {
+        User user = userQueryRepository.findByContact(request.getContact())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String maskedEmail = MaskUtil.maskEmail(user.getEmail());
+
+        return FindEmailResponseDto.of(maskedEmail);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/ResetPassword.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/ResetPassword.java
@@ -1,0 +1,50 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.ResetPasswordRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.ResetPasswordUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("resetPassword")
+@RequiredArgsConstructor
+@Transactional
+public class ResetPassword implements ResetPasswordUseCase {
+
+    private static final String SESSION_KEY_PREFIX = "PASSWORD_RESET:PENDING:";
+    private static final String USER_INDEX_KEY_PREFIX = "PASSWORD_RESET:USER:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final UserQueryRepository userQueryRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void execute(ResetPasswordRequestDto request) {
+        // 세션 확인
+        String sessionKey = SESSION_KEY_PREFIX + request.getSessionId();
+        String userId = redisTemplate.opsForValue().get(sessionKey);
+
+        if (ObjectUtils.isEmpty(userId)) {
+            throw new CustomException(ErrorCode.PASSWORD_RESET_SESSION_NOT_EXIST);
+        }
+
+        // 사용자 조회
+        User user = userQueryRepository.findById(Long.parseLong(userId))
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 업데이트
+        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+
+        // 세션 키와 인덱스 키 모두 삭제
+        redisTemplate.delete(sessionKey);
+        String userIndexKey = USER_INDEX_KEY_PREFIX + userId;
+        redisTemplate.delete(userIndexKey);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     SOCIAL_AUTH_CODE_EXPIRED(400, "A010", "소셜 인가 코드가 만료되었습니다."),
     INVALID_LOGIN_INFO(400, "A011", "로그인 정보가 올바르지 않습니다."),
     SOCIAL_PROVIDER_ALREADY_LINKED(400, "A012", "이미 연동되어 있는 소셜 플랫폼입니다."),
+    PASSWORD_RESET_SESSION_NOT_EXIST(400, "A013", "비밀번호 재설정 세션이 존재하지 않거나 만료되었습니다."),
 
     ILLEGAL_ARGUMENT(400, "B001", "잘못된 요청입니다."),
     REFRESH_TOKEN_REQUIRED(400, "B002", "RefreshToken을 통해 요청해야 합니다."),

--- a/src/main/java/com/dreamteam/alter/common/util/MaskUtil.java
+++ b/src/main/java/com/dreamteam/alter/common/util/MaskUtil.java
@@ -1,0 +1,43 @@
+package com.dreamteam.alter.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * 마스킹 유틸리티 클래스
+ */
+public class MaskUtil {
+
+    private static final String MASK_CHAR = "*";
+
+    /**
+     * 이메일 주소를 마스킹 처리합니다.
+     *
+     * @param email 마스킹할 이메일 주소
+     * @return 마스킹된 이메일 주소
+     */
+    public static String maskEmail(String email) {
+        if (StringUtils.isBlank(email)) {
+            return email;
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex == -1) {
+            // @ 기호가 없으면 전체를 마스킹
+            return email;
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domain = email.substring(atIndex);
+
+        int localPartLength = localPart.length();
+        int halfLength = localPartLength / 2;
+        int maskStartIndex = localPartLength - halfLength;
+
+        StringBuilder maskedLocalPart = new StringBuilder(localPart);
+        for (int i = maskStartIndex; i < localPartLength; i++) {
+            maskedLocalPart.setCharAt(i, MASK_CHAR.charAt(0));
+        }
+
+        return maskedLocalPart.toString() + domain;
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -106,4 +106,13 @@ public class User {
     public void addUserSocial(UserSocial userSocial) {
         userSocials.add(userSocial);
     }
+
+    /**
+     * 비밀번호를 업데이트합니다.
+     *
+     * @param encodedPassword 암호화된 비밀번호
+     */
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/CreatePasswordResetSessionUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/CreatePasswordResetSessionUseCase.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreatePasswordResetSessionRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreatePasswordResetSessionResponseDto;
+
+public interface CreatePasswordResetSessionUseCase {
+    CreatePasswordResetSessionResponseDto execute(CreatePasswordResetSessionRequestDto request);
+}
+

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/FindEmailByContactUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/FindEmailByContactUseCase.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.FindEmailRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.FindEmailResponseDto;
+
+public interface FindEmailByContactUseCase {
+    FindEmailResponseDto execute(FindEmailRequestDto request);
+}
+

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/ResetPasswordUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/ResetPasswordUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.ResetPasswordRequestDto;
+
+public interface ResetPasswordUseCase {
+    void execute(ResetPasswordRequestDto request);
+}
+

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserQueryRepository.java
@@ -11,6 +11,7 @@ public interface UserQueryRepository {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByContact(String contact);
+    Optional<User> findByEmailAndContact(String email, String contact);
     Optional<UserSelfInfoResponse> getUserSelfInfoSummary(Long id);
     List<User> findAllById(List<Long> ids);
 }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/ResetPasswordTest.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/ResetPasswordTest.java
@@ -1,0 +1,138 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.ResetPasswordRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import com.dreamteam.alter.domain.user.type.UserGender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResetPassword 테스트")
+class ResetPasswordTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private UserQueryRepository userQueryRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private ResetPassword resetPassword;
+
+    @Test
+    @DisplayName("Redis에 세션이 없을 때 PASSWORD_RESET_SESSION_NOT_EXIST 예외 발생")
+    void execute_세션없음_예외발생() {
+        // given
+        ResetPasswordRequestDto request = new ResetPasswordRequestDto("session-id", "newPassword123");
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(null);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            resetPassword.execute(request);
+        });
+
+        assertEquals(ErrorCode.PASSWORD_RESET_SESSION_NOT_EXIST, exception.getErrorCode());
+        verify(redisTemplate, times(1)).opsForValue();
+        verify(userQueryRepository, never()).findById(any());
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("세션은 있으나 사용자가 없을 때 USER_NOT_FOUND 예외 발생")
+    void execute_사용자없음_예외발생() {
+        // given
+        ResetPasswordRequestDto request = new ResetPasswordRequestDto("session-id", "newPassword123");
+        String userId = "1";
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(userId);
+        when(userQueryRepository.findById(Long.parseLong(userId))).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            resetPassword.execute(request);
+        });
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        verify(redisTemplate, times(1)).opsForValue();
+        verify(userQueryRepository, times(1)).findById(Long.parseLong(userId));
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("정상적인 비밀번호 재설정 - 비밀번호 업데이트 및 Redis 키 삭제 확인")
+    void execute_정상적인비밀번호재설정() {
+        // given
+        String sessionId = "session-id";
+        String newPassword = "newPassword123";
+        String encodedPassword = "encodedPassword123";
+        String userId = "1";
+        Long userIdLong = Long.parseLong(userId);
+
+        ResetPasswordRequestDto request = new ResetPasswordRequestDto(sessionId, newPassword);
+        User user = User.create(
+            "test@example.com",
+            "01012345678",
+            "oldPassword",
+            "테스트",
+            "testuser",
+            UserGender.GENDER_MALE,
+            "19900101"
+        );
+
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        String sessionKey = "PASSWORD_RESET:PENDING:" + sessionId;
+        String userIndexKey = "PASSWORD_RESET:USER:" + userId;
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(sessionKey)).thenReturn(userId);
+        when(userQueryRepository.findById(userIdLong)).thenReturn(Optional.of(user));
+        when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
+
+        // when
+        resetPassword.execute(request);
+
+        // then
+        verify(redisTemplate, times(1)).opsForValue();
+        verify(valueOperations, times(1)).get(sessionKey);
+        verify(userQueryRepository, times(1)).findById(userIdLong);
+        verify(passwordEncoder, times(1)).encode(newPassword);
+        verify(redisTemplate, times(1)).delete(sessionKey);
+        verify(redisTemplate, times(1)).delete(userIndexKey);
+        assertEquals(encodedPassword, user.getPassword());
+    }
+}

--- a/src/test/java/com/dreamteam/alter/common/util/MaskUtilTest.java
+++ b/src/test/java/com/dreamteam/alter/common/util/MaskUtilTest.java
@@ -1,0 +1,128 @@
+package com.dreamteam.alter.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DisplayName("MaskUtil 테스트")
+class MaskUtilTest {
+
+    @Test
+    @DisplayName("null, 빈 문자열, 공백만 있는 경우 원본 반환")
+    void maskEmail_null_빈문자열_처리() {
+        // given & when & then
+        assertNull(MaskUtil.maskEmail(null));
+        assertEquals("", MaskUtil.maskEmail(""));
+        assertEquals("   ", MaskUtil.maskEmail("   "));
+    }
+
+    @Test
+    @DisplayName("@ 기호가 없는 이메일 형식의 경우 원본 반환")
+    void maskEmail_도메인이없는경우() {
+        // given
+        String email = "invalidemail";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("invalidemail", result);
+    }
+
+    @Test
+    @DisplayName("일반적인 이메일 주소의 로컬 파트 절반 마스킹")
+    void maskEmail_정상적인이메일마스킹() {
+        // given
+        String email = "testuser@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("test****@example.com", result);
+    }
+
+    @Test
+    @DisplayName("로컬 파트가 1자인 경우 마스킹 동작 확인")
+    void maskEmail_짧은로컬파트_1자() {
+        // given
+        String email = "a@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        // 1자일 경우 halfLength = 0, maskStartIndex = 1이므로 마스킹되지 않음
+        assertEquals("a@example.com", result);
+    }
+
+    @Test
+    @DisplayName("로컬 파트가 2자인 경우 마스킹 동작 확인")
+    void maskEmail_짧은로컬파트_2자() {
+        // given
+        String email = "ab@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("a*@example.com", result);
+    }
+
+    @Test
+    @DisplayName("로컬 파트가 긴 경우 마스킹 동작 확인")
+    void maskEmail_긴로컬파트() {
+        // given
+        String email = "verylongemailaddress@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        // 20자일 경우 halfLength = 10, maskStartIndex = 10이므로 인덱스 10부터 마스킹
+        assertEquals("verylongem**********@example.com", result);
+    }
+
+    @Test
+    @DisplayName("도메인 부분은 마스킹되지 않는지 확인")
+    void maskEmail_도메인은마스킹안됨() {
+        // given
+        String email = "testuser@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("test****@example.com", result);
+        // 도메인 부분이 그대로 유지되는지 확인
+        assert result.contains("@example.com");
+    }
+
+    @Test
+    @DisplayName("로컬 파트가 3자인 경우 마스킹 동작 확인")
+    void maskEmail_로컬파트_3자() {
+        // given
+        String email = "abc@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("ab*@example.com", result);
+    }
+
+    @Test
+    @DisplayName("로컬 파트가 4자인 경우 마스킹 동작 확인")
+    void maskEmail_로컬파트_4자() {
+        // given
+        String email = "abcd@example.com";
+
+        // when
+        String result = MaskUtil.maskEmail(email);
+
+        // then
+        assertEquals("ab**@example.com", result);
+    }
+}


### PR DESCRIPTION
## ID
- ALT-116

## 변경 내용
- 전화번호로 마스킹된 이메일을 조회하는 API 구현
- 이메일과 전화번호로 사용자 확인 후 비밀번호 재설정 세션 생성 API 구현
- 세션 ID와 새 비밀번호로 비밀번호 재설정 API 구현
- 전화번호 관리 정책 변경: 하이픈 없이 11자리 형식으로 통일

## 구현 사항

### 1. 이메일 찾기 기능
- 전화번호를 입력받아 해당 사용자의 마스킹된 이메일을 반환
- 이메일 마스킹: 로컬 파트(@ 앞부분)의 절반 기준 후반부 마스킹, 도메인은 마스킹하지 않음
- POST /public/users/find-email 엔드포인트 추가

### 2. 비밀번호 재설정 기능
- 이메일과 전화번호로 사용자 유효성 확인 후 세션 생성 (5분 만료)
- 세션 ID와 새 비밀번호로 비밀번호 재설정
- 사용자 ID 기준으로 세션 유일성 보장 (기존 세션 자동 삭제)
- POST /public/users/password-reset/session 엔드포인트 추가
- POST /public/users/password-reset 엔드포인트 추가

### 3. 전화번호 관리 정책 변경
- 서비스 정책 변경에 따라 전화번호를 하이픈 없이 관리하도록 수정
- 모든 DTO의 전화번호 예시 및 검증 규칙을 하이픈 없이 11자리로 변경
- users, workspaces 테이블의 기존 데이터 마이그레이션 필요 (하이픈 제거)

#### 영향받는 API 목록

**요청 스펙 변경:**
- `POST /public/users/signup-session` - 회원가입 세션 생성
  - `CreateSignupSessionRequestDto.contact`: `010-1234-5678` → `01012345678`
  - 검증 규칙: `@Size(min = 13, max = 13)` → `@Size(min = 10, max = 11)`
- `POST /public/users/exists/contact` - 전화번호 중복 확인
  - `CheckContactDuplicationRequestDto.contact`: `010-1234-5678` → `01012345678`
  - 검증 규칙: `@Size(max = 13)` → `@Size(min = 10, max = 11)`

**응답 스펙 변경:**
- `POST /public/users/exists/contact` - 전화번호 중복 확인
  - `CheckContactDuplicationResponseDto.contact`: `010-1234-5678` → `01012345678`
- `GET /manager/workspaces/{workspaceId}` - 업장 상세 조회
  - `ManagerWorkspaceResponseDto.contact`: `010-1234-5678` → `01012345678`
- `GET /manager/workspaces/{workspaceId}/workers` - 업장 근무자 목록 조회
  - `ManagerWorkspaceWorkerListResponseDto.user.contact`: `010-1234-5678` → `01012345678`
- `GET /manager/workspaces/{workspaceId}/managers` - 업장 매니저 목록 조회
  - `ManagerWorkspaceManagerListResponseDto.user.contact`: `010-1234-5678` → `01012345678`
- `GET /manager/postings/{postingId}/applications/{applicationId}` - 공고 지원 상세 조회
  - `PostingApplicationResponseDto.applicant.contact`: `010-1234-5678` → `01012345678`