### PR TITLE
feat: [ALT-208] 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfController.java
@@ -50,6 +50,7 @@ import com.dreamteam.alter.domain.user.port.inbound.UpdateNicknameUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdatePasswordUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdateUserProfileImageUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdateUserSelfCertificateUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
 
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -103,6 +104,9 @@ public class UserSelfController implements UserSelfControllerSpec {
 
     @Resource(name = "deleteUserProfileImage")
     private final DeleteUserProfileImageUseCase deleteUserProfileImage;
+
+    @Resource(name = "withdrawalUser")
+    private final WithdrawalUserUseCase withdrawalUser;
 
     @Override
     @GetMapping
@@ -242,6 +246,14 @@ public class UserSelfController implements UserSelfControllerSpec {
     public ResponseEntity<CommonApiResponse<Void>> deleteProfileImage() {
         AppActor actor = AppActionContext.getInstance().getActor();
         deleteUserProfileImage.execute(actor.getUser());
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<CommonApiResponse<Void>> withdraw() {
+        AppActor actor = AppActionContext.getInstance().getActor();
+        withdrawalUser.execute(actor.getUser());
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserSelfControllerSpec.java
@@ -316,4 +316,13 @@ public interface UserSelfControllerSpec {
                 }))
     })
     ResponseEntity<CommonApiResponse<Void>> deleteProfileImage();
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "본인 계정을 탈퇴 처리하고, 활성 근무지는 퇴직 처리합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+    })
+    ResponseEntity<CommonApiResponse<Void>> withdraw();
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerSelfController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerSelfController.java
@@ -20,6 +20,7 @@ import com.dreamteam.alter.adapter.inbound.manager.user.dto.RegisterEmailRequest
 import com.dreamteam.alter.adapter.inbound.manager.user.dto.UpdateManagerProfileImageRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.user.dto.UpdateNicknameRequestDto;
 import com.dreamteam.alter.adapter.inbound.manager.user.dto.UpdatePasswordRequestDto;
+import com.dreamteam.alter.application.aop.AppActionContext;
 import com.dreamteam.alter.application.aop.ManagerActionContext;
 import com.dreamteam.alter.domain.email.command.SendEmailVerificationCodeCommand;
 import com.dreamteam.alter.domain.email.command.VerifyEmailVerificationCodeCommand;
@@ -30,6 +31,7 @@ import com.dreamteam.alter.domain.user.command.RemoveEmailCommand;
 import com.dreamteam.alter.domain.user.command.UpdateEmailCommand;
 import com.dreamteam.alter.domain.user.command.UpdateNicknameCommand;
 import com.dreamteam.alter.domain.user.command.UpdatePasswordCommand;
+import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.inbound.DeleteUserProfileImageUseCase;
@@ -39,6 +41,7 @@ import com.dreamteam.alter.domain.user.port.inbound.UpdateEmailUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdateNicknameUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdatePasswordUseCase;
 import com.dreamteam.alter.domain.user.port.inbound.UpdateUserProfileImageUseCase;
