### PR TITLE
feat: [alt-207] 알림 수신 동의 관리 시스템

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentController.java
@@ -50,8 +50,8 @@ public class UserNotificationConsentController implements UserNotificationConsen
         updateNotificationConsentUseCase.execute(
             UpdateNotificationConsentCommand.of(
                 actor.getUser(),
-                request.getNotificationConsent(),
-                request.getNightNotificationConsent()
+                request.getType(),
+                request.getConsent()
             )
         );
         return ResponseEntity.ok(CommonApiResponse.empty());

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentController.java
@@ -1,0 +1,59 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationConsentResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.UpdateNotificationConsentRequestDto;
+import com.dreamteam.alter.application.aop.AppActionContext;
+import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.port.inbound.GetNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.port.inbound.UpdateNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/app/users/me")
+@PreAuthorize("hasAnyRole('USER')")
+@RequiredArgsConstructor
+@Validated
+public class UserNotificationConsentController implements UserNotificationConsentControllerSpec {
+
+    @Resource(name = "getNotificationConsent")
+    private final GetNotificationConsentUseCase getNotificationConsentUseCase;
+
+    @Resource(name = "updateNotificationConsent")
+    private final UpdateNotificationConsentUseCase updateNotificationConsentUseCase;
+
+    @Override
+    @GetMapping("/notification-consent")
+    public ResponseEntity<CommonApiResponse<NotificationConsentResponseDto>> getNotificationConsent() {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        GetNotificationConsentResult result = getNotificationConsentUseCase.execute(
+            GetNotificationConsentCommand.from(actor.getUser())
+        );
+        return ResponseEntity.ok(CommonApiResponse.of(NotificationConsentResponseDto.from(result)));
+    }
+
+    @Override
+    @PutMapping("/notification-consent")
+    public ResponseEntity<CommonApiResponse<Void>> updateNotificationConsent(
+        @Valid @RequestBody UpdateNotificationConsentRequestDto request
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        updateNotificationConsentUseCase.execute(
+            UpdateNotificationConsentCommand.of(
+                actor.getUser(),
+                request.getNotificationConsent(),
+                request.getNightNotificationConsent()
+            )
+        );
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentControllerSpec.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationConsentResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.UpdateNotificationConsentRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "APP - 알림 수신 설정 API")
+public interface UserNotificationConsentControllerSpec {
+
+    @Operation(summary = "알림 수신 설정 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<NotificationConsentResponseDto>> getNotificationConsent();
+
+    @Operation(summary = "알림 수신 설정 변경")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 변경 성공")
+    })
+    ResponseEntity<CommonApiResponse<Void>> updateNotificationConsent(
+        @Valid @RequestBody UpdateNotificationConsentRequestDto request
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationConsentControllerSpec.java
@@ -16,13 +16,15 @@ public interface UserNotificationConsentControllerSpec {
 
     @Operation(summary = "알림 수신 설정 조회")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "알림 수신 설정 조회 성공")
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "알림 수신 동의 레코드 없음")
     })
     ResponseEntity<CommonApiResponse<NotificationConsentResponseDto>> getNotificationConsent();
 
     @Operation(summary = "알림 수신 설정 변경")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "알림 수신 설정 변경 성공")
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 변경 성공"),
+        @ApiResponse(responseCode = "404", description = "알림 수신 동의 레코드 없음")
     })
     ResponseEntity<CommonApiResponse<Void>> updateNotificationConsent(
         @Valid @RequestBody UpdateNotificationConsentRequestDto request

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentItemDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentItemDto.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.dto;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 수신 동의 항목 DTO")
+public record NotificationConsentItemDto(
+    @Schema(description = "동의 항목 타입")
+    DescribedEnumDto<NotificationConsentType> type,
+
+    @Schema(description = "동의 여부")
+    boolean consent
+) {
+    public static NotificationConsentItemDto of(NotificationConsentType type, boolean consent) {
+        return new NotificationConsentItemDto(
+            DescribedEnumDto.of(type, NotificationConsentType.describe()),
+            consent
+        );
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentResponseDto.java
@@ -1,0 +1,26 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.dto;
+
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "알림 수신 설정 조회 응답 DTO")
+public class NotificationConsentResponseDto {
+
+    @Schema(description = "알림 수신 동의 여부")
+    private boolean notificationConsent;
+
+    @Schema(description = "야간 알림 수신 동의 여부")
+    private boolean nightNotificationConsent;
+
+    public static NotificationConsentResponseDto from(GetNotificationConsentResult result) {
+        return NotificationConsentResponseDto.builder()
+            .notificationConsent(result.notificationConsent())
+            .nightNotificationConsent(result.nightNotificationConsent())
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationConsentResponseDto.java
@@ -1,8 +1,12 @@
 package com.dreamteam.alter.adapter.inbound.general.notification.dto;
 
 import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -11,16 +15,18 @@ import lombok.*;
 @Schema(description = "알림 수신 설정 조회 응답 DTO")
 public class NotificationConsentResponseDto {
 
-    @Schema(description = "알림 수신 동의 여부")
-    private boolean notificationConsent;
-
-    @Schema(description = "야간 알림 수신 동의 여부")
-    private boolean nightNotificationConsent;
+    @Schema(description = "알림 항목별 동의 상태")
+    private List<NotificationConsentItemDto> items;
 
     public static NotificationConsentResponseDto from(GetNotificationConsentResult result) {
+        List<NotificationConsentItemDto> items = Arrays.stream(NotificationConsentType.values())
+            .map(type -> NotificationConsentItemDto.of(
+                type,
+                Boolean.TRUE.equals(result.consents().get(type))
+            ))
+            .toList();
         return NotificationConsentResponseDto.builder()
-            .notificationConsent(result.notificationConsent())
-            .nightNotificationConsent(result.nightNotificationConsent())
+            .items(items)
             .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/UpdateNotificationConsentRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/UpdateNotificationConsentRequestDto.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "알림 수신 설정 변경 요청 DTO")
+public class UpdateNotificationConsentRequestDto {
+
+    @NotNull
+    @Schema(description = "알림 수신 동의 여부")
+    private Boolean notificationConsent;
+
+    @NotNull
+    @Schema(description = "야간 알림 수신 동의 여부")
+    private Boolean nightNotificationConsent;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/UpdateNotificationConsentRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/UpdateNotificationConsentRequestDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.general.notification.dto;
 
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -13,10 +14,10 @@ import lombok.NoArgsConstructor;
 public class UpdateNotificationConsentRequestDto {
 
     @NotNull
-    @Schema(description = "알림 수신 동의 여부")
-    private Boolean notificationConsent;
+    @Schema(description = "동의 항목 타입")
+    private NotificationConsentType type;
 
     @NotNull
-    @Schema(description = "야간 알림 수신 동의 여부")
-    private Boolean nightNotificationConsent;
+    @Schema(description = "동의 여부")
+    private Boolean consent;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
@@ -50,4 +50,12 @@ public class CreateUserRequestDto {
     @Schema(description = "생년월일", example = "YYYYMMDD")
     private String birthday;
 
+    @NotNull
+    @Schema(description = "알림 수신 동의 여부", example = "true")
+    private Boolean notificationConsent;
+
+    @NotNull
+    @Schema(description = "야간 알림 수신 동의 여부", example = "false")
+    private Boolean nightNotificationConsent;
+
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
@@ -58,6 +58,14 @@ public class CreateUserWithSocialRequestDto {
     @Schema(description = "생년월일", example = "YYYYMMDD")
     private String birthday;
 
+    @NotNull
+    @Schema(description = "알림 수신 동의 여부", example = "true")
+    private Boolean notificationConsent;
+
+    @NotNull
+    @Schema(description = "야간 알림 수신 동의 여부", example = "false")
+    private Boolean nightNotificationConsent;
+
     @AssertTrue(message = "WEB 플랫폼은 authorizationCode가 필수입니다")
     private boolean isWebPlatformValid() {
         if (platformType != PlatformType.WEB) return true;

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentController.java
@@ -50,8 +50,8 @@ public class ManagerNotificationConsentController implements ManagerNotification
         updateNotificationConsentUseCase.execute(
             UpdateNotificationConsentCommand.of(
                 actor.getManagerUser().getUser(),
-                request.getNotificationConsent(),
-                request.getNightNotificationConsent()
+                request.getType(),
+                request.getConsent()
             )
         );
         return ResponseEntity.ok(CommonApiResponse.empty());

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentController.java
@@ -1,0 +1,59 @@
+package com.dreamteam.alter.adapter.inbound.manager.notification.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationConsentResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.UpdateNotificationConsentRequestDto;
+import com.dreamteam.alter.application.aop.ManagerActionContext;
+import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.port.inbound.GetNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.port.inbound.UpdateNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/manager/me")
+@PreAuthorize("hasAnyRole('MANAGER')")
+@RequiredArgsConstructor
+@Validated
+public class ManagerNotificationConsentController implements ManagerNotificationConsentControllerSpec {
+
+    @Resource(name = "getNotificationConsent")
+    private final GetNotificationConsentUseCase getNotificationConsentUseCase;
+
+    @Resource(name = "updateNotificationConsent")
+    private final UpdateNotificationConsentUseCase updateNotificationConsentUseCase;
+
+    @Override
+    @GetMapping("/notification-consent")
+    public ResponseEntity<CommonApiResponse<NotificationConsentResponseDto>> getNotificationConsent() {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        GetNotificationConsentResult result = getNotificationConsentUseCase.execute(
+            GetNotificationConsentCommand.from(actor.getManagerUser().getUser())
+        );
+        return ResponseEntity.ok(CommonApiResponse.of(NotificationConsentResponseDto.from(result)));
+    }
+
+    @Override
+    @PutMapping("/notification-consent")
+    public ResponseEntity<CommonApiResponse<Void>> updateNotificationConsent(
+        @Valid @RequestBody UpdateNotificationConsentRequestDto request
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        updateNotificationConsentUseCase.execute(
+            UpdateNotificationConsentCommand.of(
+                actor.getManagerUser().getUser(),
+                request.getNotificationConsent(),
+                request.getNightNotificationConsent()
+            )
+        );
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationConsentControllerSpec.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.adapter.inbound.manager.notification.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationConsentResponseDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.UpdateNotificationConsentRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "MANAGER - 알림 수신 설정 API")
+public interface ManagerNotificationConsentControllerSpec {
+
+    @Operation(summary = "알림 수신 설정 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<NotificationConsentResponseDto>> getNotificationConsent();
+
+    @Operation(summary = "알림 수신 설정 변경")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "알림 수신 설정 변경 성공")
+    })
+    ResponseEntity<CommonApiResponse<Void>> updateNotificationConsent(
+        @Valid @RequestBody UpdateNotificationConsentRequestDto request
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationConsentJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationConsentJpaRepository.java
@@ -1,0 +1,9 @@
+package com.dreamteam.alter.adapter.outbound.notification.persistence;
+
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationConsentJpaRepository extends JpaRepository<NotificationConsent, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationConsentRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationConsentRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.dreamteam.alter.adapter.outbound.notification.persistence;
+
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationConsentRepositoryImpl implements NotificationConsentRepository {
+
+    private final NotificationConsentJpaRepository notificationConsentJpaRepository;
+
+    @Override
+    public NotificationConsent save(NotificationConsent consent) {
+        return notificationConsentJpaRepository.save(consent);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/readonly/NotificationConsentQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/readonly/NotificationConsentQueryRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.dreamteam.alter.adapter.outbound.notification.persistence.readonly;
+
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.entity.QNotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationConsentQueryRepositoryImpl implements NotificationConsentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<NotificationConsent> findByUser(User user) {
+        QNotificationConsent qNotificationConsent = new QNotificationConsent("notificationConsent");
+
+        return Optional.ofNullable(queryFactory
+            .selectFrom(qNotificationConsent)
+            .where(qNotificationConsent.user.eq(user))
+            .fetchOne());
+    }
+
+    @Override
+    public List<NotificationConsent> findByUsers(List<User> users) {
+        if (ObjectUtils.isEmpty(users)) {
+            return List.of();
+        }
+
+        QNotificationConsent qNotificationConsent = new QNotificationConsent("notificationConsent");
+
+        return queryFactory
+            .selectFrom(qNotificationConsent)
+            .where(qNotificationConsent.user.in(users))
+            .fetch();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -6,6 +6,8 @@ import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFcmDev
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.notification.entity.Notification;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationRepository;
 import com.dreamteam.alter.domain.user.entity.FcmDeviceToken;
 import com.dreamteam.alter.domain.user.entity.User;
@@ -24,6 +26,8 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +46,20 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserQueryRepository userQueryRepository;
     private final EntityManager entityManager;
+    private final NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    boolean isNightTime() {
+        int hour = ZonedDateTime.now(KST).getHour();
+        return hour >= 21 || hour < 8;
+    }
+
+    private boolean shouldSendNotification(User user) {
+        return notificationConsentQueryRepository.findByUser(user)
+            .map(c -> c.isNotificationConsent() && (c.isNightNotificationConsent() || !isNightTime()))
+            .orElse(true);
+    }
 
     public void saveOrUpdateUserDeviceToken(User user, String deviceToken, DevicePlatformType devicePlatformType) {
         Optional<FcmDeviceToken> existingDeviceTokenByUser =
@@ -127,13 +145,26 @@ public class NotificationService {
             .toList();
         notificationRepository.saveAll(notifications);
 
+        // 수신 동의 기반 디바이스 토큰 필터링
+        Map<Long, NotificationConsent> consentMap = notificationConsentQueryRepository.findByUsers(users)
+            .stream()
+            .collect(Collectors.toMap(c -> c.getUser().getId(), c -> c));
+
+        List<FcmDeviceToken> eligibleTokens = deviceTokens.stream()
+            .filter(dt -> {
+                NotificationConsent consent = consentMap.get(dt.getUser().getId());
+                if (consent == null) return true;
+                return consent.isNotificationConsent() && (consent.isNightNotificationConsent() || !isNightTime());
+            })
+            .toList();
+
         // 4. FCM 배치 발송
-        if (deviceTokens.isEmpty()) {
+        if (eligibleTokens.isEmpty()) {
             return;
         }
 
         try {
-            List<String> deviceTokenStrings = deviceTokens.stream()
+            List<String> deviceTokenStrings = eligibleTokens.stream()
                 .map(FcmDeviceToken::getDeviceToken)
                 .toList();
 
@@ -142,7 +173,7 @@ public class NotificationService {
             );
 
             // 5. 결과 처리
-            processBatchResponse(response, deviceTokens);
+            processBatchResponse(response, eligibleTokens);
 
         } catch (FirebaseMessagingException e) {
             log.error("FCM 다중 알림 발송 실패: {}", e.getMessage(), e);
@@ -198,6 +229,11 @@ public class NotificationService {
             return;
         }
 
+        if (!shouldSendNotification(user)) {
+            log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", userId);
+            return;
+        }
+
         sendFcmNotification(user, title, body, false);
     }
 
@@ -209,6 +245,11 @@ public class NotificationService {
      * @param throwOnError 발송 실패 시 예외 throw 여부
      */
     private void sendFcmNotification(User user, String title, String body, boolean throwOnError) {
+        if (!shouldSendNotification(user)) {
+            log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", user.getId());
+            return;
+        }
+
         // 디바이스 토큰 조회
         Optional<FcmDeviceToken> deviceTokenOpt = userFCMDeviceTokenQueryRepository.findByUser(user);
         if (deviceTokenOpt.isEmpty()) {

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -139,7 +139,7 @@ public class NotificationService {
         List<FcmDeviceToken> eligibleTokens = deviceTokens.stream()
             .filter(dt -> {
                 NotificationConsent consent = Optional.ofNullable(consentMap.get(dt.getUser().getId()))
-                    .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND));
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 동의 레코드를 찾을 수 없습니다."));
                 return consent.isNotificationConsent() && (consent.isNightNotificationConsent() || isDaytime());
             })
             .toList();
@@ -284,7 +284,7 @@ public class NotificationService {
 
     private boolean isNotificationBlocked(User user) {
         NotificationConsent consent = notificationConsentQueryRepository.findByUser(user)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 동의 레코드를 찾을 수 없습니다."));
         return !consent.isNotificationConsent() || (!consent.isNightNotificationConsent() && !isDaytime());
     }
 

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -26,8 +26,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,19 +46,6 @@ public class NotificationService {
     private final UserQueryRepository userQueryRepository;
     private final EntityManager entityManager;
     private final NotificationConsentQueryRepository notificationConsentQueryRepository;
-
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
-    boolean isNightTime() {
-        int hour = ZonedDateTime.now(KST).getHour();
-        return hour >= 21 || hour < 8;
-    }
-
-    private boolean shouldSendNotification(User user) {
-        return notificationConsentQueryRepository.findByUser(user)
-            .map(c -> c.isNotificationConsent() && (c.isNightNotificationConsent() || !isNightTime()))
-            .orElse(true);
-    }
 
     public void saveOrUpdateUserDeviceToken(User user, String deviceToken, DevicePlatformType devicePlatformType) {
         Optional<FcmDeviceToken> existingDeviceTokenByUser =
@@ -152,9 +138,9 @@ public class NotificationService {
 
         List<FcmDeviceToken> eligibleTokens = deviceTokens.stream()
             .filter(dt -> {
-                NotificationConsent consent = consentMap.get(dt.getUser().getId());
-                if (consent == null) return true;
-                return consent.isNotificationConsent() && (consent.isNightNotificationConsent() || !isNightTime());
+                NotificationConsent consent = Optional.ofNullable(consentMap.get(dt.getUser().getId()))
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND));
+                return consent.isNotificationConsent() && (consent.isNightNotificationConsent() || isDaytime());
             })
             .toList();
 
@@ -229,7 +215,7 @@ public class NotificationService {
             return;
         }
 
-        if (!shouldSendNotification(user)) {
+        if (isNotificationBlocked(user)) {
             log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", userId);
             return;
         }
@@ -245,7 +231,7 @@ public class NotificationService {
      * @param throwOnError 발송 실패 시 예외 throw 여부
      */
     private void sendFcmNotification(User user, String title, String body, boolean throwOnError) {
-        if (!shouldSendNotification(user)) {
+        if (isNotificationBlocked(user)) {
             log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", user.getId());
             return;
         }
@@ -295,4 +281,15 @@ public class NotificationService {
             MessagingErrorCode.UNREGISTERED.equals(e.getMessagingErrorCode());
     }
 
+
+    private boolean isNotificationBlocked(User user) {
+        NotificationConsent consent = notificationConsentQueryRepository.findByUser(user)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND));
+        return !consent.isNotificationConsent() || (!consent.isNightNotificationConsent() && !isDaytime());
+    }
+
+    private boolean isDaytime() {
+        int hour = LocalTime.now().getHour();
+        return hour >= 8 && hour < 21;
+    }
 }

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
@@ -25,6 +25,6 @@ public class GetNotificationConsent implements GetNotificationConsentUseCase {
         NotificationConsent consent = notificationConsentQueryRepository.findByUser(command.getUser())
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 설정을 찾을 수 없습니다."));
 
-        return new GetNotificationConsentResult(consent.isNotificationConsent(), consent.isNightNotificationConsent());
+        return GetNotificationConsentResult.from(consent);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.application.notification.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.inbound.GetNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("getNotificationConsent")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetNotificationConsent implements GetNotificationConsentUseCase {
+
+    private final NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    @Override
+    public GetNotificationConsentResult execute(GetNotificationConsentCommand command) {
+        NotificationConsent consent = notificationConsentQueryRepository.findByUser(command.getUser())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 설정을 찾을 수 없습니다."));
+
+        return new GetNotificationConsentResult(consent.isNotificationConsent(), consent.isNightNotificationConsent());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsent.java
@@ -8,9 +8,11 @@ import com.dreamteam.alter.domain.notification.port.inbound.GetNotificationConse
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service("getNotificationConsent")
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsent.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.application.notification.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.inbound.UpdateNotificationConsentUseCase;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("updateNotificationConsent")
+@RequiredArgsConstructor
+@Transactional
+public class UpdateNotificationConsent implements UpdateNotificationConsentUseCase {
+
+    private final NotificationConsentRepository notificationConsentRepository;
+    private final NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    @Override
+    public void execute(UpdateNotificationConsentCommand command) {
+        NotificationConsent consent = notificationConsentQueryRepository.findByUser(command.getUser())
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 설정을 찾을 수 없습니다."));
+
+        consent.updateConsent(command.isNotificationConsent(), command.isNightNotificationConsent());
+        notificationConsentRepository.save(consent);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsent.java
@@ -24,7 +24,6 @@ public class UpdateNotificationConsent implements UpdateNotificationConsentUseCa
         NotificationConsent consent = notificationConsentQueryRepository.findByUser(command.getUser())
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 설정을 찾을 수 없습니다."));
 
-        consent.updateConsent(command.isNotificationConsent(), command.isNightNotificationConsent());
-        notificationConsentRepository.save(consent);
+        consent.updateConsent(command.getType(), command.isConsent());
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
@@ -50,7 +50,11 @@ public class CreateUser implements CreateUserUseCase {
         String verifiedEmail = resolveVerifiedEmail(request);
 
         // 사용자 엔티티 저장
-        GenerateTokenResponseDto response = createUserTx.process(request, contact, verifiedEmail);
+        GenerateTokenResponseDto response = createUserTx.process(
+            request, contact, verifiedEmail,
+            request.getNotificationConsent(),
+            request.getNightNotificationConsent()
+        );
 
         // 회원가입 세션 삭제
         String contactKey = SignupSessionConstants.Session.CONTACT_INDEX_KEY_PREFIX + contact;

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
@@ -31,7 +31,9 @@ public class CreateUserTx {
     public GenerateTokenResponseDto process(
         CreateUserRequestDto request,
         String contact,
-        String verifiedEmail
+        String verifiedEmail,
+        boolean notificationConsent,
+        boolean nightNotificationConsent
     ) {
         // 사용자 생성
         User user = userRepository.save(User.create(
@@ -44,7 +46,7 @@ public class CreateUserTx {
             verifiedEmail
         ));
 
-        notificationConsentRepository.save(NotificationConsent.createDefault(user));
+        notificationConsentRepository.save(NotificationConsent.create(user, notificationConsent, nightNotificationConsent));
 
         Authorization authorization = authService.generateAuthorization(user, TokenScope.APP);
         authLogRepository.save(AuthLog.create(user, authorization, AuthLogType.LOGIN));

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
@@ -8,6 +8,8 @@ import com.dreamteam.alter.domain.auth.entity.Authorization;
 import com.dreamteam.alter.domain.auth.port.outbound.AuthLogRepository;
 import com.dreamteam.alter.domain.auth.type.AuthLogType;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class CreateUserTx {
     private final AuthService authService;
     private final PasswordEncoder passwordEncoder;
     private final AuthLogRepository authLogRepository;
+    private final NotificationConsentRepository notificationConsentRepository;
 
     @Transactional
     public GenerateTokenResponseDto process(
@@ -40,6 +43,8 @@ public class CreateUserTx {
             request.getBirthday(),
             verifiedEmail
         ));
+
+        notificationConsentRepository.save(NotificationConsent.createDefault(user));
 
         Authorization authorization = authService.generateAuthorization(user, TokenScope.APP);
         authLogRepository.save(AuthLog.create(user, authorization, AuthLogType.LOGIN));

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
@@ -73,7 +73,11 @@ public class CreateUserWithSocial implements CreateUserWithSocialUseCase {
         }
 
         // 사용자 및 소셜 계정 엔티티 저장
-        GenerateTokenResponseDto response = createUserWithSocialTx.process(contact, request, socialAuthInfo);
+        GenerateTokenResponseDto response = createUserWithSocialTx.process(
+            contact, request, socialAuthInfo,
+            request.getNotificationConsent(),
+            request.getNightNotificationConsent()
+        );
 
         // 회원가입 세션 삭제
         String contactKey = SignupSessionConstants.Session.CONTACT_INDEX_KEY_PREFIX + contact;

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
@@ -9,6 +9,8 @@ import com.dreamteam.alter.domain.auth.entity.Authorization;
 import com.dreamteam.alter.domain.auth.port.outbound.AuthLogRepository;
 import com.dreamteam.alter.domain.auth.type.AuthLogType;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
@@ -23,6 +25,7 @@ public class CreateUserWithSocialTx {
     private final UserRepository userRepository;
     private final AuthService authService;
     private final AuthLogRepository authLogRepository;
+    private final NotificationConsentRepository notificationConsentRepository;
 
     @Transactional
     public GenerateTokenResponseDto process(
@@ -39,6 +42,8 @@ public class CreateUserWithSocialTx {
             request.getBirthday(),
             socialAuthInfo.getEmail()
         ));
+
+        notificationConsentRepository.save(NotificationConsent.createDefault(user));
 
         // 소셜 계정 연동
         UserSocial userSocial = UserSocial.create(

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
@@ -31,7 +31,9 @@ public class CreateUserWithSocialTx {
     public GenerateTokenResponseDto process(
         String contact,
         CreateUserWithSocialRequestDto request,
-        SocialAuthInfo socialAuthInfo
+        SocialAuthInfo socialAuthInfo,
+        boolean notificationConsent,
+        boolean nightNotificationConsent
     ) {
         // 사용자 생성
         User user = userRepository.save(User.createWithSocial(
@@ -43,7 +45,7 @@ public class CreateUserWithSocialTx {
             socialAuthInfo.getEmail()
         ));
 
-        notificationConsentRepository.save(NotificationConsent.createDefault(user));
+        notificationConsentRepository.save(NotificationConsent.create(user, notificationConsent, nightNotificationConsent));
 
         // 소셜 계정 연동
         UserSocial userSocial = UserSocial.create(

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/LogoutManager.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/LogoutManager.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.application.user.usecase;
 
 import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.port.inbound.LogoutManagerUseCase;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class LogoutManager implements LogoutManagerUseCase {
 
     private final AuthService authService;
+    private final NotificationService notificationService;
 
     @Override
     public void execute(ManagerActor actor) {
         authService.revokeAllExistingAuthorizations(actor.getManagerUser().getUser());
+        notificationService.removeUserDeviceToken(actor.getManagerUser().getUser());
     }
 }

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -50,7 +50,6 @@ public enum ErrorCode {
     INVALID_FILE_TYPE(400, "B023", "허용되지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(400, "B024", "파일 크기가 제한을 초과합니다."),
     FILE_ALREADY_ATTACHED(409, "B025", "이미 연결된 파일입니다."),
-    NOTIFICATION_CONSENT_NOT_FOUND(404, "B026", "알림 수신 동의 레코드를 찾을 수 없습니다."),
 
     TOO_MANY_REQUESTS(429, "E001", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     INVALID_FILE_TYPE(400, "B023", "허용되지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(400, "B024", "파일 크기가 제한을 초과합니다."),
     FILE_ALREADY_ATTACHED(409, "B025", "이미 연결된 파일입니다."),
+    NOTIFICATION_CONSENT_NOT_FOUND(404, "B026", "알림 수신 동의 레코드를 찾을 수 없습니다."),
 
     TOO_MANY_REQUESTS(429, "E001", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 

--- a/src/main/java/com/dreamteam/alter/domain/notification/command/GetNotificationConsentCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/command/GetNotificationConsentCommand.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.domain.notification.command;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetNotificationConsentCommand {
+
+    private User user;
+
+    public static GetNotificationConsentCommand from(User user) {
+        return GetNotificationConsentCommand.builder()
+            .user(user)
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/command/UpdateNotificationConsentCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/command/UpdateNotificationConsentCommand.java
@@ -1,0 +1,25 @@
+package com.dreamteam.alter.domain.notification.command;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateNotificationConsentCommand {
+
+    private User user;
+    private boolean notificationConsent;
+    private boolean nightNotificationConsent;
+
+    public static UpdateNotificationConsentCommand of(User user, boolean notificationConsent, boolean nightNotificationConsent) {
+        return UpdateNotificationConsentCommand.builder()
+            .user(user)
+            .notificationConsent(notificationConsent)
+            .nightNotificationConsent(nightNotificationConsent)
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/command/UpdateNotificationConsentCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/command/UpdateNotificationConsentCommand.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.domain.notification.command;
 
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import com.dreamteam.alter.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,14 +13,14 @@ import lombok.Getter;
 public class UpdateNotificationConsentCommand {
 
     private User user;
-    private boolean notificationConsent;
-    private boolean nightNotificationConsent;
+    private NotificationConsentType type;
+    private boolean consent;
 
-    public static UpdateNotificationConsentCommand of(User user, boolean notificationConsent, boolean nightNotificationConsent) {
+    public static UpdateNotificationConsentCommand of(User user, NotificationConsentType type, boolean consent) {
         return UpdateNotificationConsentCommand.builder()
             .user(user)
-            .notificationConsent(notificationConsent)
-            .nightNotificationConsent(nightNotificationConsent)
+            .type(type)
+            .consent(consent)
             .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -34,11 +34,11 @@ public class NotificationConsent {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static NotificationConsent createDefault(User user) {
+    public static NotificationConsent create(User user, boolean notificationConsent, boolean nightNotificationConsent) {
         return NotificationConsent.builder()
             .user(user)
-            .notificationConsent(true)
-            .nightNotificationConsent(true)
+            .notificationConsent(notificationConsent)
+            .nightNotificationConsent(nightNotificationConsent)
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
             .build();

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -1,0 +1,52 @@
+package com.dreamteam.alter.domain.notification.entity;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "notification_consents")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationConsent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "notification_consent", nullable = false)
+    private boolean notificationConsent;
+
+    @Column(name = "night_notification_consent", nullable = false)
+    private boolean nightNotificationConsent;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static NotificationConsent createDefault(User user) {
+        return NotificationConsent.builder()
+            .user(user)
+            .notificationConsent(true)
+            .nightNotificationConsent(true)
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .build();
+    }
+
+    public void updateConsent(boolean notificationConsent, boolean nightNotificationConsent) {
+        this.notificationConsent = notificationConsent;
+        this.nightNotificationConsent = nightNotificationConsent;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -1,8 +1,27 @@
 package com.dreamteam.alter.domain.notification.entity;
 
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import com.dreamteam.alter.domain.user.entity.User;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +31,7 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 public class NotificationConsent {
 
     @Id
@@ -28,9 +48,11 @@ public class NotificationConsent {
     @Column(name = "night_notification_consent", nullable = false)
     private boolean nightNotificationConsent;
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
@@ -39,14 +61,26 @@ public class NotificationConsent {
             .user(user)
             .notificationConsent(notificationConsent)
             .nightNotificationConsent(notificationConsent && nightNotificationConsent)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
             .build();
     }
 
-    public void updateConsent(boolean notificationConsent, boolean nightNotificationConsent) {
-        this.notificationConsent = notificationConsent;
-        this.nightNotificationConsent = notificationConsent && nightNotificationConsent;
-        this.updatedAt = LocalDateTime.now();
+    public void updateConsent(NotificationConsentType type, boolean consent) {
+        switch (type) {
+            case GENERAL -> {
+                this.notificationConsent = consent;
+                if (!consent) {
+                    this.nightNotificationConsent = false;
+                }
+            }
+            case NIGHT -> {
+                if (consent && !this.notificationConsent) {
+                    throw new CustomException(
+                        ErrorCode.ILLEGAL_ARGUMENT,
+                        "전체 알림 수신 동의가 꺼진 상태에서는 야간 알림을 켤 수 없습니다."
+                    );
+                }
+                this.nightNotificationConsent = consent;
+            }
+        }
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -38,7 +38,7 @@ public class NotificationConsent {
         return NotificationConsent.builder()
             .user(user)
             .notificationConsent(notificationConsent)
-            .nightNotificationConsent(nightNotificationConsent)
+            .nightNotificationConsent(notificationConsent && nightNotificationConsent)
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())
             .build();
@@ -46,7 +46,7 @@ public class NotificationConsent {
 
     public void updateConsent(boolean notificationConsent, boolean nightNotificationConsent) {
         this.notificationConsent = notificationConsent;
-        this.nightNotificationConsent = nightNotificationConsent;
+        this.nightNotificationConsent = notificationConsent && nightNotificationConsent;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/GetNotificationConsentUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/GetNotificationConsentUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.notification.port.inbound;
+
+import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+
+public interface GetNotificationConsentUseCase {
+    GetNotificationConsentResult execute(GetNotificationConsentCommand command);
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/UpdateNotificationConsentUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/UpdateNotificationConsentUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.notification.port.inbound;
+
+import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
+
+public interface UpdateNotificationConsentUseCase {
+    void execute(UpdateNotificationConsentCommand command);
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationConsentQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationConsentQueryRepository.java
@@ -1,0 +1,12 @@
+package com.dreamteam.alter.domain.notification.port.outbound;
+
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.user.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationConsentQueryRepository {
+    Optional<NotificationConsent> findByUser(User user);
+    List<NotificationConsent> findByUsers(List<User> users);
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationConsentRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationConsentRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.notification.port.outbound;
+
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+
+public interface NotificationConsentRepository {
+    NotificationConsent save(NotificationConsent consent);
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
@@ -1,7 +1,18 @@
 package com.dreamteam.alter.domain.notification.result;
 
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
 public record GetNotificationConsentResult(
-    boolean notificationConsent,
-    boolean nightNotificationConsent
+    Map<NotificationConsentType, Boolean> consents
 ) {
+    public static GetNotificationConsentResult from(NotificationConsent consent) {
+        Map<NotificationConsentType, Boolean> consents = new EnumMap<>(NotificationConsentType.class);
+        consents.put(NotificationConsentType.GENERAL, consent.isNotificationConsent());
+        consents.put(NotificationConsentType.NIGHT, consent.isNightNotificationConsent());
+        return new GetNotificationConsentResult(consents);
+    }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
@@ -3,16 +3,15 @@ package com.dreamteam.alter.domain.notification.result;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 
-import java.util.EnumMap;
 import java.util.Map;
 
 public record GetNotificationConsentResult(
     Map<NotificationConsentType, Boolean> consents
 ) {
     public static GetNotificationConsentResult from(NotificationConsent consent) {
-        Map<NotificationConsentType, Boolean> consents = new EnumMap<>(NotificationConsentType.class);
-        consents.put(NotificationConsentType.GENERAL, consent.isNotificationConsent());
-        consents.put(NotificationConsentType.NIGHT, consent.isNightNotificationConsent());
-        return new GetNotificationConsentResult(consents);
+        return new GetNotificationConsentResult(Map.of(
+            NotificationConsentType.GENERAL, consent.isNotificationConsent(),
+            NotificationConsentType.NIGHT, consent.isNightNotificationConsent()
+        ));
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.notification.result;
+
+public record GetNotificationConsentResult(
+    boolean notificationConsent,
+    boolean nightNotificationConsent
+) {
+}

--- a/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationConsentType.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationConsentType.java
@@ -1,0 +1,16 @@
+package com.dreamteam.alter.domain.notification.type;
+
+import java.util.Map;
+
+public enum NotificationConsentType {
+    GENERAL,
+    NIGHT,
+    ;
+
+    public static Map<NotificationConsentType, String> describe() {
+        return Map.of(
+            NotificationConsentType.GENERAL, "전체 알림 수신",
+            NotificationConsentType.NIGHT, "야간 알림 수신"
+        );
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -26,8 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,9 +73,9 @@ class NotificationServiceConsentTests {
         return NotificationConsent.create(user, notificationConsent, nightNotificationConsent);
     }
 
-    // ── 고정 시각을 반환하는 ZonedDateTime mock 헬퍼 ──────────────────────
-    private ZonedDateTime kstAt(int hour) {
-        return ZonedDateTime.of(2024, 1, 1, hour, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+    // ── 고정 시각을 반환하는 LocalTime 헬퍼 ──────────────────────────────
+    private LocalTime localTimeAt(int hour) {
+        return LocalTime.of(hour, 0);
     }
 
     // ── FcmNotificationRequestDto 헬퍼 ───────────────────────────────────
@@ -116,9 +115,9 @@ class NotificationServiceConsentTests {
             NotificationConsent consent = consentWith(true, false);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
-            ZonedDateTime nightTime = kstAt(22);
-            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(nightTime);
+            LocalTime nightTime = localTimeAt(22);
+            try (MockedStatic<LocalTime> mockedStatic = mockStatic(LocalTime.class)) {
+                mockedStatic.when(LocalTime::now).thenReturn(nightTime);
 
                 // when
                 notificationService.sendNotification(notificationRequest(1L));
@@ -136,9 +135,9 @@ class NotificationServiceConsentTests {
             NotificationConsent consent = consentWith(true, false);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
-            ZonedDateTime dayTime = kstAt(10);
-            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(dayTime);
+            LocalTime dayTime = localTimeAt(10);
+            try (MockedStatic<LocalTime> mockedStatic = mockStatic(LocalTime.class)) {
+                mockedStatic.when(LocalTime::now).thenReturn(dayTime);
 
                 // when
                 notificationService.sendNotification(notificationRequest(1L));
@@ -249,9 +248,9 @@ class NotificationServiceConsentTests {
             NotificationConsent consent = consentWith(true, false);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
-            ZonedDateTime nightTime = kstAt(22);
-            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
-                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(nightTime);
+            LocalTime nightTime = localTimeAt(22);
+            try (MockedStatic<LocalTime> mockedStatic = mockStatic(LocalTime.class)) {
+                mockedStatic.when(LocalTime::now).thenReturn(nightTime);
 
                 // when
                 notificationService.sendNotificationOnly(1L, "제목", "내용");

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -2,6 +2,8 @@ package com.dreamteam.alter.application.notification;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.FcmBatchNotificationRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.FcmNotificationRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFcmDeviceTokenQueryRepository;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
@@ -29,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -146,16 +149,16 @@ class NotificationServiceConsentTests {
         }
 
         @Test
-        @DisplayName("수신 동의 레코드 없는 사용자(empty) → FCM 호출됨 (기본 동의)")
-        void sends_fcm_when_no_consent_record_exists() throws Exception {
+        @DisplayName("수신 동의 레코드 없는 사용자(empty) → NOTIFICATION_CONSENT_NOT_FOUND 예외")
+        void throws_exception_when_no_consent_record_exists() {
             // given
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
 
-            // when
-            notificationService.sendNotification(notificationRequest(1L));
-
-            // then
-            then(fcmClient).should().sendNotification(eq("test-device-token"), any(), any());
+            // when & then
+            assertThatThrownBy(() -> notificationService.sendNotification(notificationRequest(1L)))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND);
         }
     }
 
@@ -234,6 +237,25 @@ class NotificationServiceConsentTests {
 
             // when
             notificationService.sendNotificationOnly(1L, "제목", "내용");
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("야간 동의 false + 야간 시간(22시 KST) → FCM 미호출")
+        void skips_fcm_when_nightConsent_false_and_is_night() throws Exception {
+            // given
+            NotificationConsent consent = consentWith(true, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            ZonedDateTime nightTime = kstAt(22);
+            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
+                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(nightTime);
+
+                // when
+                notificationService.sendNotificationOnly(1L, "제목", "내용");
+            }
 
             // then
             then(fcmClient).should(never()).sendNotification(any(), any(), any());

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -23,7 +23,6 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -69,10 +68,7 @@ class NotificationServiceConsentTests {
 
     // ── NotificationConsent 헬퍼 ──────────────────────────────────────────
     private NotificationConsent consentWith(boolean notificationConsent, boolean nightNotificationConsent) {
-        NotificationConsent consent = NotificationConsent.createDefault(user);
-        ReflectionTestUtils.setField(consent, "notificationConsent", notificationConsent);
-        ReflectionTestUtils.setField(consent, "nightNotificationConsent", nightNotificationConsent);
-        return consent;
+        return NotificationConsent.create(user, notificationConsent, nightNotificationConsent);
     }
 
     // ── 고정 시각을 반환하는 ZonedDateTime mock 헬퍼 ──────────────────────
@@ -193,9 +189,8 @@ class NotificationServiceConsentTests {
                 .willReturn(List.of(consentingToken, nonConsentingToken));
 
             // findByUsers 배치 응답: consentingUser는 동의, nonConsentingUser는 미동의
-            NotificationConsent consentingConsent = NotificationConsent.createDefault(consentingUser);
-            NotificationConsent nonConsentingConsent = NotificationConsent.createDefault(nonConsentingUser);
-            ReflectionTestUtils.setField(nonConsentingConsent, "notificationConsent", false);
+            NotificationConsent consentingConsent = NotificationConsent.create(consentingUser, true, true);
+            NotificationConsent nonConsentingConsent = NotificationConsent.create(nonConsentingUser, false, true);
             given(notificationConsentQueryRepository.findByUsers(anyList()))
                 .willReturn(List.of(consentingConsent, nonConsentingConsent));
 

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -1,0 +1,247 @@
+package com.dreamteam.alter.application.notification;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.FcmBatchNotificationRequestDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.FcmNotificationRequestDto;
+import com.dreamteam.alter.adapter.outbound.user.persistence.readonly.UserFcmDeviceTokenQueryRepository;
+import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationRepository;
+import com.dreamteam.alter.domain.user.entity.FcmDeviceToken;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserFcmDeviceTokenRepository;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("NotificationService 수신 동의 필터링 테스트")
+class NotificationServiceConsentTests {
+
+    @Mock private FcmClient fcmClient;
+    @Mock private UserFcmDeviceTokenRepository userFCMDeviceTokenRepository;
+    @Mock private UserFcmDeviceTokenQueryRepository userFCMDeviceTokenQueryRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private UserQueryRepository userQueryRepository;
+    @Mock private EntityManager entityManager;
+    @Mock private NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private User user;
+    private FcmDeviceToken deviceToken;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+        deviceToken = mock(FcmDeviceToken.class);
+        given(deviceToken.getDeviceToken()).willReturn("test-device-token");
+        given(deviceToken.getUser()).willReturn(user);
+
+        given(userFCMDeviceTokenQueryRepository.findByUser(user)).willReturn(Optional.of(deviceToken));
+        given(userQueryRepository.findById(1L)).willReturn(Optional.of(user));
+    }
+
+    // ── NotificationConsent 헬퍼 ──────────────────────────────────────────
+    private NotificationConsent consentWith(boolean notificationConsent, boolean nightNotificationConsent) {
+        NotificationConsent consent = NotificationConsent.createDefault(user);
+        ReflectionTestUtils.setField(consent, "notificationConsent", notificationConsent);
+        ReflectionTestUtils.setField(consent, "nightNotificationConsent", nightNotificationConsent);
+        return consent;
+    }
+
+    // ── 고정 시각을 반환하는 ZonedDateTime mock 헬퍼 ──────────────────────
+    private ZonedDateTime kstAt(int hour) {
+        return ZonedDateTime.of(2024, 1, 1, hour, 0, 0, 0, ZoneId.of("Asia/Seoul"));
+    }
+
+    // ── FcmNotificationRequestDto 헬퍼 ───────────────────────────────────
+    private FcmNotificationRequestDto notificationRequest(Long userId) {
+        return FcmNotificationRequestDto.of(userId, TokenScope.APP, "제목", "내용");
+    }
+
+    // ── FcmBatchNotificationRequestDto 헬퍼 ──────────────────────────────
+    private FcmBatchNotificationRequestDto batchRequest(List<Long> userIds) {
+        return FcmBatchNotificationRequestDto.of(userIds, TokenScope.APP, "제목", "내용");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    @Nested
+    @DisplayName("sendNotification — 수신 동의 검사")
+    class SendNotificationConsentTests {
+
+        @Test
+        @DisplayName("수신 동의 false → FCM 미호출, Notification 레코드는 저장됨")
+        void skips_fcm_when_notificationConsent_is_false() throws Exception {
+            // given
+            NotificationConsent consent = consentWith(false, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            notificationService.sendNotification(notificationRequest(1L));
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+            then(notificationRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("야간 동의 false + 야간 시간(22시 KST) → FCM 미호출, Notification 레코드 저장됨")
+        void skips_fcm_when_nightConsent_false_and_is_night() throws Exception {
+            // given
+            NotificationConsent consent = consentWith(true, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            ZonedDateTime nightTime = kstAt(22);
+            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
+                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(nightTime);
+
+                // when
+                notificationService.sendNotification(notificationRequest(1L));
+            }
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+            then(notificationRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("야간 동의 false + 주간 시간(10시 KST) → FCM 호출됨")
+        void sends_fcm_when_nightConsent_false_but_is_daytime() throws Exception {
+            // given
+            NotificationConsent consent = consentWith(true, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            ZonedDateTime dayTime = kstAt(10);
+            try (MockedStatic<ZonedDateTime> mockedStatic = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS)) {
+                mockedStatic.when(() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul"))).thenReturn(dayTime);
+
+                // when
+                notificationService.sendNotification(notificationRequest(1L));
+            }
+
+            // then
+            then(fcmClient).should().sendNotification(eq("test-device-token"), any(), any());
+        }
+
+        @Test
+        @DisplayName("수신 동의 레코드 없는 사용자(empty) → FCM 호출됨 (기본 동의)")
+        void sends_fcm_when_no_consent_record_exists() throws Exception {
+            // given
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
+
+            // when
+            notificationService.sendNotification(notificationRequest(1L));
+
+            // then
+            then(fcmClient).should().sendNotification(eq("test-device-token"), any(), any());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    @Nested
+    @DisplayName("sendMultipleNotifications — 배치 수신 동의 필터")
+    class SendMultipleNotificationsConsentTests {
+
+        @Test
+        @DisplayName("미동의 사용자가 포함된 배치 → 미동의 사용자 제외하고 FCM 배치 발송, Notification 레코드는 전원 저장됨")
+        void excludes_non_consenting_user_from_fcm_batch_but_saves_all_notifications() throws Exception {
+            // given
+            User consentingUser = mock(User.class);
+            given(consentingUser.getId()).willReturn(10L);
+
+            User nonConsentingUser = mock(User.class);
+            given(nonConsentingUser.getId()).willReturn(20L);
+
+            given(userQueryRepository.findAllById(List.of(10L, 20L)))
+                .willReturn(List.of(consentingUser, nonConsentingUser));
+
+            FcmDeviceToken consentingToken = mock(FcmDeviceToken.class);
+            given(consentingToken.getDeviceToken()).willReturn("token-consenting");
+            given(consentingToken.getUser()).willReturn(consentingUser);
+
+            FcmDeviceToken nonConsentingToken = mock(FcmDeviceToken.class);
+            given(nonConsentingToken.getDeviceToken()).willReturn("token-non-consenting");
+            given(nonConsentingToken.getUser()).willReturn(nonConsentingUser);
+
+            given(userFCMDeviceTokenQueryRepository.findByUsers(anyList()))
+                .willReturn(List.of(consentingToken, nonConsentingToken));
+
+            // findByUsers 배치 응답: consentingUser는 동의, nonConsentingUser는 미동의
+            NotificationConsent consentingConsent = NotificationConsent.createDefault(consentingUser);
+            NotificationConsent nonConsentingConsent = NotificationConsent.createDefault(nonConsentingUser);
+            ReflectionTestUtils.setField(nonConsentingConsent, "notificationConsent", false);
+            given(notificationConsentQueryRepository.findByUsers(anyList()))
+                .willReturn(List.of(consentingConsent, nonConsentingConsent));
+
+            com.google.firebase.messaging.BatchResponse batchResponse =
+                mock(com.google.firebase.messaging.BatchResponse.class);
+            com.google.firebase.messaging.SendResponse sendResponse =
+                mock(com.google.firebase.messaging.SendResponse.class);
+            given(sendResponse.isSuccessful()).willReturn(true);
+            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+            given(fcmClient.sendMultipleNotifications(anyList(), any(), any())).willReturn(batchResponse);
+
+            // when
+            notificationService.sendMultipleNotifications(batchRequest(List.of(10L, 20L)));
+
+            // then: Notification 레코드는 두 사용자 모두 저장
+            then(notificationRepository).should().saveAll(argThat(list -> ((List<?>) list).size() == 2));
+
+            // then: FCM 배치는 동의한 사용자의 토큰만 포함
+            then(fcmClient).should().sendMultipleNotifications(
+                argThat(tokens -> {
+                    @SuppressWarnings("unchecked")
+                    List<String> tokenList = (List<String>) tokens;
+                    return tokenList.size() == 1 && tokenList.contains("token-consenting");
+                }),
+                any(), any()
+            );
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    @Nested
+    @DisplayName("sendNotificationOnly — 수신 동의 검사")
+    class SendNotificationOnlyConsentTests {
+
+        @Test
+        @DisplayName("수신 동의 false → FCM 미호출")
+        void skips_fcm_when_notificationConsent_is_false() throws Exception {
+            // given
+            NotificationConsent consent = consentWith(false, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            notificationService.sendNotificationOnly(1L, "제목", "내용");
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -149,7 +149,7 @@ class NotificationServiceConsentTests {
         }
 
         @Test
-        @DisplayName("수신 동의 레코드 없는 사용자(empty) → NOTIFICATION_CONSENT_NOT_FOUND 예외")
+        @DisplayName("수신 동의 레코드 없는 사용자(empty) → NOT_FOUND 예외")
         void throws_exception_when_no_consent_record_exists() {
             // given
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
@@ -158,7 +158,7 @@ class NotificationServiceConsentTests {
             assertThatThrownBy(() -> notificationService.sendNotification(notificationRequest(1L)))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.NOTIFICATION_CONSENT_NOT_FOUND);
+                .isEqualTo(ErrorCode.NOT_FOUND);
         }
     }
 

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
@@ -1,5 +1,7 @@
 package com.dreamteam.alter.application.notification.usecase;
 
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
@@ -14,11 +16,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -38,19 +40,18 @@ class GetNotificationConsentTests {
     class ExecuteTests {
 
         @Test
-        @DisplayName("레코드가 없을 때 기본값(notificationConsent=true, nightNotificationConsent=true) 반환")
-        void returnsDefaults_whenNoRecordExists() {
+        @DisplayName("레코드가 없을 때 NOT_FOUND 예외를 던짐")
+        void throwsNotFound_whenNoRecordExists() {
             // given
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
 
-            // when
-            GetNotificationConsentResult result = getNotificationConsent.execute(command);
-
-            // then
-            assertThat(result.notificationConsent()).isTrue();
-            assertThat(result.nightNotificationConsent()).isTrue();
+            // when & then
+            assertThatThrownBy(() -> getNotificationConsent.execute(command))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOT_FOUND);
         }
 
         @Test
@@ -60,8 +61,7 @@ class GetNotificationConsentTests {
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
 
-            NotificationConsent consent = NotificationConsent.createDefault(user);
-            // createDefault already sets both to true
+            NotificationConsent consent = NotificationConsent.create(user, true, true);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
             // when
@@ -79,8 +79,7 @@ class GetNotificationConsentTests {
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
 
-            NotificationConsent consent = NotificationConsent.createDefault(user);
-            ReflectionTestUtils.setField(consent, "notificationConsent", false);
+            NotificationConsent consent = NotificationConsent.create(user, false, true);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
             // when
@@ -98,8 +97,7 @@ class GetNotificationConsentTests {
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
 
-            NotificationConsent consent = NotificationConsent.createDefault(user);
-            ReflectionTestUtils.setField(consent, "nightNotificationConsent", false);
+            NotificationConsent consent = NotificationConsent.create(user, true, false);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
             // when

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.util.Optional;
 
@@ -25,7 +23,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("GetNotificationConsent 테스트")
 class GetNotificationConsentTests {
 
@@ -73,7 +70,7 @@ class GetNotificationConsentTests {
         }
 
         @Test
-        @DisplayName("레코드 존재 + notificationConsent=false이면 false 반환")
+        @DisplayName("레코드 존재 + notificationConsent=false이면 nightNotificationConsent도 false 반환")
         void returnsActualValues_whenNotificationConsentIsFalse() {
             // given
             User user = mock(User.class);
@@ -87,7 +84,7 @@ class GetNotificationConsentTests {
 
             // then
             assertThat(result.notificationConsent()).isFalse();
-            assertThat(result.nightNotificationConsent()).isTrue();
+            assertThat(result.nightNotificationConsent()).isFalse();
         }
 
         @Test

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
@@ -1,0 +1,113 @@
+package com.dreamteam.alter.application.notification.usecase;
+
+import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import com.dreamteam.alter.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("GetNotificationConsent 테스트")
+class GetNotificationConsentTests {
+
+    @Mock
+    private NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    @InjectMocks
+    private GetNotificationConsent getNotificationConsent;
+
+    @Nested
+    @DisplayName("execute")
+    class ExecuteTests {
+
+        @Test
+        @DisplayName("레코드가 없을 때 기본값(notificationConsent=true, nightNotificationConsent=true) 반환")
+        void returnsDefaults_whenNoRecordExists() {
+            // given
+            User user = mock(User.class);
+            GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
+
+            // when
+            GetNotificationConsentResult result = getNotificationConsent.execute(command);
+
+            // then
+            assertThat(result.notificationConsent()).isTrue();
+            assertThat(result.nightNotificationConsent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("레코드 존재 + 둘 다 true이면 그대로 반환")
+        void returnsActualValues_whenBothTrue() {
+            // given
+            User user = mock(User.class);
+            GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
+
+            NotificationConsent consent = NotificationConsent.createDefault(user);
+            // createDefault already sets both to true
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            GetNotificationConsentResult result = getNotificationConsent.execute(command);
+
+            // then
+            assertThat(result.notificationConsent()).isTrue();
+            assertThat(result.nightNotificationConsent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("레코드 존재 + notificationConsent=false이면 false 반환")
+        void returnsActualValues_whenNotificationConsentIsFalse() {
+            // given
+            User user = mock(User.class);
+            GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
+
+            NotificationConsent consent = NotificationConsent.createDefault(user);
+            ReflectionTestUtils.setField(consent, "notificationConsent", false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            GetNotificationConsentResult result = getNotificationConsent.execute(command);
+
+            // then
+            assertThat(result.notificationConsent()).isFalse();
+            assertThat(result.nightNotificationConsent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("레코드 존재 + nightNotificationConsent=false이면 false 반환")
+        void returnsActualValues_whenNightNotificationConsentIsFalse() {
+            // given
+            User user = mock(User.class);
+            GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
+
+            NotificationConsent consent = NotificationConsent.createDefault(user);
+            ReflectionTestUtils.setField(consent, "nightNotificationConsent", false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            GetNotificationConsentResult result = getNotificationConsent.execute(command);
+
+            // then
+            assertThat(result.notificationConsent()).isTrue();
+            assertThat(result.nightNotificationConsent()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.domain.notification.command.GetNotificationConsentCom
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.result.GetNotificationConsentResult;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import com.dreamteam.alter.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -52,7 +53,7 @@ class GetNotificationConsentTests {
         }
 
         @Test
-        @DisplayName("레코드 존재 + 둘 다 true이면 그대로 반환")
+        @DisplayName("레코드 존재 + 둘 다 true이면 GENERAL/NIGHT 모두 true 반환")
         void returnsActualValues_whenBothTrue() {
             // given
             User user = mock(User.class);
@@ -65,13 +66,13 @@ class GetNotificationConsentTests {
             GetNotificationConsentResult result = getNotificationConsent.execute(command);
 
             // then
-            assertThat(result.notificationConsent()).isTrue();
-            assertThat(result.nightNotificationConsent()).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.GENERAL)).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.NIGHT)).isTrue();
         }
 
         @Test
-        @DisplayName("레코드 존재 + notificationConsent=false이면 nightNotificationConsent도 false 반환")
-        void returnsActualValues_whenNotificationConsentIsFalse() {
+        @DisplayName("레코드 존재 + GENERAL=false이면 NIGHT도 false 반환")
+        void returnsActualValues_whenGeneralIsFalse() {
             // given
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
@@ -83,13 +84,13 @@ class GetNotificationConsentTests {
             GetNotificationConsentResult result = getNotificationConsent.execute(command);
 
             // then
-            assertThat(result.notificationConsent()).isFalse();
-            assertThat(result.nightNotificationConsent()).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.GENERAL)).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.NIGHT)).isFalse();
         }
 
         @Test
-        @DisplayName("레코드 존재 + nightNotificationConsent=false이면 false 반환")
-        void returnsActualValues_whenNightNotificationConsentIsFalse() {
+        @DisplayName("레코드 존재 + NIGHT=false이면 false 반환")
+        void returnsActualValues_whenNightIsFalse() {
             // given
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
@@ -101,8 +102,8 @@ class GetNotificationConsentTests {
             GetNotificationConsentResult result = getNotificationConsent.execute(command);
 
             // then
-            assertThat(result.notificationConsent()).isTrue();
-            assertThat(result.nightNotificationConsent()).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.GENERAL)).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.NIGHT)).isFalse();
         }
     }
 }

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
@@ -1,5 +1,7 @@
 package com.dreamteam.alter.application.notification.usecase;
 
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
@@ -15,15 +17,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -44,27 +47,22 @@ class UpdateNotificationConsentTests {
     class ExecuteTests {
 
         @Test
-        @DisplayName("레코드가 없을 때 createDefault 후 updateConsent 호출 + save 호출됨")
-        void createsDefaultAndSaves_whenNoRecordExists() {
+        @DisplayName("레코드가 없을 때 NOT_FOUND 예외를 던지고 save는 호출되지 않음")
+        void throwsNotFound_whenNoRecordExists() {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
                 UpdateNotificationConsentCommand.of(user, true, false);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
-            given(notificationConsentRepository.save(any(NotificationConsent.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
 
-            // when
-            updateNotificationConsent.execute(command);
+            // when & then
+            assertThatThrownBy(() -> updateNotificationConsent.execute(command))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOT_FOUND);
 
-            // then
-            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
-            then(notificationConsentRepository).should().save(captor.capture());
-
-            NotificationConsent saved = captor.getValue();
-            assertThat(saved.isNotificationConsent()).isTrue();
-            assertThat(saved.isNightNotificationConsent()).isFalse();
+            then(notificationConsentRepository).should(never()).save(any(NotificationConsent.class));
         }
 
         @Test
@@ -75,9 +73,7 @@ class UpdateNotificationConsentTests {
             UpdateNotificationConsentCommand command =
                 UpdateNotificationConsentCommand.of(user, true, true);
 
-            NotificationConsent existing = NotificationConsent.createDefault(user);
-            ReflectionTestUtils.setField(existing, "notificationConsent", false);
-            ReflectionTestUtils.setField(existing, "nightNotificationConsent", false);
+            NotificationConsent existing = NotificationConsent.create(user, false, false);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
             given(notificationConsentRepository.save(any(NotificationConsent.class)))
@@ -103,8 +99,7 @@ class UpdateNotificationConsentTests {
             UpdateNotificationConsentCommand command =
                 UpdateNotificationConsentCommand.of(user, true, false);
 
-            NotificationConsent existing = NotificationConsent.createDefault(user);
-            // both flags currently true
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
             given(notificationConsentRepository.save(any(NotificationConsent.class)))
@@ -130,8 +125,7 @@ class UpdateNotificationConsentTests {
             UpdateNotificationConsentCommand command =
                 UpdateNotificationConsentCommand.of(user, false, false);
 
-            NotificationConsent existing = NotificationConsent.createDefault(user);
-            // both flags currently true
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
             given(notificationConsentRepository.save(any(NotificationConsent.class)))

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
@@ -1,0 +1,152 @@
+package com.dreamteam.alter.application.notification.usecase;
+
+import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsentCommand;
+import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
+import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import com.dreamteam.alter.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("UpdateNotificationConsent 테스트")
+class UpdateNotificationConsentTests {
+
+    @Mock
+    private NotificationConsentRepository notificationConsentRepository;
+
+    @Mock
+    private NotificationConsentQueryRepository notificationConsentQueryRepository;
+
+    @InjectMocks
+    private UpdateNotificationConsent updateNotificationConsent;
+
+    @Nested
+    @DisplayName("execute")
+    class ExecuteTests {
+
+        @Test
+        @DisplayName("레코드가 없을 때 createDefault 후 updateConsent 호출 + save 호출됨")
+        void createsDefaultAndSaves_whenNoRecordExists() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, true, false);
+
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
+            given(notificationConsentRepository.save(any(NotificationConsent.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
+            then(notificationConsentRepository).should().save(captor.capture());
+
+            NotificationConsent saved = captor.getValue();
+            assertThat(saved.isNotificationConsent()).isTrue();
+            assertThat(saved.isNightNotificationConsent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("기존 레코드 존재 시 updateConsent 호출 후 save 호출됨")
+        void updatesExistingRecordAndSaves_whenRecordExists() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, true, true);
+
+            NotificationConsent existing = NotificationConsent.createDefault(user);
+            ReflectionTestUtils.setField(existing, "notificationConsent", false);
+            ReflectionTestUtils.setField(existing, "nightNotificationConsent", false);
+
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+            given(notificationConsentRepository.save(any(NotificationConsent.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
+            then(notificationConsentRepository).should().save(captor.capture());
+
+            NotificationConsent saved = captor.getValue();
+            assertThat(saved.isNotificationConsent()).isTrue();
+            assertThat(saved.isNightNotificationConsent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("nightNotificationConsent만 false로 변경 시 그 값으로 저장됨")
+        void savesWithNightConsentFalse_whenOnlyNightConsentChanged() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, true, false);
+
+            NotificationConsent existing = NotificationConsent.createDefault(user);
+            // both flags currently true
+
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+            given(notificationConsentRepository.save(any(NotificationConsent.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
+            then(notificationConsentRepository).should().save(captor.capture());
+
+            NotificationConsent saved = captor.getValue();
+            assertThat(saved.isNotificationConsent()).isTrue();
+            assertThat(saved.isNightNotificationConsent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("두 플래그 모두 false로 변경 시 그 값으로 저장됨")
+        void savesWithBothFlagsFalse_whenBothChanged() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, false, false);
+
+            NotificationConsent existing = NotificationConsent.createDefault(user);
+            // both flags currently true
+
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+            given(notificationConsentRepository.save(any(NotificationConsent.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
+            then(notificationConsentRepository).should().save(captor.capture());
+
+            NotificationConsent saved = captor.getValue();
+            assertThat(saved.isNotificationConsent()).isFalse();
+            assertThat(saved.isNightNotificationConsent()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
@@ -6,12 +6,12 @@ import com.dreamteam.alter.domain.notification.command.UpdateNotificationConsent
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import com.dreamteam.alter.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -49,7 +49,7 @@ class UpdateNotificationConsentTests {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
-                UpdateNotificationConsentCommand.of(user, true, false);
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.GENERAL, true);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.empty());
 
@@ -63,75 +63,103 @@ class UpdateNotificationConsentTests {
         }
 
         @Test
-        @DisplayName("기존 레코드 존재 시 updateConsent 호출 후 save 호출됨")
-        void updatesExistingRecordAndSaves_whenRecordExists() {
+        @DisplayName("GENERAL=true 토글 시 notificationConsent만 변경되어 저장됨")
+        void savesGeneralTrue_keepsNightAsIs() {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
-                UpdateNotificationConsentCommand.of(user, true, true);
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.GENERAL, true);
 
             NotificationConsent existing = NotificationConsent.create(user, false, false);
-
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
 
             // when
             updateNotificationConsent.execute(command);
 
             // then
-            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
-            then(notificationConsentRepository).should().save(captor.capture());
-
-            NotificationConsent saved = captor.getValue();
-            assertThat(saved.isNotificationConsent()).isTrue();
-            assertThat(saved.isNightNotificationConsent()).isTrue();
+            assertThat(existing.isNotificationConsent()).isTrue();
+            assertThat(existing.isNightNotificationConsent()).isFalse();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
         }
 
         @Test
-        @DisplayName("nightNotificationConsent만 false로 변경 시 그 값으로 저장됨")
-        void savesWithNightConsentFalse_whenOnlyNightConsentChanged() {
+        @DisplayName("GENERAL=false 토글 시 NIGHT도 자동으로 false로 cascade")
+        void savesGeneralFalse_cascadesNightToFalse() {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
-                UpdateNotificationConsentCommand.of(user, true, false);
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.GENERAL, false);
 
             NotificationConsent existing = NotificationConsent.create(user, true, true);
-
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
 
             // when
             updateNotificationConsent.execute(command);
 
             // then
-            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
-            then(notificationConsentRepository).should().save(captor.capture());
-
-            NotificationConsent saved = captor.getValue();
-            assertThat(saved.isNotificationConsent()).isTrue();
-            assertThat(saved.isNightNotificationConsent()).isFalse();
+            assertThat(existing.isNotificationConsent()).isFalse();
+            assertThat(existing.isNightNotificationConsent()).isFalse();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
         }
 
         @Test
-        @DisplayName("두 플래그 모두 false로 변경 시 그 값으로 저장됨")
-        void savesWithBothFlagsFalse_whenBothChanged() {
+        @DisplayName("GENERAL=true 상태에서 NIGHT=true 토글 시 정상 저장")
+        void savesNightTrue_whenGeneralIsTrue() {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
-                UpdateNotificationConsentCommand.of(user, false, false);
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.NIGHT, true);
 
-            NotificationConsent existing = NotificationConsent.create(user, true, true);
-
+            NotificationConsent existing = NotificationConsent.create(user, true, false);
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
 
             // when
             updateNotificationConsent.execute(command);
 
             // then
-            ArgumentCaptor<NotificationConsent> captor = ArgumentCaptor.forClass(NotificationConsent.class);
-            then(notificationConsentRepository).should().save(captor.capture());
+            assertThat(existing.isNotificationConsent()).isTrue();
+            assertThat(existing.isNightNotificationConsent()).isTrue();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
+        }
 
-            NotificationConsent saved = captor.getValue();
-            assertThat(saved.isNotificationConsent()).isFalse();
-            assertThat(saved.isNightNotificationConsent()).isFalse();
+        @Test
+        @DisplayName("GENERAL=false 상태에서 NIGHT=true 토글 시 ILLEGAL_ARGUMENT 예외, save 미호출")
+        void throwsIllegalArgument_whenNightTrueWithGeneralFalse() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.NIGHT, true);
+
+            NotificationConsent existing = NotificationConsent.create(user, false, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when & then
+            assertThatThrownBy(() -> updateNotificationConsent.execute(command))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
+
+            then(notificationConsentRepository).should(never()).save(any(NotificationConsent.class));
+        }
+
+        @Test
+        @DisplayName("NIGHT=false 토글 시 GENERAL은 유지하고 NIGHT만 false로 저장")
+        void savesNightFalse_keepsGeneralAsIs() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.NIGHT, false);
+
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            assertThat(existing.isNotificationConsent()).isTrue();
+            assertThat(existing.isNightNotificationConsent()).isFalse();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
         }
     }
 }

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
@@ -15,8 +15,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.util.Optional;
 
@@ -29,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("UpdateNotificationConsent 테스트")
 class UpdateNotificationConsentTests {
 
@@ -76,8 +73,6 @@ class UpdateNotificationConsentTests {
             NotificationConsent existing = NotificationConsent.create(user, false, false);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
-            given(notificationConsentRepository.save(any(NotificationConsent.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             updateNotificationConsent.execute(command);
@@ -102,8 +97,6 @@ class UpdateNotificationConsentTests {
             NotificationConsent existing = NotificationConsent.create(user, true, true);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
-            given(notificationConsentRepository.save(any(NotificationConsent.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             updateNotificationConsent.execute(command);
@@ -128,8 +121,6 @@ class UpdateNotificationConsentTests {
             NotificationConsent existing = NotificationConsent.create(user, true, true);
 
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
-            given(notificationConsentRepository.save(any(NotificationConsent.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             updateNotificationConsent.execute(command);

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -69,7 +70,9 @@ class CreateUserWithSocialTests {
             "김철수",
             "유땡땡",
             UserGender.GENDER_MALE,
-            "19900101"
+            "19900101",
+            true,
+            false
         );
     }
 
@@ -98,7 +101,7 @@ class CreateUserWithSocialTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.SIGNUP_SESSION_NOT_EXIST));
 
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
         }
 
         @Test
@@ -115,7 +118,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.NICKNAME_DUPLICATED));
 
             then(cacheRepository).should().deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
         }
 
         @Test
@@ -133,7 +136,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.USER_CONTACT_DUPLICATED));
 
             then(cacheRepository).should().deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
         }
 
         @Test
@@ -156,7 +159,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.SOCIAL_ID_DUPLICATED));
 
             then(cacheRepository).should(never()).deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
         }
 
         @Test
@@ -180,7 +183,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.EMAIL_DUPLICATED));
 
             then(cacheRepository).should(never()).deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
         }
 
         @Test
@@ -198,14 +201,14 @@ class CreateUserWithSocialTests {
 
             // TX 저장
             GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
-            given(createUserWithSocialTx.process(any(), any(), any())).willReturn(mockResponse);
+            given(createUserWithSocialTx.process(any(), any(), any(), anyBoolean(), anyBoolean())).willReturn(mockResponse);
 
             // when
             GenerateTokenResponseDto result = createUserWithSocial.execute(request);
 
             // then
             assertThat(result).isEqualTo(mockResponse);
-            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any());
+            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), anyBoolean(), anyBoolean());
             then(cacheRepository).should().deleteAll(anyList());
         }
     }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -201,14 +201,14 @@ class CreateUserWithSocialTests {
 
             // TX 저장
             GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
-            given(createUserWithSocialTx.process(any(), any(), any(), anyBoolean(), anyBoolean())).willReturn(mockResponse);
+            given(createUserWithSocialTx.process(any(), any(), any(), eq(true), eq(false))).willReturn(mockResponse);
 
             // when
             GenerateTokenResponseDto result = createUserWithSocial.execute(request);
 
             // then
             assertThat(result).isEqualTo(mockResponse);
-            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), eq(true), eq(false));
             then(cacheRepository).should().deleteAll(anyList());
         }
     }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/LogoutManagerTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/LogoutManagerTests.java
@@ -1,0 +1,73 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.notification.NotificationService;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.user.entity.ManagerUser;
+import com.dreamteam.alter.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("LogoutManager 테스트")
+class LogoutManagerTests {
+
+    @Mock private AuthService authService;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private LogoutManager logoutManager;
+
+    private ManagerActor actor;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+        ManagerUser managerUser = mock(ManagerUser.class);
+        given(managerUser.getUser()).willReturn(user);
+
+        actor = mock(ManagerActor.class);
+        given(actor.getManagerUser()).willReturn(managerUser);
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class ExecuteTests {
+
+        @Test
+        @DisplayName("execute() → authService.revokeAllExistingAuthorizations() 호출")
+        void calls_revokeAllExistingAuthorizations() {
+            // when
+            logoutManager.execute(actor);
+
+            // then
+            then(authService).should().revokeAllExistingAuthorizations(user);
+        }
+
+        @Test
+        @DisplayName("execute() → notificationService.removeUserDeviceToken(user) 호출")
+        void calls_removeUserDeviceToken() {
+            // when
+            logoutManager.execute(actor);
+
+            // then
+            then(notificationService).should().removeUserDeviceToken(user);
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/LogoutManagerTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/LogoutManagerTests.java
@@ -13,15 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("LogoutManager 테스트")
 class LogoutManagerTests {
 
@@ -37,7 +34,6 @@ class LogoutManagerTests {
     @BeforeEach
     void setUp() {
         user = mock(User.class);
-        given(user.getId()).willReturn(1L);
 
         ManagerUser managerUser = mock(ManagerUser.class);
         given(managerUser.getUser()).willReturn(user);


### PR DESCRIPTION
## 변경사항

- 알림 수신 동의 설정 API 구현 및 FCM 발송 필터링 적용
- 로그아웃 시 FCM 디바이스 토큰 삭제
- 회원가입 시 알림 수신 동의 수집 추가
- 알림 수신 동의 조회/수정 테스트 NOT_FOUND 동작 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자·매니저용 알림 동의 API 추가 — 일반/야간 알림 조회·수정 가능
  * 가입 요청에 알림 동의 필드 추가 및 가입 시 동의 정보 영속화
  * 알림 수신 동의 엔티티·조회·저장 흐름 및 관련 인터페이스 추가
  * 알림 전송에 동의 및 야간 시간대를 반영한 차단 로직 적용
* **테스트**
  * 동의 기반 알림 전송 필터링 및 조회/수정 유스케이스에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->