### PR TITLE
feat: [alt-216] 근무자 색상 코드 변경 기능 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/WorkerSummaryDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/WorkerSummaryDto.java
@@ -11,21 +11,25 @@ import org.apache.commons.lang3.ObjectUtils;
 @Builder(access = AccessLevel.PRIVATE)
 @Schema(description = "근무자 요약 정보")
 public class WorkerSummaryDto {
-    
+
     @Schema(description = "근무자 ID", example = "1")
     private Long workerId;
-    
+
     @Schema(description = "근무자명", example = "김알바")
     private String workerName;
+
+    @Schema(description = "근무자 표시 색상 (hex)", example = "#9CA3AF")
+    private String colorCode;
 
     public static WorkerSummaryDto of(WorkspaceWorker workspaceWorker) {
         if (ObjectUtils.isEmpty(workspaceWorker)) {
             return null;
         }
-        
+
         return WorkerSummaryDto.builder()
             .workerId(workspaceWorker.getId())
             .workerName(workspaceWorker.getUser().getName())
+            .colorCode(workspaceWorker.getColorCode())
             .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
@@ -21,6 +21,7 @@ import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.ManagerWorkspac
 import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.ManagerWorkspaceWorkerListFilterDto;
 import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.ManagerWorkspaceWorkerListResponseDto;
 import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateFixedScheduleDateRequestDto;
+import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
 import com.dreamteam.alter.application.aop.ManagerActionContext;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceListUseCase;
@@ -28,6 +29,7 @@ import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceMana
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceWorkerListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateFixedScheduleDateUseCase;
+import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateWorkspaceWorkerColorCodeUseCase;
 
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -54,6 +56,9 @@ public class ManagerWorkspaceController implements ManagerWorkspaceControllerSpe
 
     @Resource(name = "managerUpdateFixedScheduleDate")
     private final ManagerUpdateFixedScheduleDateUseCase managerUpdateFixedScheduleDate;
+
+    @Resource(name = "managerUpdateWorkspaceWorkerColorCode")
+    private final ManagerUpdateWorkspaceWorkerColorCodeUseCase managerUpdateWorkspaceWorkerColor;
 
     @Override
     @GetMapping
@@ -104,6 +109,18 @@ public class ManagerWorkspaceController implements ManagerWorkspaceControllerSpe
     ) {
         ManagerActor actor = ManagerActionContext.getInstance().getActor();
         managerUpdateFixedScheduleDate.execute(actor, workspaceId, request);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @PatchMapping("/{workspaceId}/workers/{workerId}/color")
+    public ResponseEntity<CommonApiResponse<Void>> updateWorkspaceWorkerColorCode(
+        @PathVariable Long workspaceId,
+        @PathVariable Long workerId,
+        @RequestBody @Valid UpdateWorkspaceWorkerColorRequestDto request
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        managerUpdateWorkspaceWorkerColor.execute(actor, workspaceId, workerId, request);
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
@@ -24,6 +24,7 @@ import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateFixedSche
 import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
 import com.dreamteam.alter.application.aop.ManagerActionContext;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.command.UpdateWorkspaceWorkerColorCommand;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceManagerListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceUseCase;
@@ -120,7 +121,12 @@ public class ManagerWorkspaceController implements ManagerWorkspaceControllerSpe
         @RequestBody @Valid UpdateWorkspaceWorkerColorRequestDto request
     ) {
         ManagerActor actor = ManagerActionContext.getInstance().getActor();
-        managerUpdateWorkspaceWorkerColor.execute(actor, workspaceId, workerId, request);
+        managerUpdateWorkspaceWorkerColor.execute(
+            actor,
+            workspaceId,
+            workerId,
+            UpdateWorkspaceWorkerColorCommand.of(request.getColorCode())
+        );
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
@@ -120,7 +120,7 @@ public interface ManagerWorkspaceControllerSpec {
                 examples = {
                     @ExampleObject(
                         name = "이미 사용 중인 근무자 색상입니다.",
-                        value = "{\"code\" : \"B026\"}"
+                        value = "{\"code\" : \"B020\"}"
                     ),
                 })),
     })

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
@@ -86,6 +86,50 @@ public interface ManagerWorkspaceControllerSpec {
         @RequestBody @Valid UpdateFixedScheduleDateRequestDto request
     );
 