+import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
 
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -77,6 +80,9 @@ public class ManagerSelfController implements ManagerSelfControllerSpec {
 
     @Resource(name = "deleteUserProfileImage")
     private final DeleteUserProfileImageUseCase deleteUserProfileImage;
+
+    @Resource(name = "withdrawalUser")
+    private final WithdrawalUserUseCase withdrawalUser;
 
     @Override
     @GetMapping
@@ -156,6 +162,13 @@ public class ManagerSelfController implements ManagerSelfControllerSpec {
     @DeleteMapping("/profile-image")
     public ResponseEntity<CommonApiResponse<Void>> deleteProfileImage() {
         deleteUserProfileImage.execute(currentUser());
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<CommonApiResponse<Void>> withdraw() {
+        withdrawalUser.execute(currentUser());
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerSelfControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/user/controller/ManagerSelfControllerSpec.java
@@ -259,4 +259,23 @@ public interface ManagerSelfControllerSpec {
     })
     ResponseEntity<CommonApiResponse<Void>> deleteProfileImage();
 
+    @Operation(
+        summary = "매니저 회원 탈퇴",
+        description = "본인 계정을 탈퇴 처리하고,  활성화된 업장을 보유한 경우 탈퇴할 수 없습니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "매니저 회원 탈퇴 성공"),
+        @ApiResponse(responseCode = "409", description = "변경할 수 없는 상태",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "활성화된 업장 보유",
+                        value = "{\"code\" : \"B020\", \"message\" : \"활성화된 업장이 있습니다.\"}"
+                    )
+                }))
+    })
+    ResponseEntity<CommonApiResponse<Void>> withdraw();
+
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingApplicationQueryRepositoryImpl.java
@@ -313,11 +313,27 @@ public class PostingApplicationQueryRepositoryImpl implements PostingApplication
     ) {
         BooleanExpression managerCondition = qManagerUser.eq(managerUser);
         BooleanExpression workspaceCondition = eqWorkspaceId(qWorkspace, filter.getWorkspaceId());
-        
+
         if (ObjectUtils.isNotEmpty(workspaceCondition)) {
             return managerCondition.and(workspaceCondition);
         }
         return managerCondition;
+    }
+
+    @Override
+    public List<PostingApplication> findAllActiveByUserId(Long userId) {
+        QPostingApplication qPostingApplication = QPostingApplication.postingApplication;
+        return queryFactory
+            .selectFrom(qPostingApplication)
+            .where(
+                qPostingApplication.user.id.eq(userId),
+                qPostingApplication.status.in(
+                    PostingApplicationStatus.SUBMITTED,
+                    PostingApplicationStatus.SHORTLISTED,
+                    PostingApplicationStatus.ACCEPTED
+                )
+            )
+            .fetch();
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserCertificateJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserCertificateJpaRepository.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.entity.UserCertificate;
+
+public interface UserCertificateJpaRepository extends JpaRepository<UserCertificate, Long> {
+	void deleteAllByUser(User user);
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserCertificateRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserCertificateRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.outbound.user.persistence;
+
+import org.springframework.stereotype.Repository;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCertificateRepositoryImpl implements UserCertificateRepository {
+
+	private final UserCertificateJpaRepository userCertificateJpaRepository;
+
+	@Override
+	public void deleteAll(User user) {
+		userCertificateJpaRepository.deleteAllByUser(user);
+	}
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.dreamteam.alter.adapter.outbound.user.persistence;
 
+import java.util.List;
+
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 import com.dreamteam.alter.domain.user.port.outbound.UserSocialRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,5 +16,10 @@ public class UserSocialRepositoryImpl implements UserSocialRepository {
     @Override
     public void delete(UserSocial userSocial) {
         userSocialJpaRepository.delete(userSocial);
+    }
+
+    @Override
+    public void deleteAll(List<UserSocial> userSocials) {
+        userSocialJpaRepository.deleteAll(userSocials);
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
@@ -1,11 +1,11 @@
 package com.dreamteam.alter.adapter.outbound.user.persistence;
 
-import java.util.List;
+import org.springframework.stereotype.Repository;
 
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 import com.dreamteam.alter.domain.user.port.outbound.UserSocialRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/user/persistence/UserSocialRepositoryImpl.java
@@ -17,9 +17,4 @@ public class UserSocialRepositoryImpl implements UserSocialRepository {
     public void delete(UserSocial userSocial) {
         userSocialJpaRepository.delete(userSocial);
     }
-
-    @Override
-    public void deleteAll(List<UserSocial> userSocials) {
-        userSocialJpaRepository.deleteAll(userSocials);
-    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -12,9 +12,11 @@ import com.dreamteam.alter.domain.user.entity.QUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.QWorkspaceWorker;
 import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.entity.QSubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
 import com.dreamteam.alter.domain.workspace.type.SubstituteRequestStatus;
+import com.dreamteam.alter.domain.workspace.type.SubstituteRequestTargetStatus;
 import com.dreamteam.alter.domain.workspace.type.SubstituteRequestType;
 import com.dreamteam.alter.domain.workspace.type.WorkspaceWorkerStatus;
 import com.querydsl.core.types.Projections;
@@ -423,8 +425,33 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             // 상태가 지정되지 않은 경우 모든 조회 가능한 상태 조회
             return substituteRequest.status.in(SubstituteRequestStatus.getManagerViewableStatuses());
         }
-        
+
         // 특정 상태가 지정된 경우 해당 상태만 조회
         return substituteRequest.status.eq(status);
+    }
+
+    @Override
+    public List<SubstituteRequest> findAllActiveByRequesterUserId(Long userId) {
+        return queryFactory
+            .selectFrom(substituteRequest)
+            .join(workspaceWorker).on(workspaceWorker.id.eq(substituteRequest.requesterId))
+            .where(
+                workspaceWorker.user.id.eq(userId),
+                substituteRequest.status.in(SubstituteRequestStatus.PENDING, SubstituteRequestStatus.ACCEPTED)
+            )
+            .fetch();
+    }
+
+    @Override
+    public List<SubstituteRequestTarget> findAllPendingTargetsByUserId(Long userId) {
+        QSubstituteRequestTarget target = QSubstituteRequestTarget.substituteRequestTarget;
+        return queryFactory
+            .selectFrom(target)
+            .join(workspaceWorker).on(workspaceWorker.id.eq(target.targetWorkerId))
+            .where(
+                workspaceWorker.user.id.eq(userId),
+                target.status.eq(SubstituteRequestTargetStatus.PENDING)
+            )
+            .fetch();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
@@ -612,6 +612,22 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         return result != null;
     }
 
+    @Override
+    public boolean existsActiveWorkspaceByUserId(Long userId) {
+        QWorkspace qWorkspace = QWorkspace.workspace;
+
+        Integer result = queryFactory
+            .selectOne()
+            .from(qWorkspace)
+            .where(
+                qWorkspace.managerUser.user.id.eq(userId),
+                qWorkspace.status.eq(WorkspaceStatus.ACTIVATED)
+            )
+            .fetchFirst();
+
+        return result != null;
+    }
+
     private BooleanExpression eqWorkerStatus(QWorkspaceWorker qWorkspaceWorker, WorkspaceWorkerStatus status) {
         return status != null ? qWorkspaceWorker.status.eq(status) : null;
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerQueryRepositoryImpl.java
@@ -69,6 +69,16 @@ public class WorkspaceWorkerQueryRepositoryImpl implements WorkspaceWorkerQueryR
     }
 
     @Override
+    public List<WorkspaceWorker> findAllActiveByUserId(Long userId) {
+        QWorkspaceWorker qWorkspaceWorker = QWorkspaceWorker.workspaceWorker;
+
+        return queryFactory.selectFrom(qWorkspaceWorker)
+            .where(qWorkspaceWorker.user.id.eq(userId)
+                .and(qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED)))
+            .fetch();
+    }
+
+    @Override
     public long getUserActiveWorkspaceCount(User user) {
         QWorkspaceWorker qWorkspaceWorker = QWorkspaceWorker.workspaceWorker;
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerScheduleQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerScheduleQueryRepositoryImpl.java
@@ -85,4 +85,19 @@ public class WorkspaceWorkerScheduleQueryRepositoryImpl implements WorkspaceWork
 			)
 			.fetch();
 	}
+
+	@Override
+	public List<WorkspaceWorkerSchedule> findAllActivatedByUserId(Long userId) {
+		QWorkspaceWorkerSchedule qWorkspaceWorkerSchedule = QWorkspaceWorkerSchedule.workspaceWorkerSchedule;
+		QWorkspaceWorker qWorkspaceWorker = QWorkspaceWorker.workspaceWorker;
+
+		return queryFactory
+			.selectFrom(qWorkspaceWorkerSchedule)
+			.join(qWorkspaceWorkerSchedule.workspaceWorker, qWorkspaceWorker)
+			.where(
+				qWorkspaceWorker.user.id.eq(userId),
+				qWorkspaceWorkerSchedule.status.eq(WorkspaceWorkerScheduleStatus.ACTIVATED)
+			)
+			.fetch();
+	}
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
@@ -13,7 +13,6 @@ import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
-import com.dreamteam.alter.domain.user.port.outbound.UserSocialRepository;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
@@ -28,7 +27,6 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 	private final UserRepository userRepository;
 	private final WorkspaceQueryRepository workspaceQueryRepository;
 	private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
-	private final UserSocialRepository userSocialRepository;
 	private final FileQueryRepository fileQueryRepository;
 	private final AuthService authService;
 	private final NotificationService notificationService;
@@ -51,7 +49,6 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 		fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, user.getId().toString())
 			.ifPresent(File::markDeleted);
 
-		userSocialRepository.deleteAll(user.getUserSocials()); 	// 소셜 연동 해제
 		authService.revokeAllExistingAuthorizations(user);		// 인가 정보 삭제
 		notificationService.removeUserDeviceToken(user);		// 다비이스 토큰 삭제
 	}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
@@ -10,17 +10,24 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.file.entity.File;
 import com.dreamteam.alter.domain.file.port.outbound.FileQueryRepository;
 import com.dreamteam.alter.domain.file.type.FileTargetType;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingApplicationQueryRepository;
+import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
+import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
-@Service( "withdrawalUser")
+@Service("withdrawalUser")
 @RequiredArgsConstructor
 @Transactional
 public class WithdrawalUser implements WithdrawalUserUseCase {
@@ -29,6 +36,9 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 	private final UserCertificateRepository userCertificateRepository;
 	private final WorkspaceQueryRepository workspaceQueryRepository;
 	private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+	private final WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
+	private final SubstituteRequestQueryRepository substituteRequestQueryRepository;
+	private final PostingApplicationQueryRepository postingApplicationQueryRepository;
 	private final FileQueryRepository fileQueryRepository;
 	private final AuthService authService;
 	private final NotificationService notificationService;
@@ -44,15 +54,31 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 		userRepository.save(user);
 		userCertificateRepository.deleteAll(user);
 
-		// 활설화된 근무지 퇴직처리
+		// 활성화된 근무지 퇴직처리
 		workspaceWorkerQueryRepository.findAllActiveByUserId(user.getId())
 			.forEach(WorkspaceWorker::resign);
+
+		// 고정근무 스케줄 삭제
+		workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(user.getId())
+			.forEach(WorkspaceWorkerSchedule::delete);
+
+		// 본인이 요청자인 활성 대타 요청 취소 (자식 target 까지 cascade)
+		substituteRequestQueryRepository.findAllActiveByRequesterUserId(user.getId())
+			.forEach(SubstituteRequest::cancel);
+
+		// 본인이 PENDING target 으로 지정된 대타 요청 target 행 취소
+		substituteRequestQueryRepository.findAllPendingTargetsByUserId(user.getId())
+			.forEach(SubstituteRequestTarget::cancel);
+
+		// 본인이 지원한 활성 PostingApplication 취소
+		postingApplicationQueryRepository.findAllActiveByUserId(user.getId())
+			.forEach(application -> application.updateStatus(PostingApplicationStatus.CANCELLED));
 
 		// 프로필 이미지 삭제
 		fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, user.getId().toString())
 			.ifPresent(File::markDeleted);
 
 		authService.revokeAllExistingAuthorizations(user);		// 인가 정보 삭제
-		notificationService.removeUserDeviceToken(user);		// 다비이스 토큰 삭제
+		notificationService.removeUserDeviceToken(user);		// 디바이스 토큰 삭제
 	}
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
@@ -1,0 +1,58 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.notification.NotificationService;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.file.entity.File;
+import com.dreamteam.alter.domain.file.port.outbound.FileQueryRepository;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
+import com.dreamteam.alter.domain.user.port.outbound.UserSocialRepository;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service( "withdrawalUser")
+@RequiredArgsConstructor
+@Transactional
+public class WithdrawalUser implements WithdrawalUserUseCase {
+
+	private final UserRepository userRepository;
+	private final WorkspaceQueryRepository workspaceQueryRepository;
+	private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+	private final UserSocialRepository userSocialRepository;
+	private final FileQueryRepository fileQueryRepository;
+	private final AuthService authService;
+	private final NotificationService notificationService;
+
+	@Override
+	public void execute(User user) {
+		// (매니저) 활성 업장 보유시 차단
+		if (workspaceQueryRepository.existsActiveWorkspaceByUserId(user.getId())) {
+			throw new CustomException(ErrorCode.CONFLICT, "활성화된 업장이 있습니다.");
+		}
+
+		user.withdraw();
+		userRepository.save(user);
+
+		// 활설화된 근무지 퇴직처리
+		workspaceWorkerQueryRepository.findAllActiveByUserId(user.getId())
+			.forEach(WorkspaceWorker::resign);
+
+		// 프로필 이미지 삭제
+		fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, user.getId().toString())
+			.ifPresent(File::markDeleted);
+
+		userSocialRepository.deleteAll(user.getUserSocials()); 	// 소셜 연동 해제
+		authService.revokeAllExistingAuthorizations(user);		// 인가 정보 삭제
+		notificationService.removeUserDeviceToken(user);		// 다비이스 토큰 삭제
+	}
+}

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
@@ -12,6 +12,7 @@ import com.dreamteam.alter.domain.file.port.outbound.FileQueryRepository;
 import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
