### PR TITLE
feat: [ALT-200] 월별 스케줄 조회 시 예상 급여/인건비 응답 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleController.java
@@ -12,8 +12,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @PreAuthorize("hasAnyRole('USER')")
 @RequiredArgsConstructor
@@ -39,7 +37,7 @@ public class UserScheduleController implements UserScheduleControllerSpec {
 
     @Override
     @GetMapping("/workspaces/{workspaceId}")
-    public ResponseEntity<CommonApiResponse<List<WorkspaceScheduleResponseDto>>> getWorkspaceSchedule(
+    public ResponseEntity<CommonApiResponse<GetWorkspaceScheduleResponseDto>> getWorkspaceSchedule(
         @PathVariable Long workspaceId,
         WorkScheduleInquiryRequestDto request
     ) {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/controller/UserScheduleControllerSpec.java
@@ -14,14 +14,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.util.List;
-
 @Tag(name = "APP - 근무 스케줄 관리 API")
 public interface UserScheduleControllerSpec {
 
     @Operation(summary = "나의 근무 스케줄 조회", description = "파라미터 조합에 따라 조회가 달라집니다. <br>"+
                                                            "- 인자 없음: 이번 주 스케줄 조회<br>" +
-                                                           "- year, month: 해당 월 스케줄 조회<br>" +
+                                                           "- year, month: 해당 월 스케줄 조회 (예상 급여 포함)<br>" +
                                                            "- year, month, day: 해당 일 스케줄 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "스케줄 조회 성공")
@@ -30,7 +28,7 @@ public interface UserScheduleControllerSpec {
         WorkScheduleInquiryRequestDto request
     );
 
-    @Operation(summary = "업장별 근무 스케줄 조회", description = "year, month 값을 모두 포함해야합니다.")
+    @Operation(summary = "업장별 근무 스케줄 조회", description = "year, month 값을 모두 포함해야합니다. 응답에는 나의 총 근무 시간과 예상 급여가 포함됩니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "스케줄 조회 성공"),
         @ApiResponse(responseCode = "400", description = "실패 케이스",
@@ -44,7 +42,7 @@ public interface UserScheduleControllerSpec {
                     )
                 }))
     })
-    ResponseEntity<CommonApiResponse<List<WorkspaceScheduleResponseDto>>> getWorkspaceSchedule(
+    ResponseEntity<CommonApiResponse<GetWorkspaceScheduleResponseDto>> getWorkspaceSchedule(
         @Parameter(description = "업장 ID", example = "1", required = true)
         @PathVariable Long workspaceId,
         WorkScheduleInquiryRequestDto request

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/GetWorkspaceScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/GetWorkspaceScheduleResponseDto.java
@@ -13,25 +13,25 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@Schema(description = "스케줄 조회 통합 응답")
-public class GetMyScheduleResponseDto {
+@Schema(description = "업장 스케줄 조회 통합 응답")
+public class GetWorkspaceScheduleResponseDto {
 
-    @Schema(description = "총 근무 시간", example = "40.5")
+    @Schema(description = "나의 총 근무 시간", example = "20.0")
     private double totalWorkHours;
 
-    @Schema(description = "예상 급여 (최저시급 기준, 월별 조회 시에만 제공)", example = "412800")
+    @Schema(description = "나의 예상 급여 (최저시급 기준)", example = "206400")
     private Long estimatedSalary;
 
-    @Schema(description = "스케줄 목록")
-    private List<MyScheduleResponseDto> schedules;
+    @Schema(description = "업장 전체 스케줄 목록")
+    private List<WorkspaceScheduleResponseDto> schedules;
 
-    public static GetMyScheduleResponseDto of(
-        double totalWorkHours,
+    public static GetWorkspaceScheduleResponseDto of(
+        double myTotalWorkHours,
         Long estimatedSalary,
-        List<MyScheduleResponseDto> schedules
+        List<WorkspaceScheduleResponseDto> schedules
     ) {
-        return GetMyScheduleResponseDto.builder()
-            .totalWorkHours(totalWorkHours)
+        return GetWorkspaceScheduleResponseDto.builder()
+            .totalWorkHours(myTotalWorkHours)
             .estimatedSalary(estimatedSalary)
             .schedules(schedules)
             .build();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleController.java
@@ -3,6 +3,7 @@ package com.dreamteam.alter.adapter.inbound.manager.schedule.controller;
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.AssignWorkerRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.CreateWorkScheduleRequestDto;
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.GetManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerWorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
@@ -64,7 +65,7 @@ public class ManagerScheduleController implements ManagerScheduleControllerSpec 
 
     @Override
     @GetMapping
-    public ResponseEntity<CommonApiResponse<List<ManagerScheduleResponseDto>>> getScheduleList(
+    public ResponseEntity<CommonApiResponse<GetManagerScheduleResponseDto>> getScheduleList(
         ManagerWorkScheduleInquiryRequestDto request
     ) {
         ManagerActor actor = ManagerActionContext.getInstance().getActor();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/controller/ManagerScheduleControllerSpec.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
 import com.dreamteam.alter.adapter.inbound.common.dto.ErrorResponse;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.AssignWorkerRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.CreateWorkScheduleRequestDto;
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.GetManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerTodayScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerWorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
@@ -44,11 +45,11 @@ public interface ManagerScheduleControllerSpec {
         @Valid @RequestBody CreateWorkScheduleRequestDto request
     );
 
-    @Operation(summary = "스케줄 목록 조회", description = "특정 워크스페이스의 월별 스케줄 목록을 조회합니다.")
+    @Operation(summary = "스케줄 목록 조회", description = "특정 워크스페이스의 월별 스케줄 목록을 조회합니다. 응답에는 전체 근무자의 총 근무 시간과 예상 인건비가 포함됩니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "스케줄 목록 조회 성공")
     })
-    ResponseEntity<CommonApiResponse<List<ManagerScheduleResponseDto>>> getScheduleList(
+    ResponseEntity<CommonApiResponse<GetManagerScheduleResponseDto>> getScheduleList(
         ManagerWorkScheduleInquiryRequestDto request
     );
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/GetManagerScheduleResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/GetManagerScheduleResponseDto.java
@@ -1,0 +1,39 @@
+package com.dreamteam.alter.adapter.inbound.manager.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "매니저 스케줄 목록 조회 통합 응답")
+public class GetManagerScheduleResponseDto {
+
+    @Schema(description = "전체 근무자 총 근무 시간", example = "80.0")
+    private double totalWorkHours;
+
+    @Schema(description = "예상 인건비 (최저시급 기준)", example = "825600")
+    private Long estimatedLaborCost;
+
+    @Schema(description = "스케줄 목록")
+    private List<ManagerScheduleResponseDto> schedules;
+
+    public static GetManagerScheduleResponseDto of(
+        double totalWorkHours,
+        Long estimatedLaborCost,
+        List<ManagerScheduleResponseDto> schedules
+    ) {
+        return GetManagerScheduleResponseDto.builder()
+            .totalWorkHours(totalWorkHours)
+            .estimatedLaborCost(estimatedLaborCost)
+            .schedules(schedules)
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class GetMySchedule implements GetMyScheduleUseCase {
 
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+    private static final int MINIMUM_HOURLY_WAGE = 10_320;
 
     @Override
     public GetMyScheduleResponseDto execute(AppActor actor, WorkScheduleInquiryRequestDto request) {
@@ -66,16 +67,19 @@ public class GetMySchedule implements GetMyScheduleUseCase {
         }
 
         double totalWorkHours = shifts.stream()
-                .mapToDouble(shift -> {
-                    Duration duration = Duration.between(shift.getStartDateTime(), shift.getEndDateTime());
-                    return duration.toMinutes() / 60.0;
-                })
-                .sum();
+            .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime())
+                .toMinutes() / 60.0)
+            .sum();
+
+        boolean isMonthlyQuery = ObjectUtils.isNotEmpty(request.getYear())
+            && ObjectUtils.isNotEmpty(request.getMonth())
+            && ObjectUtils.isEmpty(request.getDay());
+        Long estimatedSalary = isMonthlyQuery ? Math.round(totalWorkHours * MINIMUM_HOURLY_WAGE) : null;
 
         List<MyScheduleResponseDto> scheduleDtos = shifts.stream()
-                .map(MyScheduleResponseDto::of)
-                .toList();
+            .map(MyScheduleResponseDto::of)
+            .toList();
 
-        return GetMyScheduleResponseDto.of(totalWorkHours, scheduleDtos);
+        return GetMyScheduleResponseDto.of(totalWorkHours, estimatedSalary, scheduleDtos);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
@@ -3,6 +3,7 @@ package com.dreamteam.alter.application.workspace.usecase;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.GetMyScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.MyScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
+import com.dreamteam.alter.common.constants.WorkspaceConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.AppActor;
@@ -27,7 +28,6 @@ import java.util.List;
 public class GetMySchedule implements GetMyScheduleUseCase {
 
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
-    private static final int MINIMUM_HOURLY_WAGE = 10_320;
 
     @Override
     public GetMyScheduleResponseDto execute(AppActor actor, WorkScheduleInquiryRequestDto request) {
@@ -76,7 +76,7 @@ public class GetMySchedule implements GetMyScheduleUseCase {
         boolean isMonthlyQuery = ObjectUtils.isNotEmpty(request.getYear())
             && ObjectUtils.isNotEmpty(request.getMonth())
             && ObjectUtils.isEmpty(request.getDay());
-        Long estimatedSalary = isMonthlyQuery ? Math.round(totalWorkHours * MINIMUM_HOURLY_WAGE) : null;
+        Long estimatedSalary = isMonthlyQuery ? Math.round(totalWorkHours * WorkspaceConstants.MINIMUM_HOURLY_WAGE) : null;
 
         List<MyScheduleResponseDto> scheduleDtos = shifts.stream()
             .map(MyScheduleResponseDto::of)

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetMySchedule.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 import com.dreamteam.alter.domain.workspace.port.inbound.GetMyScheduleUseCase;
+import com.dreamteam.alter.domain.workspace.type.WorkspaceShiftStatus;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
@@ -67,6 +68,7 @@ public class GetMySchedule implements GetMyScheduleUseCase {
         }
 
         double totalWorkHours = shifts.stream()
+            .filter(shift -> shift.getStatus() != WorkspaceShiftStatus.CANCELLED)
             .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime())
                 .toMinutes() / 60.0)
             .sum();

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.GetWorkspaceScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkspaceScheduleResponseDto;
 import com.dreamteam.alter.common.exception.CustomException;
@@ -17,6 +18,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,9 +30,10 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
     private final WorkspaceQueryRepository workspaceQueryRepository;
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
     private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+    private static final int MINIMUM_HOURLY_WAGE = 10_320;
 
     @Override
-    public List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request) {
+    public GetWorkspaceScheduleResponseDto execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request) {
         if (ObjectUtils.isEmpty(request.getYear()) || ObjectUtils.isEmpty(request.getMonth())) {
             throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "근무일정 조회 시 연도, 월 파라미터는 필수입니다.");
         }
@@ -41,16 +44,25 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
 
         Optional<WorkspaceWorker> workspaceWorker = workspaceWorkerQueryRepository
             .findActiveWorkerByWorkspaceAndUser(workspace, actor.getUser());
-        
+
         if (workspaceWorker.isEmpty()) {
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
         List<WorkspaceShift> shifts = workspaceShiftQueryRepository
             .findByWorkspaceAndDateRange(workspaceWorker.get().getWorkspace(), request.getYear(), request.getMonth());
-        
-        return shifts.stream()
+
+        // 본인에게 배정된 근무 일정들의 근무 시간 합산 및 예상 급여 계산
+        double myTotalWorkHours = shifts.stream()
+            .filter(shift -> workspaceWorker.get().equals(shift.getAssignedWorkspaceWorker()))
+            .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime()).toMinutes() / 60.0)
+            .sum();
+        long estimatedSalary = Math.round(myTotalWorkHours * MINIMUM_HOURLY_WAGE);
+
+        List<WorkspaceScheduleResponseDto> scheduleDtos = shifts.stream()
             .map(WorkspaceScheduleResponseDto::of)
             .toList();
+
+        return GetWorkspaceScheduleResponseDto.of(myTotalWorkHours, estimatedSalary, scheduleDtos);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/GetWorkspaceWorkSchedule.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
+import com.dreamteam.alter.common.constants.WorkspaceConstants;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.GetWorkspaceScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkspaceScheduleResponseDto;
@@ -30,8 +31,6 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
     private final WorkspaceQueryRepository workspaceQueryRepository;
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
     private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
-    private static final int MINIMUM_HOURLY_WAGE = 10_320;
-
     @Override
     public GetWorkspaceScheduleResponseDto execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request) {
         if (ObjectUtils.isEmpty(request.getYear()) || ObjectUtils.isEmpty(request.getMonth())) {
@@ -57,7 +56,7 @@ public class GetWorkspaceWorkSchedule implements GetWorkspaceScheduleUseCase {
             .filter(shift -> workspaceWorker.get().equals(shift.getAssignedWorkspaceWorker()))
             .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime()).toMinutes() / 60.0)
             .sum();
-        long estimatedSalary = Math.round(myTotalWorkHours * MINIMUM_HOURLY_WAGE);
+        long estimatedSalary = Math.round(myTotalWorkHours * WorkspaceConstants.MINIMUM_HOURLY_WAGE);
 
         List<WorkspaceScheduleResponseDto> scheduleDtos = shifts.stream()
             .map(WorkspaceScheduleResponseDto::of)

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.GetManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,9 +25,10 @@ public class ManagerGetWorkScheduleList implements ManagerGetScheduleListUseCase
 
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
     private final WorkspaceQueryRepository workspaceQueryRepository;
+    private static final int MINIMUM_HOURLY_WAGE = 10_320;
 
     @Override
-    public List<ManagerScheduleResponseDto> execute(ManagerActor actor, Long workspaceId, int year, int month) {
+    public GetManagerScheduleResponseDto execute(ManagerActor actor, Long workspaceId, int year, int month) {
         // 워크스페이스 존재 확인
         Optional<Workspace> workspace = workspaceQueryRepository.findById(workspaceId);
         if (workspace.isEmpty()) {
@@ -39,9 +42,16 @@ public class ManagerGetWorkScheduleList implements ManagerGetScheduleListUseCase
 
         List<WorkspaceShift> shifts = workspaceShiftQueryRepository
             .findByManagerAndDateRange(actor.getManagerUser(), workspaceId, year, month);
-        
-        return shifts.stream()
+
+        double totalWorkHours = shifts.stream()
+            .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime()).toMinutes() / 60.0)
+            .sum();
+        long estimatedLaborCost = Math.round(totalWorkHours * MINIMUM_HOURLY_WAGE);
+
+        List<ManagerScheduleResponseDto> scheduleDtos = shifts.stream()
             .map(ManagerScheduleResponseDto::of)
             .toList();
+
+        return GetManagerScheduleResponseDto.of(totalWorkHours, estimatedLaborCost, scheduleDtos);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetScheduleListUseCase;
+import com.dreamteam.alter.domain.workspace.type.WorkspaceShiftStatus;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +45,7 @@ public class ManagerGetWorkScheduleList implements ManagerGetScheduleListUseCase
             .findByManagerAndDateRange(actor.getManagerUser(), workspaceId, year, month);
 
         double totalWorkHours = shifts.stream()
+            .filter(shift -> shift.getStatus() != WorkspaceShiftStatus.CANCELLED)
             .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime()).toMinutes() / 60.0)
             .sum();
         long estimatedLaborCost = Math.round(totalWorkHours * MINIMUM_HOURLY_WAGE);

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerGetWorkScheduleList.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.application.workspace.usecase;
 
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.GetManagerScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
+import com.dreamteam.alter.common.constants.WorkspaceConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
@@ -26,8 +27,6 @@ public class ManagerGetWorkScheduleList implements ManagerGetScheduleListUseCase
 
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
     private final WorkspaceQueryRepository workspaceQueryRepository;
-    private static final int MINIMUM_HOURLY_WAGE = 10_320;
-
     @Override
     public GetManagerScheduleResponseDto execute(ManagerActor actor, Long workspaceId, int year, int month) {
         // 워크스페이스 존재 확인
@@ -48,7 +47,7 @@ public class ManagerGetWorkScheduleList implements ManagerGetScheduleListUseCase
             .filter(shift -> shift.getStatus() != WorkspaceShiftStatus.CANCELLED)
             .mapToDouble(shift -> Duration.between(shift.getStartDateTime(), shift.getEndDateTime()).toMinutes() / 60.0)
             .sum();
-        long estimatedLaborCost = Math.round(totalWorkHours * MINIMUM_HOURLY_WAGE);
+        long estimatedLaborCost = Math.round(totalWorkHours * WorkspaceConstants.MINIMUM_HOURLY_WAGE);
 
         List<ManagerScheduleResponseDto> scheduleDtos = shifts.stream()
             .map(ManagerScheduleResponseDto::of)

--- a/src/main/java/com/dreamteam/alter/common/constants/WorkspaceConstants.java
+++ b/src/main/java/com/dreamteam/alter/common/constants/WorkspaceConstants.java
@@ -1,0 +1,6 @@
+package com.dreamteam.alter.common.constants;
+
+public final class WorkspaceConstants {
+
+    public static final int MINIMUM_HOURLY_WAGE = 10_320;
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetWorkspaceScheduleUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/GetWorkspaceScheduleUseCase.java
@@ -1,11 +1,9 @@
 package com.dreamteam.alter.domain.workspace.port.inbound;
 
+import com.dreamteam.alter.adapter.inbound.general.schedule.dto.GetWorkspaceScheduleResponseDto;
 import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkScheduleInquiryRequestDto;
-import com.dreamteam.alter.adapter.inbound.general.schedule.dto.WorkspaceScheduleResponseDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 
-import java.util.List;
-
 public interface GetWorkspaceScheduleUseCase {
-    List<WorkspaceScheduleResponseDto> execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request);
+    GetWorkspaceScheduleResponseDto execute(AppActor actor, Long workspaceId, WorkScheduleInquiryRequestDto request);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerGetScheduleListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerGetScheduleListUseCase.java
@@ -1,10 +1,8 @@
 package com.dreamteam.alter.domain.workspace.port.inbound;
 
-import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerScheduleResponseDto;
+import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.GetManagerScheduleResponseDto;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 
-import java.util.List;
-
 public interface ManagerGetScheduleListUseCase {
-    List<ManagerScheduleResponseDto> execute(ManagerActor actor, Long workspaceId, int year, int month);
+    GetManagerScheduleResponseDto execute(ManagerActor actor, Long workspaceId, int year, int month);
 }


### PR DESCRIPTION
## 변경사항

### 사용자 스케줄 조회
- `GetMySchedule`: 자신의 모든 업장 월별 근무 시간 합산 → 예상 급여 추가
- `GetWorkspaceWorkSchedule`: 특정 업장의 월별 자신 근무 시간 합산 → 예상 급여 + 전체 시프트 목록 포함
- 신규 DTO: `GetWorkspaceScheduleResponseDto` (개인 시간/급여 + 업장 전체 스케줄)

### 매니저 스케줄 조회
- `ManagerGetWorkScheduleList`: 월별 전체 근무자의 근무 시간 합산 → 예상 인건비 추가
- 신규 DTO: `GetManagerScheduleResponseDto` (전체 시간/인건비 + 스케줄 목록)

### 급여 계산
- 최저시급: 10,320원/시간 (모든 근무자 동일 적용)
- 공식: \`Math.round(총 근무 시간 × 최저시급)\`
- 월별 조회 시에만 예상 급여/인건비 포함 (주별/일별은 null)

### 기술 변경
- 각 UseCase에 \`MINIMUM_HOURLY_WAGE\` 상수 추가
- 포트 인터페이스 반환 타입 변경
- 컨트롤러 및 Swagger 스펙 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 개인 스케줄 조회에 월간 기준 예상 급여 정보가 포함됩니다
  * 워크스페이스 스케줄 조회에 총 근무 시간 및 예상 급여 정보가 함께 제공됩니다
  * 매니저 스케줄 조회에 팀 전체의 총 근무 시간 및 예상 인건비가 표시됩니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->