### PR TITLE
feat: 금일 스케줄 목록 조회 API

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleController.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.AssignWorkerRequ
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.CreateWorkScheduleRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerWorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.UpdateWorkScheduleRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.UpdateWorkerRequestDto;
 import com.dreamteam.alter.application.aop.ManagerActionContext;
@@ -48,6 +49,9 @@ public class ManagerScheduleController implements ManagerScheduleControllerSpec 
     @Resource(name = "managerRemoveWorkerFromSchedule")
     private final ManagerRemoveWorkerUseCase managerRemoveWorker;
 
+    @Resource(name = "managerGetTodayWorkScheduleList")
+    private final ManagerGetDailyScheduleListUseCase managerGetTodayScheduleList;
+
     @Override
     @PostMapping
     public ResponseEntity<CommonApiResponse<Void>> createSchedule(
@@ -66,6 +70,15 @@ public class ManagerScheduleController implements ManagerScheduleControllerSpec 
         ManagerActor actor = ManagerActionContext.getInstance().getActor();
 
         return ResponseEntity.ok(CommonApiResponse.of(managerGetScheduleList.execute(actor, request.getWorkspaceId(), request.getYear(), request.getMonth())));
+    }
+
+    @Override
+    @GetMapping("/today")
+    public ResponseEntity<CommonApiResponse<List<ManagerTodayScheduleResponseDto>>> getTodayScheduleList(
+        @RequestParam Long workspaceId
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        return ResponseEntity.ok(CommonApiResponse.of(managerGetTodayScheduleList.execute(actor, workspaceId)));
     }
 
     @Override

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
@@ -54,7 +54,8 @@ public interface ManagerScheduleControllerSpec {
 
     @Operation(summary = "금일 스케줄 목록 조회", description = "특정 워크스페이스의 오늘 날짜 스케줄 목록을 조회합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "금일 스케줄 목록 조회 성공")
+        @ApiResponse(responseCode = "200", description = "금일 스케줄 목록 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "해당 워크스페이스 찾을 수 없음")
     })
     ResponseEntity<CommonApiResponse<List<ManagerTodayScheduleResponseDto>>> getTodayScheduleList(
         @Parameter(description = "워크스페이스 ID", example = "1", required = true)

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
 import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.AssignWorkerRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.CreateWorkScheduleRequestDto;
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerWorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.UpdateWorkScheduleRequestDto;
@@ -49,6 +50,15 @@ public interface ManagerScheduleControllerSpec {
     })
     ResponseEntity<CommonApiResponse<List<ManagerScheduleResponseDto>>> getScheduleList(
         ManagerWorkScheduleInquiryRequestDto request
+    );
+
+    @Operation(summary = "금일 스케줄 목록 조회", description = "특정 워크스페이스의 오늘 날짜 스케줄 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "금일 스케줄 목록 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<List<ManagerTodayScheduleResponseDto>>> getTodayScheduleList(
+        @Parameter(description = "워크스페이스 ID", example = "1", required = true)
+        @RequestParam Long workspaceId
     );
 
     @Operation(summary = "스케줄 수정", description = "기존 스케줄의 정보를 수정합니다.")

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
@@ -1,20 +1,23 @@
 package com.dreamteam.alter.adapter.inbound.manager.schedule.dto;
 
-import com.dreamteam.alter.domain.workspace.model.WorkspaceShiftTodayResponse;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import java.time.LocalDateTime;
+import com.dreamteam.alter.domain.workspace.model.WorkspaceShiftTodayResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@Schema(description = "매니저 금일 스케줄 응답")
+@Schema(description = "매니저 금일 근무자 응답")
 public class ManagerTodayScheduleResponseDto {
-
-    @Schema(description = "스케줄 ID", example = "1")
-    private Long shiftId;
 
     @Schema(description = "근무자 ID", example = "1")
     private Long workerId;
@@ -25,19 +28,27 @@ public class ManagerTodayScheduleResponseDto {
     @Schema(description = "근무자 프로필 이미지 S3 URL")
     private String profileImageUrl;
 
-    @Schema(description = "근무 시작 시간", example = "2024-01-15T09:00:00")
-    private LocalDateTime startDateTime;
+    @Schema(description = "금일 근무 목록")
+    private List<ManagerTodayScheduleShiftItem> shifts;
 
-    @Schema(description = "근무 종료 시간", example = "2024-01-15T18:00:00")
-    private LocalDateTime endDateTime;
-
-    public static ManagerTodayScheduleResponseDto of(WorkspaceShiftTodayResponse entity) {
-        return ManagerTodayScheduleResponseDto.builder()
-            .shiftId(entity.shiftId())
-            .workerName(entity.workerName())
-            .profileImageUrl(entity.profileImageUrl())
-            .startDateTime(entity.startDateTime())
-            .endDateTime(entity.endDateTime())
-            .build();
+    public static List<ManagerTodayScheduleResponseDto> from(List<WorkspaceShiftTodayResponse> responses) {
+        return responses.stream()
+            .collect(Collectors.groupingBy(WorkspaceShiftTodayResponse::workerId))
+            .values()
+            .stream()
+            .map(group -> {
+                WorkspaceShiftTodayResponse first = group.getFirst();
+                return ManagerTodayScheduleResponseDto.builder()
+                    .workerId(first.workerId())
+                    .workerName(first.workerName())
+                    .profileImageUrl(first.profileImageUrl())
+                    .shifts(
+                        group.stream()
+                            .map(r -> ManagerTodayScheduleShiftItem.of(r.shiftId(), r.startDateTime(), r.endDateTime()))
+                            .toList()
+                    )
+                    .build();
+            })
+            .toList();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
@@ -1,0 +1,40 @@
+package com.dreamteam.alter.adapter.inbound.manager.schedule.dto;
+
+import com.dreamteam.alter.domain.workspace.model.WorkspaceShiftTodayResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "매니저 금일 스케줄 응답")
+public class ManagerTodayScheduleResponseDto {
+
+    @Schema(description = "스케줄 ID", example = "1")
+    private Long shiftId;
+
+    @Schema(description = "근무자 이름", example = "홍길동")
+    private String workerName;
+
+    @Schema(description = "근무자 프로필 이미지 S3 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "근무 시작 시간", example = "2024-01-15T09:00:00")
+    private LocalDateTime startDateTime;
+
+    @Schema(description = "근무 종료 시간", example = "2024-01-15T18:00:00")
+    private LocalDateTime endDateTime;
+
+    public static ManagerTodayScheduleResponseDto of(WorkspaceShiftTodayResponse entity) {
+        return ManagerTodayScheduleResponseDto.builder()
+            .shiftId(entity.shiftId())
+            .workerName(entity.workerName())
+            .profileImageUrl(entity.profileImageUrl())
+            .startDateTime(entity.startDateTime())
+            .endDateTime(entity.endDateTime())
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleResponseDto.java
@@ -16,6 +16,9 @@ public class ManagerTodayScheduleResponseDto {
     @Schema(description = "스케줄 ID", example = "1")
     private Long shiftId;
 
+    @Schema(description = "근무자 ID", example = "1")
+    private Long workerId;
+
     @Schema(description = "근무자 이름", example = "홍길동")
     private String workerName;
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleShiftItem.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerTodayScheduleShiftItem.java
@@ -1,0 +1,35 @@
+package com.dreamteam.alter.adapter.inbound.manager.schedule.dto;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "근무 항목")
+public class ManagerTodayScheduleShiftItem {
+
+	@Schema(description = "스케줄 ID", example = "1")
+	private Long shiftId;
+
+	@Schema(description = "근무 시작 시간", example = "2024-01-15T09:00:00")
+	private LocalDateTime startDateTime;
+
+	@Schema(description = "근무 종료 시간", example = "2024-01-15T18:00:00")
+	private LocalDateTime endDateTime;
+
+	public static ManagerTodayScheduleShiftItem of(Long shiftId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		return ManagerTodayScheduleShiftItem.builder()
+			.shiftId(shiftId)
+			.startDateTime(startDateTime)
+			.endDateTime(endDateTime)
+			.build();
+	}
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -1,12 +1,16 @@
 package com.dreamteam.alter.adapter.outbound.workspace.persistence;
 
+import com.dreamteam.alter.domain.file.type.FileStatus;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
+import com.dreamteam.alter.domain.workspace.model.WorkspaceShiftTodayResponse;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceShiftStatus;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,13 +20,46 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.dreamteam.alter.domain.file.entity.QFile.file;
+import static com.dreamteam.alter.domain.user.entity.QUser.user;
 import static com.dreamteam.alter.domain.workspace.entity.QWorkspaceShift.workspaceShift;
+import static com.dreamteam.alter.domain.workspace.entity.QWorkspaceWorker.workspaceWorker;
 
 @Repository
 @RequiredArgsConstructor
 public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<WorkspaceShiftTodayResponse> getTodayShiftList(
+        Long workspaceId
+    ) {
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        return queryFactory
+            .select(Projections.constructor(WorkspaceShiftTodayResponse.class,
+                workspaceShift.id,
+                user.name,
+                file.fileUrl,
+                workspaceShift.startDateTime,
+                workspaceShift.endDateTime
+            ))
+            .from(workspaceShift)
+            .leftJoin(workspaceShift.assignedWorkspaceWorker, workspaceWorker)
+            .leftJoin(workspaceWorker.user, user)
+            .leftJoin(file).on(
+                file.targetType.eq(FileTargetType.USER_PROFILE)
+                    .and(file.targetId.eq(user.id.stringValue()))
+                    .and(file.status.eq(FileStatus.ATTACHED))
+            )
+            .where(workspaceShift.workspace.id.eq(workspaceId)
+                .and(workspaceShift.startDateTime.goe(startOfDay))
+                .and(workspaceShift.startDateTime.lt(endOfDay))
+                .and(workspaceShift.status.ne(WorkspaceShiftStatus.DELETED)))
+            .orderBy(workspaceShift.startDateTime.asc())
+            .fetch();
+    }
 
     @Override
     public List<WorkspaceShift> findByUserAndDateRange(User user, int year, int month) {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -57,6 +57,7 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
                 .and(workspaceShift.startDateTime.goe(startOfDay))
                 .and(workspaceShift.startDateTime.lt(endOfDay))
                 .and(workspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)))
+            .groupBy(user.id)
             .orderBy(workspaceShift.startDateTime.asc())
             .fetch();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -40,6 +40,7 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
         return queryFactory
             .select(Projections.constructor(WorkspaceShiftTodayResponse.class,
                 workspaceShift.id,
+                workspaceWorker.id,
                 user.name,
                 file.fileUrl,
                 workspaceShift.startDateTime,
@@ -57,7 +58,6 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
                 .and(workspaceShift.startDateTime.goe(startOfDay))
                 .and(workspaceShift.startDateTime.lt(endOfDay))
                 .and(workspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)))
-            .groupBy(user.id)
             .orderBy(workspaceShift.startDateTime.asc())
             .fetch();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -56,7 +56,7 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
             .where(workspaceShift.workspace.id.eq(workspaceId)
                 .and(workspaceShift.startDateTime.goe(startOfDay))
                 .and(workspaceShift.startDateTime.lt(endOfDay))
-                .and(workspaceShift.status.ne(WorkspaceShiftStatus.DELETED)))
+                .and(workspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)))
             .orderBy(workspaceShift.startDateTime.asc())
             .fetch();
     }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
@@ -1,0 +1,43 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetDailyScheduleListUseCase;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service("managerGetTodayWorkScheduleList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerGetDailyWorkScheduleList implements ManagerGetDailyScheduleListUseCase {
+
+    private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+    private final WorkspaceQueryRepository workspaceQueryRepository;
+
+    @Override
+    public List<ManagerTodayScheduleResponseDto> execute(ManagerActor actor, Long workspaceId) {
+        Optional<Workspace> workspace = workspaceQueryRepository.findById(workspaceId);
+        if (workspace.isEmpty()) {
+            throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
+        if (!workspace.get().getManagerUser().equals(actor.getManagerUser())) {
+            throw new CustomException(ErrorCode.FORBIDDEN, "관리 중인 업장이 아닙니다.");
+        }
+
+        return workspaceShiftQueryRepository.getTodayShiftList(workspaceId).stream()
+            .map(ManagerTodayScheduleResponseDto::of)
+            .toList();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
@@ -29,8 +29,6 @@ public class ManagerGetDailyWorkScheduleList implements ManagerGetDailyScheduleL
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        return workspaceShiftQueryRepository.getTodayShiftList(workspaceId).stream()
-            .map(ManagerTodayScheduleResponseDto::of)
-            .toList();
+        return ManagerTodayScheduleResponseDto.from(workspaceShiftQueryRepository.getTodayShiftList(workspaceId));
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetDailyWorkScheduleList.java
@@ -1,7 +1,6 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +9,6 @@ import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodaySche
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
-import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetDailyScheduleListUseCase;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
@@ -27,13 +25,8 @@ public class ManagerGetDailyWorkScheduleList implements ManagerGetDailyScheduleL
 
     @Override
     public List<ManagerTodayScheduleResponseDto> execute(ManagerActor actor, Long workspaceId) {
-        Optional<Workspace> workspace = workspaceQueryRepository.findById(workspaceId);
-        if (workspace.isEmpty()) {
+        if (!workspaceQueryRepository.existsByIdAndManagerUser(workspaceId, actor.getManagerUser())) {
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
-        }
-
-        if (!workspace.get().getManagerUser().equals(actor.getManagerUser())) {
-            throw new CustomException(ErrorCode.FORBIDDEN, "관리 중인 업장이 아닙니다.");
         }
 
         return workspaceShiftQueryRepository.getTodayShiftList(workspaceId).stream()

--- a/src/main/java/com/dreamteam/alter/domain/workspace/model/WorkspaceShiftTodayResponse.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/model/WorkspaceShiftTodayResponse.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.workspace.model;
+
+import java.time.LocalDateTime;
+
+public record WorkspaceShiftTodayResponse(
+    Long shiftId,
+    String workerName,
+    String profileImageUrl,
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime
+) {}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/model/WorkspaceShiftTodayResponse.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/model/WorkspaceShiftTodayResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record WorkspaceShiftTodayResponse(
     Long shiftId,
+	Long workerId,
     String workerName,
     String profileImageUrl,
     LocalDateTime startDateTime,

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerGetDailyScheduleListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerGetDailyScheduleListUseCase.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+import java.util.List;
+
+public interface ManagerGetDailyScheduleListUseCase {
+    List<ManagerTodayScheduleResponseDto> execute(ManagerActor actor, Long workspaceId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.domain.user.entity.ManagerUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
+import com.dreamteam.alter.domain.workspace.model.WorkspaceShiftTodayResponse;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface WorkspaceShiftQueryRepository {
+    List<WorkspaceShiftTodayResponse> getTodayShiftList(Long workspaceId);
+
     List<WorkspaceShift> findByUserAndDateRange(User user, int year, int month);
     List<WorkspaceShift> findByUserAndWeeklyRange(User user, LocalDate startDate, LocalDate endDate);
     List<WorkspaceShift> findByUserAndDate(User user, int year, int month, int day);


### PR DESCRIPTION
## 관련 문서
[https://www.notion.so/BE-API-343865531628803f98c2e3afff674af2?v=2b186553162880979f62000c6c946512&source=copy_link](https://www.notion.so/BE-API-343865531628803f98c2e3afff674af2?v=2b186553162880979f62000c6c946512&source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자를 위한 "오늘" 일정 조회 API 추가
  * 응답에 근무(교대) ID, 직원 이름, 프로필 이미지 URL, 시작/종료 시각 포함
  * 요청 시 워크스페이스 존재 검증을 수행하며, 미존재 시 적절한 오류(404) 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->