### PR TITLE
feat: 어드민 업장 등록 요청 반려 사유 조회 API

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/workspace/controller/AdminWorkspaceReasonController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/workspace/controller/AdminWorkspaceReasonController.java
@@ -1,7 +1,10 @@
 package com.dreamteam.alter.adapter.inbound.admin.workspace.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dreamteam.alter.adapter.inbound.admin.workspace.dto.CreateWorkspaceReasonDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.workspace.dto.WorkspaceReasonResponseDto;
+import com.dreamteam.alter.domain.workspace.port.inbound.AdminGetWorkspaceReasonListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.CreateWorkspaceReasonUseCase;
 
 import jakarta.annotation.Resource;
@@ -22,8 +27,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AdminWorkspaceReasonController implements AdminWorkspaceReasonControllerSpec{
 
+	@Resource(name = "adminGetWorkspaceReasonList")
+	private final AdminGetWorkspaceReasonListUseCase adminGetWorkspaceReasonList;
+
 	@Resource(name = "createWorkspaceReason")
 	private final CreateWorkspaceReasonUseCase createWorkspaceReason;
+
+	@GetMapping
+	public ResponseEntity<CommonApiResponse<List<WorkspaceReasonResponseDto>>> getWorkspaceReasonList(
+		@PathVariable Long workspaceRequestId
+	) {
+		return ResponseEntity.ok(CommonApiResponse.of(adminGetWorkspaceReasonList.execute(workspaceRequestId)));
+	}
 
 	@Override
 	@PostMapping

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/workspace/controller/AdminWorkspaceReasonControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/workspace/controller/AdminWorkspaceReasonControllerSpec.java
@@ -1,11 +1,14 @@
 package com.dreamteam.alter.adapter.inbound.admin.workspace.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.dreamteam.alter.adapter.inbound.admin.workspace.dto.CreateWorkspaceReasonDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.workspace.dto.WorkspaceReasonResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,6 +19,15 @@ import jakarta.validation.Valid;
 
 @Tag(name = "ADMIN - 업장 등록 신청 반려 사유 API")
 public interface AdminWorkspaceReasonControllerSpec {
+
+	@Operation(summary = "반려 사유 목록 조회")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "반려 사유 목록 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "존재하지 않는 업장 등록 신청")
+	})
+	ResponseEntity<CommonApiResponse<List<WorkspaceReasonResponseDto>>> getWorkspaceReasonList(
+		@Parameter(description = "업장 등록 신청 ID", example = "1") @PathVariable Long workspaceRequestId
+	);
 
 	@Operation(summary = "업장 등록 신청 반려 사유 등록", description = "관리자가 업장 등록 신청에 대한 반려 사유를 등록합니다.")
 	@ApiResponses(value = {

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/AdminGetWorkspaceReasonList.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/AdminGetWorkspaceReasonList.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dreamteam.alter.adapter.inbound.general.workspace.dto.WorkspaceReasonResponseDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.workspace.port.inbound.AdminGetWorkspaceReasonListUseCase;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceReasonQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceRequestQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service( "adminGetWorkspaceReasonList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGetWorkspaceReasonList implements AdminGetWorkspaceReasonListUseCase {
+
+	private final WorkspaceRequestQueryRepository workspaceRequestQueryRepository;
+	private final WorkspaceReasonQueryRepository workspaceReasonQueryRepository;
+
+	@Override
+	public List<WorkspaceReasonResponseDto> execute(Long workspaceRequestId) {
+		if (!workspaceRequestQueryRepository.existsById(workspaceRequestId)) {
+			throw new CustomException(ErrorCode.NOT_FOUND);
+		}
+
+		return workspaceReasonQueryRepository.getWorkspaceReasonList(workspaceRequestId)
+			.stream()
+			.map(WorkspaceReasonResponseDto::from)
+			.toList();
+	}
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/AdminGetWorkspaceReasonListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/AdminGetWorkspaceReasonListUseCase.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import java.util.List;
+
+import com.dreamteam.alter.adapter.inbound.general.workspace.dto.WorkspaceReasonResponseDto;
+
+public interface AdminGetWorkspaceReasonListUseCase {
+	List<WorkspaceReasonResponseDto> execute(Long workspaceRequestId);
+}


### PR DESCRIPTION
## 관련 문서
[https://www.notion.so/BE-355865531628806b8ce5c90b43cbe4d9?v=2b186553162880979f62000c6c946512&source=copy_link](https://www.notion.so/BE-355865531628806b8ce5c90b43cbe4d9?v=2b186553162880979f62000c6c946512&source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 요청의 거절 사유 목록을 조회할 수 있는 새로운 API 엔드포인트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->