### PR TITLE
feat: [ALT-214] 회원가입 약관 동의 API 구현

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicController.java
@@ -1,0 +1,30 @@
+package com.dreamteam.alter.adapter.inbound.general.terms.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+import com.dreamteam.alter.domain.terms.port.inbound.GetPublishedTermsListUseCase;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/public/terms")
+@RequiredArgsConstructor
+@Validated
+public class TermsPublicController implements TermsPublicControllerSpec {
+
+    @Resource(name = "getPublishedTermsList")
+    private final GetPublishedTermsListUseCase getPublishedTermsList;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<CommonApiResponse<List<PublishedTermsItemResponseDto>>> getPublishedTermsList() {
+        return ResponseEntity.ok(CommonApiResponse.of(getPublishedTermsList.execute()));
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicController.java
@@ -25,6 +25,11 @@ public class TermsPublicController implements TermsPublicControllerSpec {
     @Override
     @GetMapping
     public ResponseEntity<CommonApiResponse<List<PublishedTermsItemResponseDto>>> getPublishedTermsList() {
-        return ResponseEntity.ok(CommonApiResponse.of(getPublishedTermsList.execute()));
+        return ResponseEntity.ok(CommonApiResponse.of(
+            getPublishedTermsList.execute()
+                .stream()
+                .map(PublishedTermsItemResponseDto::from)
+                .toList()
+        ));
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/controller/TermsPublicControllerSpec.java
@@ -1,0 +1,21 @@
+package com.dreamteam.alter.adapter.inbound.general.terms.controller;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Public - 약관")
+public interface TermsPublicControllerSpec {
+
+    @Operation(summary = "게시된 약관 목록 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "약관 목록 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<List<PublishedTermsItemResponseDto>>> getPublishedTermsList();
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/dto/PublishedTermsItemResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/dto/PublishedTermsItemResponseDto.java
@@ -1,7 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.general.terms.dto;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
-import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.result.GetPublishedTermsListResult;
 import com.dreamteam.alter.domain.terms.type.TermsType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -40,15 +40,15 @@ public class PublishedTermsItemResponseDto {
     @Schema(description = "게시 일시", example = "2025-01-01T12:00:00")
     private LocalDateTime effectiveAt;
 
-    public static PublishedTermsItemResponseDto from(Terms terms) {
+    public static PublishedTermsItemResponseDto from(GetPublishedTermsListResult result) {
         return PublishedTermsItemResponseDto.builder()
-                .id(terms.getId())
-                .type(DescribedEnumDto.of(terms.getType(), TermsType.describe()))
-                .version("v" + terms.getVersion())
-                .title(terms.getTitle())
-                .docUrl(terms.getDocUrl())
-                .required(terms.isRequired())
-                .effectiveAt(terms.getEffectiveAt())
+                .id(result.id())
+                .type(DescribedEnumDto.of(result.type(), TermsType.describe()))
+                .version("v" + result.version())
+                .title(result.title())
+                .docUrl(result.docUrl())
+                .required(result.required())
+                .effectiveAt(result.effectiveAt())
                 .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/dto/PublishedTermsItemResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/terms/dto/PublishedTermsItemResponseDto.java
@@ -1,0 +1,54 @@
+package com.dreamteam.alter.adapter.inbound.general.terms.dto;
+
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.type.TermsType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "게시된 약관 항목 응답 DTO")
+public class PublishedTermsItemResponseDto {
+
+    @Schema(description = "약관 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "약관 유형")
+    private DescribedEnumDto<TermsType> type;
+
+    @Schema(description = "약관 버전", example = "v1.0")
+    private String version;
+
+    @Schema(description = "약관 제목", example = "서비스 이용약관")
+    private String title;
+
+    @Schema(description = "약관 문서 URL", example = "https://example.com/terms/service/v1.0")
+    private String docUrl;
+
+    @Schema(description = "필수 동의 여부", example = "true")
+    private boolean required;
+
+    @Schema(description = "게시 일시", example = "2025-01-01T12:00:00")
+    private LocalDateTime effectiveAt;
+
+    public static PublishedTermsItemResponseDto from(Terms terms) {
+        return PublishedTermsItemResponseDto.builder()
+                .id(terms.getId())
+                .type(DescribedEnumDto.of(terms.getType(), TermsType.describe()))
+                .version("v" + terms.getVersion())
+                .title(terms.getTitle())
+                .docUrl(terms.getDocUrl())
+                .required(terms.isRequired())
+                .effectiveAt(terms.getEffectiveAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.general.user.dto;
 
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.type.UserGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -10,7 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -61,7 +62,7 @@ public class CreateUserRequestDto {
     private Boolean nightNotificationConsent;
 
     @NotNull
-    @Schema(description = "동의한 약관 ID 목록", example = "[1, 2, 3]")
-    private List<Long> agreedTermsIds;
+    @Schema(description = "동의한 약관 타입 목록", example = "[\"SERVICE\", \"PRIVACY\"]")
+    private Set<TermsType> agreedTermsTypes;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserRequestDto.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -57,5 +59,9 @@ public class CreateUserRequestDto {
     @NotNull
     @Schema(description = "야간 알림 수신 동의 여부", example = "false")
     private Boolean nightNotificationConsent;
+
+    @NotNull
+    @Schema(description = "동의한 약관 ID 목록", example = "[1, 2, 3]")
+    private List<Long> agreedTermsIds;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -65,6 +67,10 @@ public class CreateUserWithSocialRequestDto {
     @NotNull
     @Schema(description = "야간 알림 수신 동의 여부", example = "false")
     private Boolean nightNotificationConsent;
+
+    @NotNull
+    @Schema(description = "동의한 약관 ID 목록", example = "[1, 2, 3]")
+    private List<Long> agreedTermsIds;
 
     @AssertTrue(message = "WEB 플랫폼은 authorizationCode가 필수입니다")
     private boolean isWebPlatformValid() {

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/CreateUserWithSocialRequestDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.general.user.dto;
 
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.type.PlatformType;
 import com.dreamteam.alter.domain.user.type.SocialProvider;
 import com.dreamteam.alter.domain.user.type.UserGender;
@@ -13,7 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -69,8 +70,8 @@ public class CreateUserWithSocialRequestDto {
     private Boolean nightNotificationConsent;
 
     @NotNull
-    @Schema(description = "동의한 약관 ID 목록", example = "[1, 2, 3]")
-    private List<Long> agreedTermsIds;
+    @Schema(description = "동의한 약관 타입 목록", example = "[\"SERVICE\", \"PRIVACY\"]")
+    private Set<TermsType> agreedTermsTypes;
 
     @AssertTrue(message = "WEB 플랫폼은 authorizationCode가 필수입니다")
     private boolean isWebPlatformValid() {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
@@ -8,6 +8,9 @@ import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -96,7 +99,7 @@ public class TermsQueryRepositoryImpl implements TermsQueryRepository {
     public List<Terms> findLatestPublishedPerType() {
         QTerms sub = new QTerms("sub");
 
-        return queryFactory
+        List<Terms> result = queryFactory
                 .selectFrom(terms)
                 .where(
                         terms.status.eq(TermsStatus.PUBLISHED),
@@ -110,8 +113,20 @@ public class TermsQueryRepositoryImpl implements TermsQueryRepository {
                                         )
                         )
                 )
-                .orderBy(terms.type.asc())
+                .orderBy(terms.type.asc(), terms.effectiveAt.desc(), terms.id.desc())
                 .fetch();
+
+        // 동일 effective_at 중복 방어: 타입별 id 내림차순 기준 첫 번째 1건만 취함
+        return result.stream()
+                .collect(Collectors.toMap(
+                        Terms::getType,
+                        t -> t,
+                        (existing, replacement) -> existing
+                ))
+                .values()
+                .stream()
+                .sorted(Comparator.comparing(Terms::getType))
+                .toList();
     }
 
     private BooleanExpression notDeleted() {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
@@ -91,6 +91,17 @@ public class TermsQueryRepositoryImpl implements TermsQueryRepository {
         );
     }
 
+    @Override
+    public List<Terms> findAllRequiredPublished() {
+        return queryFactory
+                .selectFrom(terms)
+                .where(
+                        terms.status.eq(TermsStatus.PUBLISHED),
+                        terms.required.isTrue()
+                )
+                .fetch();
+    }
+
     private BooleanExpression notDeleted() {
         return terms.status.ne(TermsStatus.DELETED);
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/TermsQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
 import com.dreamteam.alter.domain.terms.type.TermsStatus;
 import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
@@ -92,13 +93,24 @@ public class TermsQueryRepositoryImpl implements TermsQueryRepository {
     }
 
     @Override
-    public List<Terms> findAllRequiredPublished() {
+    public List<Terms> findLatestPublishedPerType() {
+        QTerms sub = new QTerms("sub");
+
         return queryFactory
                 .selectFrom(terms)
                 .where(
                         terms.status.eq(TermsStatus.PUBLISHED),
-                        terms.required.isTrue()
+                        terms.effectiveAt.eq(
+                                JPAExpressions
+                                        .select(sub.effectiveAt.max())
+                                        .from(sub)
+                                        .where(
+                                                sub.type.eq(terms.type),
+                                                sub.status.eq(TermsStatus.PUBLISHED)
+                                        )
+                        )
                 )
+                .orderBy(terms.type.asc())
                 .fetch();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/UserTermsAgreementJpaRepository.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/UserTermsAgreementJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.adapter.outbound.terms.persistence;
+
+import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTermsAgreementJpaRepository extends JpaRepository<UserTermsAgreement, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/UserTermsAgreementRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/terms/persistence/UserTermsAgreementRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.dreamteam.alter.adapter.outbound.terms.persistence;
+
+import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
+import com.dreamteam.alter.domain.terms.port.outbound.UserTermsAgreementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class UserTermsAgreementRepositoryImpl implements UserTermsAgreementRepository {
+
+    private final UserTermsAgreementJpaRepository userTermsAgreementJpaRepository;
+
+    @Override
+    public List<UserTermsAgreement> saveAll(List<UserTermsAgreement> agreements) {
+        return userTermsAgreementJpaRepository.saveAll(agreements);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
@@ -7,6 +7,7 @@ import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
 import com.dreamteam.alter.domain.terms.type.TermsType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
@@ -17,6 +18,7 @@ public class TermsAgreementValidator {
 
     private final TermsQueryRepository termsQueryRepository;
 
+    @Transactional(readOnly = true)
     public List<Terms> validateAndResolve(Set<TermsType> agreedTermsTypes) {
         List<Terms> latestPublishedTerms = termsQueryRepository.findLatestPublishedPerType();
 

--- a/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
@@ -1,0 +1,37 @@
+package com.dreamteam.alter.application.terms.service;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component("termsAgreementValidator")
+@RequiredArgsConstructor
+public class TermsAgreementValidator {
+
+    private final TermsQueryRepository termsQueryRepository;
+
+    public List<Terms> validateAndResolve(List<Long> agreedTermsIds) {
+        List<Terms> requiredTermsList = termsQueryRepository.findAllRequiredPublished();
+
+        Set<Long> agreedSet = new HashSet<>(agreedTermsIds);
+        boolean allRequiredAgreed = requiredTermsList.stream()
+                .allMatch(t -> agreedSet.contains(t.getId()));
+
+        if (!allRequiredAgreed) {
+            throw new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
+        }
+
+        return agreedTermsIds.stream()
+                .map(id -> termsQueryRepository.findById(id)
+                        .orElseThrow(() -> new CustomException(
+                                ErrorCode.TERMS_NOT_FOUND, "약관 ID: " + id)))
+                .toList();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
@@ -18,7 +18,10 @@ public class TermsAgreementValidator {
     private final TermsQueryRepository termsQueryRepository;
 
     public List<Terms> validateAndResolve(List<Long> agreedTermsIds) {
-        List<Terms> requiredTermsList = termsQueryRepository.findAllRequiredPublished();
+        List<Terms> requiredTermsList = termsQueryRepository.findLatestPublishedPerType()
+                .stream()
+                .filter(Terms::isRequired)
+                .toList();
 
         Set<Long> agreedSet = new HashSet<>(agreedTermsIds);
         boolean allRequiredAgreed = requiredTermsList.stream()

--- a/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidator.java
@@ -4,10 +4,10 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -17,24 +17,19 @@ public class TermsAgreementValidator {
 
     private final TermsQueryRepository termsQueryRepository;
 
-    public List<Terms> validateAndResolve(List<Long> agreedTermsIds) {
-        List<Terms> requiredTermsList = termsQueryRepository.findLatestPublishedPerType()
-                .stream()
-                .filter(Terms::isRequired)
-                .toList();
+    public List<Terms> validateAndResolve(Set<TermsType> agreedTermsTypes) {
+        List<Terms> latestPublishedTerms = termsQueryRepository.findLatestPublishedPerType();
 
-        Set<Long> agreedSet = new HashSet<>(agreedTermsIds);
-        boolean allRequiredAgreed = requiredTermsList.stream()
-                .allMatch(t -> agreedSet.contains(t.getId()));
+        boolean allRequiredAgreed = latestPublishedTerms.stream()
+                .filter(Terms::isRequired)
+                .allMatch(t -> agreedTermsTypes.contains(t.getType()));
 
         if (!allRequiredAgreed) {
             throw new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
         }
 
-        return agreedTermsIds.stream()
-                .map(id -> termsQueryRepository.findById(id)
-                        .orElseThrow(() -> new CustomException(
-                                ErrorCode.TERMS_NOT_FOUND, "약관 ID: " + id)))
+        return latestPublishedTerms.stream()
+                .filter(t -> agreedTermsTypes.contains(t.getType()))
                 .toList();
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
@@ -3,7 +3,6 @@ package com.dreamteam.alter.application.terms.usecase;
 import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
 import com.dreamteam.alter.domain.terms.port.inbound.GetPublishedTermsListUseCase;
 import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
-import com.dreamteam.alter.domain.terms.type.TermsStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +18,7 @@ public class GetPublishedTermsList implements GetPublishedTermsListUseCase {
 
     @Override
     public List<PublishedTermsItemResponseDto> execute() {
-        return termsQueryRepository.findByFilter(null, TermsStatus.PUBLISHED, 1, 100)
+        return termsQueryRepository.findLatestPublishedPerType()
                 .stream()
                 .map(PublishedTermsItemResponseDto::from)
                 .toList();

--- a/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
@@ -1,6 +1,6 @@
 package com.dreamteam.alter.application.terms.usecase;
 
-import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.terms.port.inbound.GetPublishedTermsListUseCase;
 import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +17,7 @@ public class GetPublishedTermsList implements GetPublishedTermsListUseCase {
     private final TermsQueryRepository termsQueryRepository;
 
     @Override
-    public List<PublishedTermsItemResponseDto> execute() {
-        return termsQueryRepository.findLatestPublishedPerType()
-                .stream()
-                .map(PublishedTermsItemResponseDto::from)
-                .toList();
+    public List<Terms> execute() {
+        return termsQueryRepository.findLatestPublishedPerType();
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
@@ -1,0 +1,27 @@
+package com.dreamteam.alter.application.terms.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+import com.dreamteam.alter.domain.terms.port.inbound.GetPublishedTermsListUseCase;
+import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import com.dreamteam.alter.domain.terms.type.TermsStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service("getPublishedTermsList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetPublishedTermsList implements GetPublishedTermsListUseCase {
+
+    private final TermsQueryRepository termsQueryRepository;
+
+    @Override
+    public List<PublishedTermsItemResponseDto> execute() {
+        return termsQueryRepository.findByFilter(null, TermsStatus.PUBLISHED, 1, 100)
+                .stream()
+                .map(PublishedTermsItemResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
+++ b/src/main/java/com/dreamteam/alter/application/terms/usecase/GetPublishedTermsList.java
@@ -1,8 +1,8 @@
 package com.dreamteam.alter.application.terms.usecase;
 
-import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.terms.port.inbound.GetPublishedTermsListUseCase;
 import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import com.dreamteam.alter.domain.terms.result.GetPublishedTermsListResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,10 @@ public class GetPublishedTermsList implements GetPublishedTermsListUseCase {
     private final TermsQueryRepository termsQueryRepository;
 
     @Override
-    public List<Terms> execute() {
-        return termsQueryRepository.findLatestPublishedPerType();
+    public List<GetPublishedTermsListResult> execute() {
+        return termsQueryRepository.findLatestPublishedPerType()
+                .stream()
+                .map(GetPublishedTermsListResult::from)
+                .toList();
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
@@ -46,7 +46,7 @@ public class CreateUser implements CreateUserUseCase {
         validateDuplication(request, contact, sessionIdKey);
 
         // 약관 동의 검증
-        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsIds());
+        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsTypes());
 
         // 비밀번호 형식 검증
         if (!PasswordValidator.isValid(request.getPassword())) {

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUser.java
@@ -8,6 +8,8 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.util.PasswordValidator;
 import com.dreamteam.alter.domain.email.port.outbound.EmailVerificationSessionStoreRepository;
+import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
+import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.user.port.inbound.CreateUserUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Service("createUser")
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class CreateUser implements CreateUserUseCase {
     private final SignupSessionCacheRepository cacheRepository;
     private final EmailVerificationSessionStoreRepository emailVerificationSessionStoreRepository;
     private final CreateUserTx createUserTx;
+    private final TermsAgreementValidator termsAgreementValidator;
 
     @Override
     public GenerateTokenResponseDto execute(CreateUserRequestDto request) {
@@ -41,6 +45,9 @@ public class CreateUser implements CreateUserUseCase {
         // 중복 확인
         validateDuplication(request, contact, sessionIdKey);
 
+        // 약관 동의 검증
+        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsIds());
+
         // 비밀번호 형식 검증
         if (!PasswordValidator.isValid(request.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD_FORMAT);
@@ -53,7 +60,8 @@ public class CreateUser implements CreateUserUseCase {
         GenerateTokenResponseDto response = createUserTx.process(
             request, contact, verifiedEmail,
             request.getNotificationConsent(),
-            request.getNightNotificationConsent()
+            request.getNightNotificationConsent(),
+            agreedTerms
         );
 
         // 회원가입 세션 삭제

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserTx.java
@@ -10,12 +10,17 @@ import com.dreamteam.alter.domain.auth.type.AuthLogType;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
+import com.dreamteam.alter.domain.terms.port.outbound.UserTermsAgreementRepository;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +31,7 @@ public class CreateUserTx {
     private final PasswordEncoder passwordEncoder;
     private final AuthLogRepository authLogRepository;
     private final NotificationConsentRepository notificationConsentRepository;
+    private final UserTermsAgreementRepository userTermsAgreementRepository;
 
     @Transactional
     public GenerateTokenResponseDto process(
@@ -33,7 +39,8 @@ public class CreateUserTx {
         String contact,
         String verifiedEmail,
         boolean notificationConsent,
-        boolean nightNotificationConsent
+        boolean nightNotificationConsent,
+        List<Terms> agreedTerms
     ) {
         // 사용자 생성
         User user = userRepository.save(User.create(
@@ -47,6 +54,11 @@ public class CreateUserTx {
         ));
 
         notificationConsentRepository.save(NotificationConsent.create(user, notificationConsent, nightNotificationConsent));
+
+        List<UserTermsAgreement> agreements = agreedTerms.stream()
+                .map(terms -> UserTermsAgreement.create(user, terms))
+                .toList();
+        userTermsAgreementRepository.saveAll(agreements);
 
         Authorization authorization = authService.generateAuthorization(user, TokenScope.APP);
         authLogRepository.save(AuthLog.create(user, authorization, AuthLogType.LOGIN));

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
@@ -48,7 +48,7 @@ public class CreateUserWithSocial implements CreateUserWithSocialUseCase {
         validateDuplication(request, contact, sessionIdKey);
 
         // 약관 동의 검증
-        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsIds());
+        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsTypes());
 
         // 소셜 인증
         OauthToken oauthToken = request.getOauthToken() != null

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocial.java
@@ -5,10 +5,12 @@ import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserWithSocial
 import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
 import com.dreamteam.alter.adapter.outbound.user.persistence.SignupSessionCacheRepository;
 import com.dreamteam.alter.application.auth.manager.SocialAuthenticationManager;
+import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
 import com.dreamteam.alter.common.constants.SignupSessionConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.auth.vo.SocialAuthRequest;
+import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.user.port.inbound.CreateUserWithSocialUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserSocialQueryRepository;
@@ -29,6 +31,7 @@ public class CreateUserWithSocial implements CreateUserWithSocialUseCase {
     private final SocialAuthenticationManager socialAuthenticationManager;
     private final SignupSessionCacheRepository cacheRepository;
     private final CreateUserWithSocialTx createUserWithSocialTx;
+    private final TermsAgreementValidator termsAgreementValidator;
 
     @Override
     public GenerateTokenResponseDto execute(CreateUserWithSocialRequestDto request) {
@@ -43,6 +46,9 @@ public class CreateUserWithSocial implements CreateUserWithSocialUseCase {
 
         // 중복 확인
         validateDuplication(request, contact, sessionIdKey);
+
+        // 약관 동의 검증
+        List<Terms> agreedTerms = termsAgreementValidator.validateAndResolve(request.getAgreedTermsIds());
 
         // 소셜 인증
         OauthToken oauthToken = request.getOauthToken() != null
@@ -76,7 +82,8 @@ public class CreateUserWithSocial implements CreateUserWithSocialUseCase {
         GenerateTokenResponseDto response = createUserWithSocialTx.process(
             contact, request, socialAuthInfo,
             request.getNotificationConsent(),
-            request.getNightNotificationConsent()
+            request.getNightNotificationConsent(),
+            agreedTerms
         );
 
         // 회원가입 세션 삭제

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTx.java
@@ -11,12 +11,17 @@ import com.dreamteam.alter.domain.auth.type.AuthLogType;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentRepository;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
+import com.dreamteam.alter.domain.terms.port.outbound.UserTermsAgreementRepository;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.entity.UserSocial;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +31,7 @@ public class CreateUserWithSocialTx {
     private final AuthService authService;
     private final AuthLogRepository authLogRepository;
     private final NotificationConsentRepository notificationConsentRepository;
+    private final UserTermsAgreementRepository userTermsAgreementRepository;
 
     @Transactional
     public GenerateTokenResponseDto process(
@@ -33,7 +39,8 @@ public class CreateUserWithSocialTx {
         CreateUserWithSocialRequestDto request,
         SocialAuthInfo socialAuthInfo,
         boolean notificationConsent,
-        boolean nightNotificationConsent
+        boolean nightNotificationConsent,
+        List<Terms> agreedTerms
     ) {
         // 사용자 생성
         User user = userRepository.save(User.createWithSocial(
@@ -46,6 +53,11 @@ public class CreateUserWithSocialTx {
         ));
 
         notificationConsentRepository.save(NotificationConsent.create(user, notificationConsent, nightNotificationConsent));
+
+        List<UserTermsAgreement> agreements = agreedTerms.stream()
+                .map(terms -> UserTermsAgreement.create(user, terms))
+                .toList();
+        userTermsAgreementRepository.saveAll(agreements);
 
         // 소셜 계정 연동
         UserSocial userSocial = UserSocial.create(

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -25,7 +25,6 @@ public enum ErrorCode {
     SOCIAL_UNLINK_NOT_ALLOWED(400, "A016", "비밀번호가 설정되지 않은 경우 마지막 소셜 계정은 해제할 수 없습니다."),
     INVALID_CURRENT_PASSWORD(400, "A017", "현재 비밀번호가 올바르지 않습니다."),
     REQUIRED_TERMS_NOT_AGREED(400, "A018", "필수 약관에 모두 동의해야 합니다."),
-    TERMS_NOT_FOUND(400, "A019", "존재하지 않는 약관입니다."),
 
     ILLEGAL_ARGUMENT(400, "B001", "잘못된 요청입니다."),
     REFRESH_TOKEN_REQUIRED(400, "B002", "RefreshToken을 통해 요청해야 합니다."),

--- a/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
+++ b/src/main/java/com/dreamteam/alter/common/exception/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
     SOCIAL_ACCOUNT_NOT_LINKED(400, "A015", "연동되지 않은 소셜 플랫폼입니다."),
     SOCIAL_UNLINK_NOT_ALLOWED(400, "A016", "비밀번호가 설정되지 않은 경우 마지막 소셜 계정은 해제할 수 없습니다."),
     INVALID_CURRENT_PASSWORD(400, "A017", "현재 비밀번호가 올바르지 않습니다."),
+    REQUIRED_TERMS_NOT_AGREED(400, "A018", "필수 약관에 모두 동의해야 합니다."),
+    TERMS_NOT_FOUND(400, "A019", "존재하지 않는 약관입니다."),
 
     ILLEGAL_ARGUMENT(400, "B001", "잘못된 요청입니다."),
     REFRESH_TOKEN_REQUIRED(400, "B002", "RefreshToken을 통해 요청해야 합니다."),

--- a/src/main/java/com/dreamteam/alter/domain/terms/entity/UserTermsAgreement.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/entity/UserTermsAgreement.java
@@ -1,9 +1,12 @@
 package com.dreamteam.alter.domain.terms.entity;
 
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,9 +41,12 @@ public class UserTermsAgreement {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "terms_id", nullable = false)
-    private Terms terms;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 30, nullable = false)
+    private TermsType type;
+
+    @Column(name = "version", length = 20, nullable = false)
+    private String version;
 
     @CreatedDate
     @Column(name = "agreed_at", nullable = false, updatable = false)
@@ -49,7 +55,8 @@ public class UserTermsAgreement {
     public static UserTermsAgreement create(User user, Terms terms) {
         return UserTermsAgreement.builder()
                 .user(user)
-                .terms(terms)
+                .type(terms.getType())
+                .version(terms.getVersion())
                 .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/entity/UserTermsAgreement.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/entity/UserTermsAgreement.java
@@ -1,0 +1,55 @@
+package com.dreamteam.alter.domain.terms.entity;
+
+import com.dreamteam.alter.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "user_terms_agreements")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class UserTermsAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "terms_id", nullable = false)
+    private Terms terms;
+
+    @CreatedDate
+    @Column(name = "agreed_at", nullable = false, updatable = false)
+    private LocalDateTime agreedAt;
+
+    public static UserTermsAgreement create(User user, Terms terms) {
+        return UserTermsAgreement.builder()
+                .user(user)
+                .terms(terms)
+                .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
@@ -1,10 +1,10 @@
 package com.dreamteam.alter.domain.terms.port.inbound;
 
-import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+import com.dreamteam.alter.domain.terms.entity.Terms;
 
 import java.util.List;
 
 public interface GetPublishedTermsListUseCase {
 
-    List<PublishedTermsItemResponseDto> execute();
+    List<Terms> execute();
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.domain.terms.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.general.terms.dto.PublishedTermsItemResponseDto;
+
+import java.util.List;
+
+public interface GetPublishedTermsListUseCase {
+
+    List<PublishedTermsItemResponseDto> execute();
+}

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/inbound/GetPublishedTermsListUseCase.java
@@ -1,10 +1,10 @@
 package com.dreamteam.alter.domain.terms.port.inbound;
 
-import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.result.GetPublishedTermsListResult;
 
 import java.util.List;
 
 public interface GetPublishedTermsListUseCase {
 
-    List<Terms> execute();
+    List<GetPublishedTermsListResult> execute();
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/TermsQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/TermsQueryRepository.java
@@ -18,4 +18,6 @@ public interface TermsQueryRepository {
     Optional<Terms> findPublishedByType(TermsType type);
 
     Optional<Terms> findPublishedByTypeWithLock(TermsType type);
+
+    List<Terms> findAllRequiredPublished();
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/TermsQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/TermsQueryRepository.java
@@ -19,5 +19,9 @@ public interface TermsQueryRepository {
 
     Optional<Terms> findPublishedByTypeWithLock(TermsType type);
 
-    List<Terms> findAllRequiredPublished();
+    /**
+     * 각 TermsType 별로 PUBLISHED 상태인 약관 중 effective_at 이 가장 최근인 것 1건씩 반환
+     * 결과 순서: TermsType 선언 순서 (SERVICE, PRIVACY, LOCATION, MARKETING)
+     */
+    List<Terms> findLatestPublishedPerType();
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/UserTermsAgreementRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/UserTermsAgreementRepository.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.terms.port.outbound;
+
+import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+}

--- a/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/UserTermsAgreementRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/port/outbound/UserTermsAgreementRepository.java
@@ -1,7 +1,9 @@
 package com.dreamteam.alter.domain.terms.port.outbound;
 
 import com.dreamteam.alter.domain.terms.entity.UserTermsAgreement;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+import java.util.List;
+
+public interface UserTermsAgreementRepository {
+    List<UserTermsAgreement> saveAll(List<UserTermsAgreement> agreements);
 }

--- a/src/main/java/com/dreamteam/alter/domain/terms/result/GetPublishedTermsListResult.java
+++ b/src/main/java/com/dreamteam/alter/domain/terms/result/GetPublishedTermsListResult.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.domain.terms.result;
+
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.type.TermsType;
+
+import java.time.LocalDateTime;
+
+public record GetPublishedTermsListResult(
+        Long id,
+        TermsType type,
+        String title,
+        String docUrl,
+        boolean required,
+        String version,
+        LocalDateTime effectiveAt
+) {
+    public static GetPublishedTermsListResult from(Terms terms) {
+        return new GetPublishedTermsListResult(
+                terms.getId(),
+                terms.getType(),
+                terms.getTitle(),
+                terms.getDocUrl(),
+                terms.isRequired(),
+                terms.getVersion(),
+                terms.getEffectiveAt()
+        );
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
+++ b/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,15 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TermsAgreementValidator 테스트")
@@ -33,9 +31,9 @@ class TermsAgreementValidatorTests {
     @InjectMocks
     private TermsAgreementValidator termsAgreementValidator;
 
-    private Terms createTermsMock(Long id, boolean required) {
+    private Terms createTermsMock(TermsType type, boolean required) {
         Terms terms = mock(Terms.class);
-        given(terms.getId()).willReturn(id);
+        given(terms.getType()).willReturn(type);
         given(terms.isRequired()).willReturn(required);
         return terms;
     }
@@ -48,14 +46,14 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관을 모두 동의한 경우 Terms 목록 반환")
         void validateAndResolve_allRequiredAgreed_returnsTermsList() {
             // given
-            Terms terms1 = createTermsMock(1L, true);
-            Terms terms2 = createTermsMock(2L, true);
-            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1, terms2));
-            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
-            given(termsQueryRepository.findById(2L)).willReturn(Optional.of(terms2));
+            Terms serviceTerms = createTermsMock(TermsType.SERVICE, true);
+            Terms privacyTerms = createTermsMock(TermsType.PRIVACY, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(serviceTerms, privacyTerms));
 
             // when
-            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of(1L, 2L));
+            List<Terms> result = termsAgreementValidator.validateAndResolve(
+                Set.of(TermsType.SERVICE, TermsType.PRIVACY)
+            );
 
             // then
             assertThat(result).hasSize(2);
@@ -65,15 +63,14 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관 외 선택 약관도 함께 동의한 경우 전체 Terms 목록 반환")
         void validateAndResolve_requiredAndOptionalAgreed_returnsAllTerms() {
             // given
-            Terms requiredTerms = createTermsMock(1L, true);
-            Terms optionalTerms = mock(Terms.class);
-            given(optionalTerms.isRequired()).willReturn(false); // filter 대상, getId() 호출 안 됨
-            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(requiredTerms, optionalTerms));
-            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(requiredTerms));
-            given(termsQueryRepository.findById(2L)).willReturn(Optional.of(optionalTerms));
+            Terms serviceTerms = createTermsMock(TermsType.SERVICE, true);
+            Terms marketingTerms = createTermsMock(TermsType.MARKETING, false);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(serviceTerms, marketingTerms));
 
             // when
-            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of(1L, 2L));
+            List<Terms> result = termsAgreementValidator.validateAndResolve(
+                Set.of(TermsType.SERVICE, TermsType.MARKETING)
+            );
 
             // then
             assertThat(result).hasSize(2);
@@ -83,43 +80,41 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관 미동의 시 REQUIRED_TERMS_NOT_AGREED 예외 발생")
         void validateAndResolve_missingRequiredTerms_throwsRequiredTermsNotAgreed() {
             // given
-            Terms terms1 = createTermsMock(1L, true);
-            Terms terms2 = createTermsMock(2L, true);
-            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1, terms2));
+            Terms serviceTerms = createTermsMock(TermsType.SERVICE, true);
+            Terms privacyTerms = createTermsMock(TermsType.PRIVACY, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(serviceTerms, privacyTerms));
 
             // when & then
-            assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(List.of(1L)))
+            assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(Set.of(TermsType.SERVICE)))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED));
-
-            then(termsQueryRepository).should(never()).findById(any());
         }
 
         @Test
-        @DisplayName("동의한 약관 ID가 존재하지 않는 경우 TERMS_NOT_FOUND 예외 발생")
-        void validateAndResolve_nonExistentTermsId_throwsTermsNotFound() {
-            // given
-            Terms terms1 = createTermsMock(1L, true);
-            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1));
-            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
-            given(termsQueryRepository.findById(999L)).willReturn(Optional.empty());
+        @DisplayName("PUBLISHED 되지 않은 타입 동의 시 해당 타입 무시하고 동의된 타입만 반환")
+        void validateAndResolve_unpublishedTypeAgreed_ignoresUnpublishedType() {
+            // given - LOCATION은 PUBLISHED 약관 없음 (findLatestPublishedPerType 결과에 미포함)
+            Terms serviceTerms = createTermsMock(TermsType.SERVICE, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(serviceTerms));
 
-            // when & then
-            assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(List.of(1L, 999L)))
-                .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
-                    .isEqualTo(ErrorCode.TERMS_NOT_FOUND));
+            // when - LOCATION 타입도 함께 동의했지만 PUBLISHED 약관이 없으므로 무시됨
+            List<Terms> result = termsAgreementValidator.validateAndResolve(
+                Set.of(TermsType.SERVICE, TermsType.LOCATION)
+            );
+
+            // then
+            assertThat(result).hasSize(1);
         }
 
         @Test
         @DisplayName("필수 약관이 없는 경우 동의 목록 없어도 통과")
-        void validateAndResolve_noRequiredTerms_emptyAgreedListPasses() {
+        void validateAndResolve_noRequiredTerms_emptyAgreedSetPasses() {
             // given
             given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of());
 
             // when
-            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of());
+            List<Terms> result = termsAgreementValidator.validateAndResolve(Set.of());
 
             // then
             assertThat(result).isEmpty();

--- a/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
+++ b/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
@@ -33,9 +33,10 @@ class TermsAgreementValidatorTests {
     @InjectMocks
     private TermsAgreementValidator termsAgreementValidator;
 
-    private Terms createTermsMock(Long id) {
+    private Terms createTermsMock(Long id, boolean required) {
         Terms terms = mock(Terms.class);
         given(terms.getId()).willReturn(id);
+        given(terms.isRequired()).willReturn(required);
         return terms;
     }
 
@@ -47,9 +48,9 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관을 모두 동의한 경우 Terms 목록 반환")
         void validateAndResolve_allRequiredAgreed_returnsTermsList() {
             // given
-            Terms terms1 = createTermsMock(1L);
-            Terms terms2 = createTermsMock(2L);
-            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1, terms2));
+            Terms terms1 = createTermsMock(1L, true);
+            Terms terms2 = createTermsMock(2L, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1, terms2));
             given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
             given(termsQueryRepository.findById(2L)).willReturn(Optional.of(terms2));
 
@@ -64,9 +65,10 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관 외 선택 약관도 함께 동의한 경우 전체 Terms 목록 반환")
         void validateAndResolve_requiredAndOptionalAgreed_returnsAllTerms() {
             // given
-            Terms requiredTerms = createTermsMock(1L);
-            Terms optionalTerms = mock(Terms.class); // 필수 목록에 없으므로 getId() 호출 안 됨
-            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(requiredTerms));
+            Terms requiredTerms = createTermsMock(1L, true);
+            Terms optionalTerms = mock(Terms.class);
+            given(optionalTerms.isRequired()).willReturn(false); // filter 대상, getId() 호출 안 됨
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(requiredTerms, optionalTerms));
             given(termsQueryRepository.findById(1L)).willReturn(Optional.of(requiredTerms));
             given(termsQueryRepository.findById(2L)).willReturn(Optional.of(optionalTerms));
 
@@ -81,9 +83,9 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관 미동의 시 REQUIRED_TERMS_NOT_AGREED 예외 발생")
         void validateAndResolve_missingRequiredTerms_throwsRequiredTermsNotAgreed() {
             // given
-            Terms terms1 = createTermsMock(1L);
-            Terms terms2 = createTermsMock(2L);
-            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1, terms2));
+            Terms terms1 = createTermsMock(1L, true);
+            Terms terms2 = createTermsMock(2L, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1, terms2));
 
             // when & then
             assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(List.of(1L)))
@@ -98,8 +100,8 @@ class TermsAgreementValidatorTests {
         @DisplayName("동의한 약관 ID가 존재하지 않는 경우 TERMS_NOT_FOUND 예외 발생")
         void validateAndResolve_nonExistentTermsId_throwsTermsNotFound() {
             // given
-            Terms terms1 = createTermsMock(1L);
-            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1));
+            Terms terms1 = createTermsMock(1L, true);
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of(terms1));
             given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
             given(termsQueryRepository.findById(999L)).willReturn(Optional.empty());
 
@@ -114,7 +116,7 @@ class TermsAgreementValidatorTests {
         @DisplayName("필수 약관이 없는 경우 동의 목록 없어도 통과")
         void validateAndResolve_noRequiredTerms_emptyAgreedListPasses() {
             // given
-            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of());
+            given(termsQueryRepository.findLatestPublishedPerType()).willReturn(List.of());
 
             // when
             List<Terms> result = termsAgreementValidator.validateAndResolve(List.of());

--- a/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
+++ b/src/test/java/com/dreamteam/alter/application/terms/service/TermsAgreementValidatorTests.java
@@ -1,0 +1,126 @@
+package com.dreamteam.alter.application.terms.service;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.port.outbound.TermsQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TermsAgreementValidator 테스트")
+class TermsAgreementValidatorTests {
+
+    @Mock
+    private TermsQueryRepository termsQueryRepository;
+
+    @InjectMocks
+    private TermsAgreementValidator termsAgreementValidator;
+
+    private Terms createTermsMock(Long id) {
+        Terms terms = mock(Terms.class);
+        given(terms.getId()).willReturn(id);
+        return terms;
+    }
+
+    @Nested
+    @DisplayName("validateAndResolve")
+    class ValidateAndResolveTests {
+
+        @Test
+        @DisplayName("필수 약관을 모두 동의한 경우 Terms 목록 반환")
+        void validateAndResolve_allRequiredAgreed_returnsTermsList() {
+            // given
+            Terms terms1 = createTermsMock(1L);
+            Terms terms2 = createTermsMock(2L);
+            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1, terms2));
+            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
+            given(termsQueryRepository.findById(2L)).willReturn(Optional.of(terms2));
+
+            // when
+            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of(1L, 2L));
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("필수 약관 외 선택 약관도 함께 동의한 경우 전체 Terms 목록 반환")
+        void validateAndResolve_requiredAndOptionalAgreed_returnsAllTerms() {
+            // given
+            Terms requiredTerms = createTermsMock(1L);
+            Terms optionalTerms = mock(Terms.class); // 필수 목록에 없으므로 getId() 호출 안 됨
+            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(requiredTerms));
+            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(requiredTerms));
+            given(termsQueryRepository.findById(2L)).willReturn(Optional.of(optionalTerms));
+
+            // when
+            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of(1L, 2L));
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("필수 약관 미동의 시 REQUIRED_TERMS_NOT_AGREED 예외 발생")
+        void validateAndResolve_missingRequiredTerms_throwsRequiredTermsNotAgreed() {
+            // given
+            Terms terms1 = createTermsMock(1L);
+            Terms terms2 = createTermsMock(2L);
+            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1, terms2));
+
+            // when & then
+            assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(List.of(1L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED));
+
+            then(termsQueryRepository).should(never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("동의한 약관 ID가 존재하지 않는 경우 TERMS_NOT_FOUND 예외 발생")
+        void validateAndResolve_nonExistentTermsId_throwsTermsNotFound() {
+            // given
+            Terms terms1 = createTermsMock(1L);
+            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of(terms1));
+            given(termsQueryRepository.findById(1L)).willReturn(Optional.of(terms1));
+            given(termsQueryRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> termsAgreementValidator.validateAndResolve(List.of(1L, 999L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.TERMS_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("필수 약관이 없는 경우 동의 목록 없어도 통과")
+        void validateAndResolve_noRequiredTerms_emptyAgreedListPasses() {
+            // given
+            given(termsQueryRepository.findAllRequiredPublished()).willReturn(List.of());
+
+            // when
+            List<Terms> result = termsAgreementValidator.validateAndResolve(List.of());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
@@ -1,0 +1,205 @@
+package com.dreamteam.alter.application.user.usecase;
+
+import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserRequestDto;
+import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
+import com.dreamteam.alter.adapter.outbound.user.persistence.SignupSessionCacheRepository;
+import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.email.port.outbound.EmailVerificationSessionStoreRepository;
+import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
+import com.dreamteam.alter.domain.user.type.UserGender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateUser 테스트")
+class CreateUserTests {
+
+    @Mock
+    private UserQueryRepository userQueryRepository;
+
+    @Mock
+    private SignupSessionCacheRepository cacheRepository;
+
+    @Mock
+    private EmailVerificationSessionStoreRepository emailVerificationSessionStoreRepository;
+
+    @Mock
+    private CreateUserTx createUserTx;
+
+    @Mock
+    private TermsAgreementValidator termsAgreementValidator;
+
+    @InjectMocks
+    private CreateUser createUser;
+
+    private CreateUserRequestDto request;
+
+    @BeforeEach
+    void setUp() {
+        request = new CreateUserRequestDto(
+            "signup-session-id",
+            null,
+            "Test1234!",
+            "김철수",
+            "유땡땡",
+            UserGender.GENDER_MALE,
+            "19900101",
+            true,
+            false,
+            List.of(1L, 2L)
+        );
+    }
+
+    @Nested
+    @DisplayName("execute")
+    class ExecuteTests {
+
+        @Test
+        @DisplayName("회원가입 세션이 존재하지 않을 경우 SIGNUP_SESSION_NOT_EXIST 예외 발생")
+        void execute_signupSessionNotFound_throwsSignupSessionNotExist() {
+            // given
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> createUser.execute(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.SIGNUP_SESSION_NOT_EXIST));
+
+            then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복될 경우 NICKNAME_DUPLICATED 예외 발생 및 Redis 세션 삭제")
+        void execute_nicknameDuplicated_throwsNicknameDuplicated() {
+            // given
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.of(mock(User.class)));
+
+            // when & then
+            assertThatThrownBy(() -> createUser.execute(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.NICKNAME_DUPLICATED));
+
+            then(cacheRepository).should().deleteAll(anyList());
+            then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("연락처가 중복될 경우 USER_CONTACT_DUPLICATED 예외 발생 및 Redis 세션 삭제")
+        void execute_contactDuplicated_throwsUserContactDuplicated() {
+            // given
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
+            given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.of(mock(User.class)));
+
+            // when & then
+            assertThatThrownBy(() -> createUser.execute(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_CONTACT_DUPLICATED));
+
+            then(cacheRepository).should().deleteAll(anyList());
+            then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("필수 약관 미동의 시 REQUIRED_TERMS_NOT_AGREED 예외 발생")
+        void execute_requiredTermsNotAgreed_throwsRequiredTermsNotAgreed() {
+            // given
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
+            given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
+                .given(termsAgreementValidator).validateAndResolve(any());
+
+            // when & then
+            assertThatThrownBy(() -> createUser.execute(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED));
+
+            then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("비밀번호 형식이 잘못된 경우 INVALID_PASSWORD_FORMAT 예외 발생")
+        void execute_invalidPasswordFormat_throwsInvalidPasswordFormat() {
+            // given
+            CreateUserRequestDto invalidRequest = new CreateUserRequestDto(
+                "signup-session-id",
+                null,
+                "password123",
+                "김철수",
+                "유땡땡",
+                UserGender.GENDER_MALE,
+                "19900101",
+                true,
+                false,
+                List.of(1L, 2L)
+            );
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
+            given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> createUser.execute(invalidRequest))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_PASSWORD_FORMAT));
+
+            then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("유효한 입력으로 일반 회원가입 성공")
+        void execute_withValidInput_succeeds() {
+            // given
+            Terms termsMock1 = mock(Terms.class);
+            Terms termsMock2 = mock(Terms.class);
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
+            given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of(termsMock1, termsMock2));
+
+            GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
+            given(createUserTx.process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList())).willReturn(mockResponse);
+
+            // when
+            GenerateTokenResponseDto result = createUser.execute(request);
+
+            // then
+            assertThat(result).isEqualTo(mockResponse);
+            then(createUserTx).should().process(eq(request), eq("01012345678"), any(), eq(true), eq(false), anyList());
+            then(cacheRepository).should().deleteAll(anyList());
+            then(emailVerificationSessionStoreRepository).should(never()).deleteSession(any());
+        }
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.email.port.outbound.EmailVerificationSessionStoreRepository;
 import com.dreamteam.alter.domain.terms.entity.Terms;
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import com.dreamteam.alter.domain.user.type.UserGender;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -71,7 +73,7 @@ class CreateUserTests {
             "19900101",
             true,
             false,
-            List.of(1L, 2L)
+            Set.of(TermsType.SERVICE, TermsType.PRIVACY)
         );
     }
 
@@ -162,7 +164,7 @@ class CreateUserTests {
                 "19900101",
                 true,
                 false,
-                List.of(1L, 2L)
+                Set.of(TermsType.SERVICE, TermsType.PRIVACY)
             );
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -109,7 +110,8 @@ class CreateUserTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.NICKNAME_DUPLICATED));
 
-            then(cacheRepository).should().deleteAll(anyList());
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
             then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
@@ -127,7 +129,8 @@ class CreateUserTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.USER_CONTACT_DUPLICATED));
 
-            then(cacheRepository).should().deleteAll(anyList());
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
             then(createUserTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
@@ -186,21 +189,23 @@ class CreateUserTests {
             // given
             Terms termsMock1 = mock(Terms.class);
             Terms termsMock2 = mock(Terms.class);
+            List<Terms> agreedTerms = List.of(termsMock1, termsMock2);
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
             given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
-            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of(termsMock1, termsMock2));
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(agreedTerms);
 
             GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
-            given(createUserTx.process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList())).willReturn(mockResponse);
+            given(createUserTx.process(any(), any(), any(), anyBoolean(), anyBoolean(), eq(agreedTerms))).willReturn(mockResponse);
 
             // when
             GenerateTokenResponseDto result = createUser.execute(request);
 
             // then
             assertThat(result).isEqualTo(mockResponse);
-            then(createUserTx).should().process(eq(request), eq("01012345678"), any(), eq(true), eq(false), anyList());
-            then(cacheRepository).should().deleteAll(anyList());
+            then(createUserTx).should().process(eq(request), eq("01012345678"), any(), eq(true), eq(false), eq(agreedTerms));
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
             then(emailVerificationSessionStoreRepository).should(never()).deleteSession(any());
         }
     }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.general.user.dto.CreateUserWithSocial
 import com.dreamteam.alter.adapter.inbound.general.user.dto.GenerateTokenResponseDto;
 import com.dreamteam.alter.adapter.outbound.user.persistence.SignupSessionCacheRepository;
 import com.dreamteam.alter.application.auth.manager.SocialAuthenticationManager;
+import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.entity.User;
@@ -22,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +56,9 @@ class CreateUserWithSocialTests {
     @Mock
     private CreateUserWithSocialTx createUserWithSocialTx;
 
+    @Mock
+    private TermsAgreementValidator termsAgreementValidator;
+
     @InjectMocks
     private CreateUserWithSocial createUserWithSocial;
 
@@ -72,7 +77,8 @@ class CreateUserWithSocialTests {
             UserGender.GENDER_MALE,
             "19900101",
             true,
-            false
+            false,
+            List.of(1L, 2L)
         );
     }
 
@@ -101,7 +107,7 @@ class CreateUserWithSocialTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.SIGNUP_SESSION_NOT_EXIST));
 
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
         @Test
@@ -118,7 +124,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.NICKNAME_DUPLICATED));
 
             then(cacheRepository).should().deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
         @Test
@@ -136,7 +142,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.USER_CONTACT_DUPLICATED));
 
             then(cacheRepository).should().deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
         @Test
@@ -146,6 +152,7 @@ class CreateUserWithSocialTests {
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
             given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of());
 
             SocialAuthInfo authInfo = createSocialAuthInfo("kakao-social-id", null, null);
             given(socialAuthenticationManager.authenticate(any())).willReturn(authInfo);
@@ -159,7 +166,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.SOCIAL_ID_DUPLICATED));
 
             then(cacheRepository).should(never()).deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
         @Test
@@ -169,6 +176,7 @@ class CreateUserWithSocialTests {
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
             given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of());
 
             SocialAuthInfo authInfo = createSocialAuthInfo("kakao-social-id", "social@example.com", null);
             given(socialAuthenticationManager.authenticate(any())).willReturn(authInfo);
@@ -183,7 +191,7 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.EMAIL_DUPLICATED));
 
             then(cacheRepository).should(never()).deleteAll(anyList());
-            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
         @Test
@@ -193,6 +201,7 @@ class CreateUserWithSocialTests {
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
             given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of());
 
             // 소셜 인증 및 중복 확인
             SocialAuthInfo authInfo = createSocialAuthInfo("kakao-social-id", null, null);
@@ -201,14 +210,14 @@ class CreateUserWithSocialTests {
 
             // TX 저장
             GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
-            given(createUserWithSocialTx.process(any(), any(), any(), eq(true), eq(false))).willReturn(mockResponse);
+            given(createUserWithSocialTx.process(any(), any(), any(), eq(true), eq(false), anyList())).willReturn(mockResponse);
 
             // when
             GenerateTokenResponseDto result = createUserWithSocial.execute(request);
 
             // then
             assertThat(result).isEqualTo(mockResponse);
-            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), eq(true), eq(false));
+            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), eq(true), eq(false), anyList());
             then(cacheRepository).should().deleteAll(anyList());
         }
     }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
@@ -191,6 +192,26 @@ class CreateUserWithSocialTests {
                     .isEqualTo(ErrorCode.EMAIL_DUPLICATED));
 
             then(cacheRepository).should(never()).deleteAll(anyList());
+            then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
+        }
+
+        @Test
+        @DisplayName("필수 약관 미동의 시 REQUIRED_TERMS_NOT_AGREED 예외 발생")
+        void execute_requiredTermsNotAgreed_throwsRequiredTermsNotAgreed() {
+            // given
+            given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
+            given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
+            given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
+            willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
+                .given(termsAgreementValidator).validateAndResolve(any());
+
+            // when & then
+            assertThatThrownBy(() -> createUserWithSocial.execute(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED));
+
+            then(socialAuthenticationManager).should(never()).authenticate(any());
             then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.application.auth.manager.SocialAuthenticationManager;
 import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserSocialQueryRepository;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,7 +81,7 @@ class CreateUserWithSocialTests {
             "19900101",
             true,
             false,
-            List.of(1L, 2L)
+            Set.of(TermsType.SERVICE, TermsType.PRIVACY)
         );
     }
 

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/CreateUserWithSocialTests.java
@@ -8,6 +8,7 @@ import com.dreamteam.alter.application.auth.manager.SocialAuthenticationManager;
 import com.dreamteam.alter.application.terms.service.TermsAgreementValidator;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.terms.entity.Terms;
 import com.dreamteam.alter.domain.terms.type.TermsType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -126,7 +128,8 @@ class CreateUserWithSocialTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.NICKNAME_DUPLICATED));
 
-            then(cacheRepository).should().deleteAll(anyList());
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
             then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
@@ -144,7 +147,8 @@ class CreateUserWithSocialTests {
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.USER_CONTACT_DUPLICATED));
 
-            then(cacheRepository).should().deleteAll(anyList());
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
             then(createUserWithSocialTx).should(never()).process(any(), any(), any(), anyBoolean(), anyBoolean(), anyList());
         }
 
@@ -221,10 +225,13 @@ class CreateUserWithSocialTests {
         @DisplayName("유효한 입력으로 소셜 회원가입 성공")
         void execute_withValidInput_succeeds() {
             // given - 기본 세션 및 검증
+            Terms termsMock1 = mock(Terms.class);
+            Terms termsMock2 = mock(Terms.class);
+            List<Terms> agreedTerms = List.of(termsMock1, termsMock2);
             given(cacheRepository.get("SIGNUP:PENDING:signup-session-id")).willReturn("01012345678");
             given(userQueryRepository.findByNickname("유땡땡")).willReturn(Optional.empty());
             given(userQueryRepository.findByContact("01012345678")).willReturn(Optional.empty());
-            given(termsAgreementValidator.validateAndResolve(any())).willReturn(List.of());
+            given(termsAgreementValidator.validateAndResolve(any())).willReturn(agreedTerms);
 
             // 소셜 인증 및 중복 확인
             SocialAuthInfo authInfo = createSocialAuthInfo("kakao-social-id", null, null);
@@ -233,15 +240,16 @@ class CreateUserWithSocialTests {
 
             // TX 저장
             GenerateTokenResponseDto mockResponse = mock(GenerateTokenResponseDto.class);
-            given(createUserWithSocialTx.process(any(), any(), any(), eq(true), eq(false), anyList())).willReturn(mockResponse);
+            given(createUserWithSocialTx.process(any(), any(), any(), eq(true), eq(false), eq(agreedTerms))).willReturn(mockResponse);
 
             // when
             GenerateTokenResponseDto result = createUserWithSocial.execute(request);
 
             // then
             assertThat(result).isEqualTo(mockResponse);
-            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), eq(true), eq(false), anyList());
-            then(cacheRepository).should().deleteAll(anyList());
+            then(createUserWithSocialTx).should().process(eq("01012345678"), eq(request), any(), eq(true), eq(false), eq(agreedTerms));
+            then(cacheRepository).should().deleteAll(argThat(list ->
+                list.containsAll(List.of("SIGNUP:PENDING:signup-session-id", "SIGNUP:CONTACT:01012345678"))));
         }
     }
 }


### PR DESCRIPTION
## 관련 문서
[https://www.notion.so/BE-API-35986553162880c8aba5dcb1db372d6a?v=3288655316288071b53d000c67f996d3&source=copy_link](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공개 약관 목록 조회용 공개 API 추가
  * 회원가입(일반/소셜) 시 약관 선택 필수화 및 동의된 약관 목록 제출 요구
  * 사용자 약관 동의 내역 저장 및 추적 기능 추가

* **Bug Fixes / Validation**
  * 필수 약관 미동의 시 명확한 400 오류 코드(필수 약관 미동의) 반환

* **Tests**
  * 약관 검증 및 가입 흐름 관련 단위 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->