+import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class WithdrawalUser implements WithdrawalUserUseCase {
 
 	private final UserRepository userRepository;
+	private final UserCertificateRepository userCertificateRepository;
 	private final WorkspaceQueryRepository workspaceQueryRepository;
 	private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
 	private final FileQueryRepository fileQueryRepository;
@@ -40,6 +42,7 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 
 		user.withdraw();
 		userRepository.save(user);
+		userCertificateRepository.deleteAll(user);
 
 		// 활설화된 근무지 퇴직처리
 		workspaceWorkerQueryRepository.findAllActiveByUserId(user.getId())

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingApplicationQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingApplicationQueryRepository.java
@@ -35,4 +35,6 @@ public interface PostingApplicationQueryRepository {
 
     Optional<PostingApplication> getByManagerAndId(ManagerUser managerUser, Long postingApplicationId);
 
+    List<PostingApplication> findAllActiveByUserId(Long userId);
+
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -174,6 +174,7 @@ public class User {
         contact = anonymize;
         email = null;
         birthday = "00000000";
+        password = null;
         userSocials.clear();
         status = UserStatus.DELETED;
     }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -174,7 +174,6 @@ public class User {
         contact = anonymize;
         email = null;
         birthday = "00000000";
-        certificates.clear();
         userSocials.clear();
         status = UserStatus.DELETED;
     }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -164,12 +164,17 @@ public class User {
         this.status = newStatus;
     }
 
+    /**
+     * 탈퇴 처리
+     */
     public void withdraw() {
         String anonymize = id + "_탈퇴";
         name = anonymize;
         nickname = anonymize;
         contact = anonymize;
         email = null;
+        certificates.clear();
+        userSocials.clear();
         status = UserStatus.DELETED;
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -173,6 +173,7 @@ public class User {
         nickname = anonymize;
         contact = anonymize;
         email = null;
+        birthday = "00000000";
         certificates.clear();
         userSocials.clear();
         status = UserStatus.DELETED;

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -163,4 +163,13 @@ public class User {
         }
         this.status = newStatus;
     }
+
+    public void withdraw() {
+        String anonymize = id + "_탈퇴";
+        name = anonymize;
+        nickname = anonymize;
+        contact = anonymize;
+        email = null;
+        status = UserStatus.DELETED;
+    }
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/inbound/WithdrawalUserUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/inbound/WithdrawalUserUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.user.port.inbound;
+
+import com.dreamteam.alter.domain.user.entity.User;
+
+public interface WithdrawalUserUseCase {
+	void execute(User user);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserCertificateRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserCertificateRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.user.port.outbound;
+
+import com.dreamteam.alter.domain.user.entity.User;
+
+public interface UserCertificateRepository {
+	void deleteAll(User user);
+}

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserSocialRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserSocialRepository.java
@@ -1,7 +1,11 @@
 package com.dreamteam.alter.domain.user.port.outbound;
 
+import java.util.List;
+
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 
 public interface UserSocialRepository {
     void delete(UserSocial userSocial);
+
+    void deleteAll(List<UserSocial> userSocials);
 }

--- a/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserSocialRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/port/outbound/UserSocialRepository.java
@@ -1,11 +1,7 @@
 package com.dreamteam.alter.domain.user.port.outbound;
 
-import java.util.List;
-
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 
 public interface UserSocialRepository {
     void delete(UserSocial userSocial);
-
-    void deleteAll(List<UserSocial> userSocials);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/SubstituteRequestQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/SubstituteRequestQueryRepository.java
@@ -9,6 +9,7 @@ import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.SentS
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.SentSubstituteRequestDetailResponse;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.type.SubstituteRequestStatus;
 
 import java.time.LocalDateTime;
@@ -45,5 +46,8 @@ public interface SubstituteRequestQueryRepository {
     );
     
     Optional<SentSubstituteRequestDetailResponse> getSentRequestDetail(User user, Long requestId);
+
+    List<SubstituteRequest> findAllActiveByRequesterUserId(Long userId);
+    List<SubstituteRequestTarget> findAllPendingTargetsByUserId(Long userId);
 }
 

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceQueryRepository.java
@@ -78,4 +78,6 @@ public interface WorkspaceQueryRepository {
     List<Workspace> findAllForNextMonthShiftGeneration(int day, boolean isLastDayOfMonth);
     Set<Long> findActiveWorkerUserIds(Long workspaceId);
     Set<Long> findActiveWorkerUserIdsByUserIds(Long workspaceId, Set<Long> userIds);
+
+    boolean existsActiveWorkspaceByUserId(Long userId);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerQueryRepository.java
@@ -14,6 +14,7 @@ public interface WorkspaceWorkerQueryRepository {
     Optional<WorkspaceWorker> findActiveWorkerByWorkspaceAndUser(Workspace workspace, User user);
     Optional<WorkspaceWorker> findById(Long id);
     List<WorkspaceWorker> findAllById(List<Long> ids);
+    List<WorkspaceWorker> findAllActiveByUserId(Long userId);
     
     long getUserActiveWorkspaceCount(User user);
     

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerScheduleQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerScheduleQueryRepository.java
@@ -11,4 +11,5 @@ public interface WorkspaceWorkerScheduleQueryRepository {
 	Optional<WorkspaceWorkerSchedule> getByIdWithWorkspaceWorker(Long workerScheduleId);
 	List<WorkspaceWorkerSchedule> getByWorkspaceWorker(WorkspaceWorker workspaceWorker);
 	List<WorkspaceWorkerSchedule> findAllActivatedWithWorkspaceWorkerByWorkspaceIds(List<Long> workspaceIds);
+	List<WorkspaceWorkerSchedule> findAllActivatedByUserId(Long userId);
 }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/WithdrawalUserTest.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/WithdrawalUserTest.java
@@ -1,0 +1,180 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.application.auth.service.AuthService;
+import com.dreamteam.alter.application.notification.NotificationService;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.file.entity.File;
+import com.dreamteam.alter.domain.file.port.outbound.FileQueryRepository;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
+import com.dreamteam.alter.domain.posting.entity.PostingApplication;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingApplicationQueryRepository;
+import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
+import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
+import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WithdrawalUser 테스트")
+class WithdrawalUserTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserCertificateRepository userCertificateRepository;
+
+    @Mock
+    private WorkspaceQueryRepository workspaceQueryRepository;
+
+    @Mock
+    private WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+
+    @Mock
+    private WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
+
+    @Mock
+    private SubstituteRequestQueryRepository substituteRequestQueryRepository;
+
+    @Mock
+    private PostingApplicationQueryRepository postingApplicationQueryRepository;
+
+    @Mock
+    private FileQueryRepository fileQueryRepository;
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private WithdrawalUser withdrawalUser;
+
+    @Test
+    @DisplayName("활성 업장 보유 시 CONFLICT 예외 발생 및 후속 정리 로직 호출되지 않음")
+    void execute_활성업장보유_예외발생() {
+        // given
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(1L);
+        when(workspaceQueryRepository.existsActiveWorkspaceByUserId(1L)).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> withdrawalUser.execute(user));
+
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+        verify(user, never()).withdraw();
+        verifyNoInteractions(userRepository);
+        verifyNoInteractions(userCertificateRepository);
+        verifyNoInteractions(workspaceWorkerQueryRepository);
+        verifyNoInteractions(workspaceWorkerScheduleQueryRepository);
+        verifyNoInteractions(substituteRequestQueryRepository);
+        verifyNoInteractions(postingApplicationQueryRepository);
+        verifyNoInteractions(fileQueryRepository);
+        verifyNoInteractions(authService);
+        verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    @DisplayName("정상 탈퇴 흐름 - 모든 정리 로직이 호출되고 SubstituteRequest/Target/PostingApplication 이 취소된다")
+    void execute_정상탈퇴_모든정리호출() {
+        // given
+        Long userId = 10L;
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(userId);
+        when(workspaceQueryRepository.existsActiveWorkspaceByUserId(userId)).thenReturn(false);
+
+        WorkspaceWorker activeWorker = mock(WorkspaceWorker.class);
+        when(workspaceWorkerQueryRepository.findAllActiveByUserId(userId))
+            .thenReturn(List.of(activeWorker));
+
+        WorkspaceWorkerSchedule activeSchedule = mock(WorkspaceWorkerSchedule.class);
+        when(workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(userId))
+            .thenReturn(List.of(activeSchedule));
+
+        SubstituteRequest activeRequest = mock(SubstituteRequest.class);
+        when(substituteRequestQueryRepository.findAllActiveByRequesterUserId(userId))
+            .thenReturn(List.of(activeRequest));
+
+        SubstituteRequestTarget pendingTarget = mock(SubstituteRequestTarget.class);
+        when(substituteRequestQueryRepository.findAllPendingTargetsByUserId(userId))
+            .thenReturn(List.of(pendingTarget));
+
+        PostingApplication activeApplication = mock(PostingApplication.class);
+        when(postingApplicationQueryRepository.findAllActiveByUserId(userId))
+            .thenReturn(List.of(activeApplication));
+
+        File profileImage = mock(File.class);
+        when(fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, userId.toString()))
+            .thenReturn(Optional.of(profileImage));
+
+        // when
+        withdrawalUser.execute(user);
+
+        // then
+        verify(user, times(1)).withdraw();
+        verify(userRepository, times(1)).save(user);
+        verify(userCertificateRepository, times(1)).deleteAll(user);
+        verify(activeWorker, times(1)).resign();
+        verify(activeSchedule, times(1)).delete();
+        verify(activeRequest, times(1)).cancel();
+        verify(pendingTarget, times(1)).cancel();
+        verify(activeApplication, times(1)).updateStatus(PostingApplicationStatus.CANCELLED);
+        verify(profileImage, times(1)).markDeleted();
+        verify(authService, times(1)).revokeAllExistingAuthorizations(user);
+        verify(notificationService, times(1)).removeUserDeviceToken(user);
+    }
+
+    @Test
+    @DisplayName("정리 대상이 비어있어도 정상 탈퇴 흐름이 완료된다")
+    void execute_정리대상없음_정상완료() {
+        // given
+        Long userId = 20L;
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(userId);
+        when(workspaceQueryRepository.existsActiveWorkspaceByUserId(userId)).thenReturn(false);
+        when(workspaceWorkerQueryRepository.findAllActiveByUserId(userId)).thenReturn(List.of());
+        when(workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(userId)).thenReturn(List.of());
+        when(substituteRequestQueryRepository.findAllActiveByRequesterUserId(userId)).thenReturn(List.of());
+        when(substituteRequestQueryRepository.findAllPendingTargetsByUserId(userId)).thenReturn(List.of());
+        when(postingApplicationQueryRepository.findAllActiveByUserId(userId)).thenReturn(List.of());
+        when(fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, userId.toString()))
+            .thenReturn(Optional.empty());
+
+        // when
+        withdrawalUser.execute(user);
+
+        // then
+        verify(user, times(1)).withdraw();
+        verify(userRepository, times(1)).save(user);
+        verify(userCertificateRepository, times(1)).deleteAll(user);
+        verify(authService, times(1)).revokeAllExistingAuthorizations(user);
+        verify(notificationService, times(1)).removeUserDeviceToken(user);
+    }
+}


### PR DESCRIPTION
## 관련 문서
[https://www.notion.so/BE-355865531628809c8fa5fa15368fa284?source=copy_link](https://www.notion.so/BE-355865531628809c8fa5fa15368fa284?source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원(일반/매니저) 탈퇴 API가 추가되었습니다.
* **동작 제약**
  * 매니저는 활성 업장이 없을 때만 탈퇴할 수 있습니다.
* **영향/동작**
  * 탈퇴 시 사용자 정보 익명화, 인증·증명서 삭제, 근무·대체 요청·지원서 정리, 권한 및 알림 토큰 회수 등이 수행됩니다.
* **테스트**
  * 탈퇴 시 정상/충돌 케이스를 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->