+    @Operation(summary = "매니저 - 근무자 색상 변경", description = "근무자 캘린더에서 사용할 표시 색상을 변경합니다. 같은 업장의 ACTIVATED 근무자끼리 색상은 unique 합니다 (기본 색상 #9CA3AF 제외).")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "색상 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 색상 형식",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "잘못된 요청",
+                        value = "{\"code\" : \"B001\"}"
+                    ),
+                })),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 업장 또는 근무자",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 업장입니다.",
+                        value = "{\"code\" : \"B008\"}"
+                    ),
+                    @ExampleObject(
+                        name = "근무자를 찾을 수 없습니다.",
+                        value = "{\"code\" : \"B019\"}"
+                    ),
+                })),
+        @ApiResponse(responseCode = "409", description = "이미 사용 중인 색상",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "이미 사용 중인 근무자 색상입니다.",
+                        value = "{\"code\" : \"B026\"}"
+                    ),
+                })),
+    })
+    ResponseEntity<CommonApiResponse<Void>> updateWorkspaceWorkerColorCode(
+        @PathVariable Long workspaceId,
+        @PathVariable Long workerId,
+        @RequestBody @Valid UpdateWorkspaceWorkerColorRequestDto request
+    );
+
     // 업장 근무자 상세 정보 조회
 
     // 업장 근무자 상태 변경

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceWorkerListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/ManagerWorkspaceWorkerListResponseDto.java
@@ -35,6 +35,10 @@ public class ManagerWorkspaceWorkerListResponseDto {
     private WorkerPositionResponseDto position;
 
     @NotNull
+    @Schema(description = "근무자 표시 색상 (hex)", example = "#9CA3AF")
+    private String colorCode;
+
+    @NotNull
     @Schema(description = "채용일자", example = "2023-10-01T12:00:00")
     private LocalDate employedAt;
 
@@ -50,6 +54,7 @@ public class ManagerWorkspaceWorkerListResponseDto {
             .user(WorkspaceWorkerResponseDto.of(entity.getUser()))
             .status(DescribedEnumDto.of(entity.getStatus(), WorkspaceWorkerStatus.describe()))
             .position(WorkerPositionResponseDto.from(entity.getPosition()))
+            .colorCode(entity.getColorCode())
             .employedAt(entity.getEmployedAt())
             .resignedAt(entity.getResignedAt())
             .nextShiftDateTime(entity.getNextShiftDateTime())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/UpdateWorkspaceWorkerColorRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/UpdateWorkspaceWorkerColorRequestDto.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.inbound.manager.workspace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "매니저 - 근무자 색상 변경 요청 DTO")
+public class UpdateWorkspaceWorkerColorRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "색상은 #로 시작하는 6자리 16진수여야 합니다.")
+    @Schema(description = "변경할 색상 (hex)", example = "#93B0A4")
+    private String colorCode;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
@@ -173,6 +173,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 ),
                 qWorkspaceWorker.status,
                 Expressions.constant(WorkerPositionType.WORKER),
+                qWorkspaceWorker.colorCode,
                 qWorkspaceWorker.employedAt,
                 qWorkspaceWorker.resignedAt,
                 qWorkspaceWorker.createdAt,
@@ -205,6 +206,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qUser.contact,
                 qUser.gender,
                 qWorkspaceWorker.status,
+                qWorkspaceWorker.colorCode,
                 qWorkspaceWorker.employedAt,
                 qWorkspaceWorker.resignedAt,
                 qWorkspaceWorker.createdAt

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceWorkerQueryRepositoryImpl.java
@@ -131,8 +131,30 @@ public class WorkspaceWorkerQueryRepositoryImpl implements WorkspaceWorkerQueryR
     }
 
 
