### PR TITLE
feat: FCM 디바이스 토큰 관리 개선

### DIFF
--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -74,6 +74,12 @@ public class NotificationService {
         }
     }
 
+    public void removeUserDeviceToken(User user) {
+        Optional<FcmDeviceToken> deviceTokenOpt = userFCMDeviceTokenQueryRepository.findByUser(user);
+
+        deviceTokenOpt.ifPresent(userFCMDeviceTokenRepository::delete);
+    }
+
     public void sendNotification(FcmNotificationRequestDto request) {
         // 1. 사용자 조회
         User user = userQueryRepository.findById(request.getTargetUserId())

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -17,6 +17,7 @@ import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.SendResponse;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
@@ -40,29 +41,37 @@ public class NotificationService {
     private final UserFcmDeviceTokenQueryRepository userFCMDeviceTokenQueryRepository;
     private final NotificationRepository notificationRepository;
     private final UserQueryRepository userQueryRepository;
+    private final EntityManager entityManager;
 
     public void saveOrUpdateUserDeviceToken(User user, String deviceToken, DevicePlatformType devicePlatformType) {
         Optional<FcmDeviceToken> existingDeviceTokenByUser =
             userFCMDeviceTokenQueryRepository.findByUser(user);
-
-        if (existingDeviceTokenByUser.isPresent()) {
-            existingDeviceTokenByUser.get().updateDeviceToken(deviceToken, devicePlatformType);
-            return;
-        }
-
-        Optional<FcmDeviceToken> existingDeviceToken =
+        Optional<FcmDeviceToken> sameDeviceTokenEndpoint =
             userFCMDeviceTokenQueryRepository.findByDeviceToken(deviceToken);
 
-        if (existingDeviceToken.isPresent()) {
-            existingDeviceToken.get().updateUserAndDeviceToken(user, deviceToken, devicePlatformType);
+        // deviceToken이 동일한 기존 매핑이 존재하고, 해당 매핑이 현재 사용자와 다를 경우 기존 매핑을 제거
+        if (sameDeviceTokenEndpoint.isPresent() && !sameDeviceTokenEndpoint.get().getUser().equals(user)) {
+            userFCMDeviceTokenRepository.delete(sameDeviceTokenEndpoint.get());
+            entityManager.flush();
+        }
+
+        // userId에 매핑된 기존 엔드포인트가 없는 경우 새로 생성
+        if (existingDeviceTokenByUser.isEmpty()) {
+            userFCMDeviceTokenRepository.save(FcmDeviceToken.create(
+                user,
+                deviceToken,
+                devicePlatformType
+            ));
             return;
         }
 
-        userFCMDeviceTokenRepository.save(FcmDeviceToken.create(
-            user,
-            deviceToken,
-            devicePlatformType
-        ));
+        FcmDeviceToken userEndpoint = existingDeviceTokenByUser.get();
+        String oldDeviceToken = userEndpoint.getDeviceToken();
+
+        // 디바이스 토큰이 변경된 경우에만 업데이트 수행
+        if (!oldDeviceToken.equals(deviceToken) || !userEndpoint.getDevicePlatform().equals(devicePlatformType)) {
+            userEndpoint.updateDeviceToken(deviceToken, devicePlatformType);
+        }
     }
 
     public void sendNotification(FcmNotificationRequestDto request) {

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/LogoutUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/LogoutUser.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.application.user.usecase;
 
 import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.user.port.inbound.LogoutUserUseCase;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class LogoutUser implements LogoutUserUseCase {
 
     private final AuthService authService;
+    private final NotificationService notificationService;
 
     @Override
     public void execute(AppActor actor) {
         authService.revokeAllExistingAuthorizations(actor.getUser());
+        notificationService.removeUserDeviceToken(actor.getUser());
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/FcmDeviceToken.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/FcmDeviceToken.java
@@ -19,10 +19,10 @@ public class FcmDeviceToken {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @Column(name = "device_token", length = 500, nullable = false)
+    @Column(name = "device_token", length = 500, nullable = false, unique = true)
     private String deviceToken;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## ID
- ALT-127

## 변경 내용
- 로그아웃 시 사용자 디바이스 토큰 제거 기능 추가
- FCM 디바이스 토큰 등록/갱신 로직 개선 (유일성 보장, 동시성 문제 방지)

## 구현 사항

### 1. 로그아웃 시 디바이스 토큰 제거 기능 추가
- `NotificationService.removeUserDeviceToken()` 메소드 추가
- `LogoutUser` UseCase에서 로그아웃 시 디바이스 토큰 제거 호출
- 로그아웃 후 해당 사용자에게 알림이 전송되지 않도록 처리

### 2. 디바이스 토큰 등록/갱신 로직 개선
- **유일성 보장**: 디바이스 토큰이 다른 사용자에게 매핑되어 있는 경우, 기존 매핑을 삭제하고 신규 사용자로 갱신
- **동시성 문제 방지**: `EntityManager.flush()`를 사용하여 삭제 작업을 즉시 DB에 반영하여 동시 요청 시 발생할 수 있는 충돌 방지
- **불필요한 업데이트 방지**: 동일한 디바이스 토큰을 재등록하는 경우 업데이트하지 않도록 개선