+    @Override
+    public boolean existsActivatedByWorkspaceAndColorCode(Long workspaceId, String colorCode, Long excludeWorkerId) {
+        QWorkspaceWorker qWorkspaceWorker = QWorkspaceWorker.workspaceWorker;
+
+        BooleanExpression excludeCondition = ObjectUtils.isNotEmpty(excludeWorkerId)
+            ? qWorkspaceWorker.id.ne(excludeWorkerId)
+            : null;
+
+        Integer result = queryFactory
+            .selectOne()
+            .from(qWorkspaceWorker)
+            .where(
+                qWorkspaceWorker.workspace.id.eq(workspaceId),
+                qWorkspaceWorker.colorCode.eq(colorCode),
+                qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED),
+                excludeCondition
+            )
+            .fetchFirst();
+
+        return result != null;
+    }
+
     private BooleanExpression cursorConditions(
-        QWorkspaceWorker qWorkspaceWorker, 
+        QWorkspaceWorker qWorkspaceWorker,
         CursorDto cursor
     ) {
         if (ObjectUtils.isEmpty(cursor)) {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerWorkspaceWorkerListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerWorkspaceWorkerListResponse.java
@@ -26,6 +26,8 @@ public class ManagerWorkspaceWorkerListResponse {
     @Enumerated(EnumType.STRING)
     private WorkerPositionType position;
 
+    private String colorCode;
+
     private LocalDate employedAt;
 
     private LocalDate resignedAt;

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerUpdateWorkspaceWorkerColorCode.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerUpdateWorkspaceWorkerColorCode.java
@@ -1,0 +1,52 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateWorkspaceWorkerColorCodeUseCase;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("managerUpdateWorkspaceWorkerColorCode")
+@RequiredArgsConstructor
+@Transactional
+public class ManagerUpdateWorkspaceWorkerColorCode implements ManagerUpdateWorkspaceWorkerColorCodeUseCase {
+
+    private final WorkspaceQueryRepository workspaceQueryRepository;
+    private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+
+    @Override
+    public void execute(
+        ManagerActor actor,
+        Long workspaceId,
+        Long workerId,
+        UpdateWorkspaceWorkerColorRequestDto request
+    ) {
+        if (!workspaceQueryRepository.existsByIdAndManagerUser(workspaceId, actor.getManagerUser())) {
+            throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
+        WorkspaceWorker worker = workspaceWorkerQueryRepository.findById(workerId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "근무자를 찾을 수 없습니다"));
+
+        if (!worker.getWorkspace().getId().equals(workspaceId)) {
+            throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
+        if (!WorkspaceWorker.DEFAULT_COLOR_CODE.equals(request.getColorCode())
+            && workspaceWorkerQueryRepository.existsActivatedByWorkspaceAndColorCode(
+                workspaceId,
+                request.getColorCode(),
+                workerId
+            )) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 사용 중인 근무자 색상입니다.");
+        }
+
+        worker.updateColorCode(request.getColorCode());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerUpdateWorkspaceWorkerColorCode.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerUpdateWorkspaceWorkerColorCode.java
@@ -1,9 +1,9 @@
 package com.dreamteam.alter.application.workspace.usecase;
 
-import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.command.UpdateWorkspaceWorkerColorCommand;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateWorkspaceWorkerColorCodeUseCase;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
@@ -25,7 +25,7 @@ public class ManagerUpdateWorkspaceWorkerColorCode implements ManagerUpdateWorks
         ManagerActor actor,
         Long workspaceId,
         Long workerId,
-        UpdateWorkspaceWorkerColorRequestDto request
+        UpdateWorkspaceWorkerColorCommand command
     ) {
         if (!workspaceQueryRepository.existsByIdAndManagerUser(workspaceId, actor.getManagerUser())) {
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
@@ -38,15 +38,15 @@ public class ManagerUpdateWorkspaceWorkerColorCode implements ManagerUpdateWorks
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        if (!WorkspaceWorker.DEFAULT_COLOR_CODE.equals(request.getColorCode())
+        if (!WorkspaceWorker.DEFAULT_COLOR_CODE.equals(command.getColorCode())
             && workspaceWorkerQueryRepository.existsActivatedByWorkspaceAndColorCode(
                 workspaceId,
-                request.getColorCode(),
+                command.getColorCode(),
                 workerId
             )) {
             throw new CustomException(ErrorCode.CONFLICT, "이미 사용 중인 근무자 색상입니다.");
         }
 
-        worker.updateColorCode(request.getColorCode());
+        worker.updateColorCode(command.getColorCode());
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/command/UpdateWorkspaceWorkerColorCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/command/UpdateWorkspaceWorkerColorCommand.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.domain.workspace.command;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateWorkspaceWorkerColorCommand {
+
+    private String colorCode;
+
+    public static UpdateWorkspaceWorkerColorCommand of(String colorCode) {
+        return UpdateWorkspaceWorkerColorCommand.builder()
+            .colorCode(colorCode)
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorker.java
@@ -20,6 +20,8 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class WorkspaceWorker {
 
+    public static final String DEFAULT_COLOR_CODE = "#9CA3AF";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,6 +37,10 @@ public class WorkspaceWorker {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private WorkspaceWorkerStatus status;
+
+    @Builder.Default
+    @Column(name = "color_code", nullable = false, length = 7)
+    private String colorCode = DEFAULT_COLOR_CODE;
 
     @Column(name = "employed_at", nullable = false)
     private LocalDate employedAt;
@@ -65,6 +71,10 @@ public class WorkspaceWorker {
     public void resign() {
         this.status = WorkspaceWorkerStatus.RESIGNED;
         this.resignedAt = LocalDate.now();
+    }
+
+    public void updateColorCode(String colorCode) {
+        this.colorCode = colorCode;
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerUpdateWorkspaceWorkerColorCodeUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerUpdateWorkspaceWorkerColorCodeUseCase.java
@@ -1,8 +1,8 @@
 package com.dreamteam.alter.domain.workspace.port.inbound;
 
-import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.command.UpdateWorkspaceWorkerColorCommand;
 
 public interface ManagerUpdateWorkspaceWorkerColorCodeUseCase {
-    void execute(ManagerActor actor, Long workspaceId, Long workerId, UpdateWorkspaceWorkerColorRequestDto request);
+    void execute(ManagerActor actor, Long workspaceId, Long workerId, UpdateWorkspaceWorkerColorCommand command);
 }

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerUpdateWorkspaceWorkerColorCodeUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerUpdateWorkspaceWorkerColorCodeUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import com.dreamteam.alter.adapter.inbound.manager.workspace.dto.UpdateWorkspaceWorkerColorRequestDto;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerUpdateWorkspaceWorkerColorCodeUseCase {
+    void execute(ManagerActor actor, Long workspaceId, Long workerId, UpdateWorkspaceWorkerColorRequestDto request);
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceWorkerQueryRepository.java
@@ -15,11 +15,13 @@ public interface WorkspaceWorkerQueryRepository {
     Optional<WorkspaceWorker> findById(Long id);
     List<WorkspaceWorker> findAllById(List<Long> ids);
     List<WorkspaceWorker> findAllActiveByUserId(Long userId);
-    
+
     long getUserActiveWorkspaceCount(User user);
-    
+
     List<UserWorkspaceListResponse> getUserActiveWorkspaceListWithCursor(
-        CursorPageRequest<CursorDto> request, 
+        CursorPageRequest<CursorDto> request,
         User user
     );
+
+    boolean existsActivatedByWorkspaceAndColorCode(Long workspaceId, String colorCode, Long excludeWorkerId);
 }


### PR DESCRIPTION
## 변경사항

- 근무자 색상 코드 엔티티 필드 및 UseCase 추가
- 근무자 색상 코드 변경 DTO 및 응답 필드 추가
- 근무자 색상 코드 변경 API 엔드포인트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 근무자별 색상 코드 지정으로 일정 캘린더에서 근무자를 색상으로 구분할 수 있습니다.
  * 관리자가 근무자의 표시 색상을 변경할 수 있는 PATCH API가 추가되었습니다.
  * 기본 색상은 #9CA3AF이며, 16진수 형식(#RRGGBB) 입력을 검증하고 중복 색상 충돌을 방지합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alter-app/alter-backend/pull/85)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->