### PR TITLE
feat: 알림 타입별 필터링 및 동의 관리 기능 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/notification/dto/AdminSendMockNotificationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/notification/dto/AdminSendMockNotificationRequestDto.java
@@ -1,5 +1,6 @@
 package com.dreamteam.alter.adapter.inbound.admin.notification.dto;
 
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -21,5 +22,8 @@ public class AdminSendMockNotificationRequestDto {
 
     @Schema(description = "알림 내용")
     private String body;
+
+    @Schema(description = "알림 타입 (null 시 GENERAL)")
+    private NotificationType type;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/FcmBatchNotificationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/FcmBatchNotificationRequestDto.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.common.dto;
 
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -23,6 +24,10 @@ public class FcmBatchNotificationRequestDto {
     @Schema(description = "알림 범위", example = "APP")
     private TokenScope scope;
 
+    @NotNull
+    @Schema(description = "알림 유형", example = "GENERAL")
+    private NotificationType type;
+
     @NotBlank
     @Schema(description = "알림 제목", example = "새로운 메시지")
     private String title;
@@ -31,7 +36,9 @@ public class FcmBatchNotificationRequestDto {
     @Schema(description = "알림 내용", example = "새로운 메시지가 도착했습니다.")
     private String body;
 
-    public static FcmBatchNotificationRequestDto of(List<Long> targetUserIds, TokenScope scope, String title, String body) {
-        return new FcmBatchNotificationRequestDto(targetUserIds, scope, title, body);
+    public static FcmBatchNotificationRequestDto of(
+        List<Long> targetUserIds, TokenScope scope, NotificationType type, String title, String body
+    ) {
+        return new FcmBatchNotificationRequestDto(targetUserIds, scope, type, title, body);
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/FcmNotificationRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/common/dto/FcmNotificationRequestDto.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.common.dto;
 
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,10 @@ public class FcmNotificationRequestDto {
     @Schema(description = "알림 범위", example = "APP")
     private TokenScope scope;
 
+    @NotNull
+    @Schema(description = "알림 유형", example = "GENERAL")
+    private NotificationType type;
+
     @NotBlank
     @Schema(description = "알림 제목", example = "새로운 메시지")
     private String title;
@@ -28,7 +33,9 @@ public class FcmNotificationRequestDto {
     @Schema(description = "알림 내용", example = "새로운 메시지가 도착했습니다.")
     private String body;
 
-    public static FcmNotificationRequestDto of(Long targetUserId, TokenScope scope, String title, String body) {
-        return new FcmNotificationRequestDto(targetUserId, scope, title, body);
+    public static FcmNotificationRequestDto of(
+        Long targetUserId, TokenScope scope, NotificationType type, String title, String body
+    ) {
+        return new FcmNotificationRequestDto(targetUserId, scope, type, title, body);
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationController.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.inbound.general.notification.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.application.aop.AppActionContext;
 import com.dreamteam.alter.domain.notification.port.inbound.GetMyNotificationsUseCase;
@@ -28,9 +29,10 @@ public class UserNotificationController implements UserNotificationControllerSpe
     @Override
     @GetMapping("/notifications")
     public ResponseEntity<CursorPaginatedApiResponse<NotificationResponseDto>> getMyNotifications(
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        NotificationListFilterDto filter
     ) {
         AppActor actor = AppActionContext.getInstance().getActor();
-        return ResponseEntity.ok(getMyNotificationsUseCase.execute(actor, pageRequest));
+        return ResponseEntity.ok(getMyNotificationsUseCase.execute(actor, pageRequest, filter));
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/controller/UserNotificationControllerSpec.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.inbound.general.notification.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,11 +13,12 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "APP - 알림 관련 API")
 public interface UserNotificationControllerSpec {
 
-    @Operation(summary = "내 알림 목록 조회 (커서 페이징)")
+    @Operation(summary = "내 알림 목록 조회 (커서 페이징, type 필터)")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
     })
     ResponseEntity<CursorPaginatedApiResponse<NotificationResponseDto>> getMyNotifications(
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        NotificationListFilterDto filter
     );
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationListFilterDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationListFilterDto.java
@@ -1,0 +1,20 @@
+package com.dreamteam.alter.adapter.inbound.general.notification.dto;
+
+import com.dreamteam.alter.domain.notification.type.NotificationType;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ParameterObject
+@Schema(description = "알림 목록 필터 DTO")
+public class NotificationListFilterDto {
+
+    @Parameter(description = "알림 유형 필터 (GENERAL | SCHEDULE | SUBSTITUTE | REPUTATION | POSTING_APPLICATION | CHAT | WORKSPACE_INVITATION | JOIN_REQUEST), 미입력 시 전체 조회")
+    private NotificationType type;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,8 @@
 package com.dreamteam.alter.adapter.inbound.general.notification.dto;
 
+import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
 import com.dreamteam.alter.adapter.outbound.notification.persistence.readonly.NotificationResponse;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -16,6 +18,9 @@ public class NotificationResponseDto {
     @Schema(description = "알림 ID")
     private Long id;
 
+    @Schema(description = "알림 유형")
+    private DescribedEnumDto<NotificationType> type;
+
     @Schema(description = "알림 제목")
     private String title;
 
@@ -28,6 +33,7 @@ public class NotificationResponseDto {
     public static NotificationResponseDto from(NotificationResponse response) {
         return NotificationResponseDto.builder()
             .id(response.id())
+            .type(DescribedEnumDto.of(response.type(), NotificationType.describe()))
             .title(response.title())
             .body(response.body())
             .createdAt(response.createdAt())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationController.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.inbound.manager.notification.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.application.aop.ManagerActionContext;
 import com.dreamteam.alter.domain.notification.port.inbound.ManagerGetMyNotificationsUseCase;
@@ -28,9 +29,10 @@ public class ManagerNotificationController implements ManagerNotificationControl
     @Override
     @GetMapping("/me")
     public ResponseEntity<CursorPaginatedApiResponse<NotificationResponseDto>> getMyNotifications(
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        NotificationListFilterDto filter
     ) {
         ManagerActor actor = ManagerActionContext.getInstance().getActor();
-        return ResponseEntity.ok(managerGetMyNotificationsUseCase.execute(actor, pageRequest));
+        return ResponseEntity.ok(managerGetMyNotificationsUseCase.execute(actor, pageRequest, filter));
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/notification/controller/ManagerNotificationControllerSpec.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.inbound.manager.notification.controller;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,11 +13,12 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "MANAGER - 알림 관련 API")
 public interface ManagerNotificationControllerSpec {
 
-    @Operation(summary = "내 알림 목록 조회 (커서 페이징)")
+    @Operation(summary = "내 알림 목록 조회 (커서 페이징, type 필터)")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
     })
     ResponseEntity<CursorPaginatedApiResponse<NotificationResponseDto>> getMyNotifications(
-        CursorPageRequestDto pageRequest
+        CursorPageRequestDto pageRequest,
+        NotificationListFilterDto filter
     );
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/NotificationQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.adapter.outbound.notification.persistence.readonly.No
 import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.QNotification;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationQueryRepository;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -26,7 +27,8 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
     public List<NotificationResponse> getNotificationsWithCursor(
         CursorPageRequest<CursorDto> pageRequest,
         User targetUser,
-        TokenScope scope
+        TokenScope scope,
+        NotificationType type
     ) {
         QNotification notification = QNotification.notification;
 
@@ -34,6 +36,7 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
             .select(Projections.constructor(
                 NotificationResponse.class,
                 notification.id,
+                notification.type,
                 notification.title,
                 notification.body,
                 notification.createdAt
@@ -42,6 +45,7 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
             .where(
                 notification.targetUser.eq(targetUser),
                 notification.scope.eq(scope),
+                eqType(notification, type),
                 cursorCondition(notification, pageRequest.cursor())
             )
             .orderBy(notification.createdAt.desc(), notification.id.desc())
@@ -50,7 +54,7 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
     }
 
     @Override
-    public long getCountOfNotifications(User targetUser, TokenScope scope) {
+    public long getCountOfNotifications(User targetUser, TokenScope scope, NotificationType type) {
         QNotification notification = QNotification.notification;
 
         Long count = queryFactory
@@ -58,11 +62,16 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
             .from(notification)
             .where(
                 notification.targetUser.eq(targetUser),
-                notification.scope.eq(scope)
+                notification.scope.eq(scope),
+                eqType(notification, type)
             )
             .fetchOne();
 
         return ObjectUtils.isEmpty(count) ? 0 : count;
+    }
+
+    private BooleanExpression eqType(QNotification notification, NotificationType type) {
+        return type != null ? notification.type.eq(type) : null;
     }
 
     private BooleanExpression cursorCondition(

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/readonly/NotificationResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/notification/persistence/readonly/NotificationResponse.java
@@ -1,9 +1,12 @@
 package com.dreamteam.alter.adapter.outbound.notification.persistence.readonly;
 
+import com.dreamteam.alter.domain.notification.type.NotificationType;
+
 import java.time.LocalDateTime;
 
 public record NotificationResponse(
     Long id,
+    NotificationType type,
     String title,
     String body,
     LocalDateTime createdAt

--- a/src/main/java/com/dreamteam/alter/application/admin/usecase/AdminSendMockNotification.java
+++ b/src/main/java/com/dreamteam/alter/application/admin/usecase/AdminSendMockNotification.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.admin.notification.dto.AdminSendMockN
 import com.dreamteam.alter.adapter.inbound.common.dto.FcmNotificationRequestDto;
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.admin.port.inbound.AdminSendMockNotificationUseCase;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
@@ -25,7 +26,7 @@ public class AdminSendMockNotification implements AdminSendMockNotificationUseCa
         String title = ObjectUtils.isNotEmpty(request.getTitle()) ? request.getTitle() : DEFAULT_MOCK_TITLE;
         String body = ObjectUtils.isNotEmpty(request.getBody()) ? request.getBody() : DEFAULT_MOCK_BODY;
 
-        notificationService.sendNotification(FcmNotificationRequestDto.of(request.getUserId(), TokenScope.APP, title, body));
+        notificationService.sendNotification(FcmNotificationRequestDto.of(request.getUserId(), TokenScope.APP, NotificationType.GENERAL, title, body));
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/application/admin/usecase/AdminSendMockNotification.java
+++ b/src/main/java/com/dreamteam/alter/application/admin/usecase/AdminSendMockNotification.java
@@ -25,8 +25,9 @@ public class AdminSendMockNotification implements AdminSendMockNotificationUseCa
     public void execute(AdminSendMockNotificationRequestDto request) {
         String title = ObjectUtils.isNotEmpty(request.getTitle()) ? request.getTitle() : DEFAULT_MOCK_TITLE;
         String body = ObjectUtils.isNotEmpty(request.getBody()) ? request.getBody() : DEFAULT_MOCK_BODY;
+        NotificationType type = ObjectUtils.isNotEmpty(request.getType()) ? request.getType() : NotificationType.GENERAL;
 
-        notificationService.sendNotification(FcmNotificationRequestDto.of(request.getUserId(), TokenScope.APP, NotificationType.GENERAL, title, body));
+        notificationService.sendNotification(FcmNotificationRequestDto.of(request.getUserId(), TokenScope.APP, type, title, body));
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/application/chat/usecase/AbstractSendChatMessageUseCase.java
+++ b/src/main/java/com/dreamteam/alter/application/chat/usecase/AbstractSendChatMessageUseCase.java
@@ -12,6 +12,7 @@ import com.dreamteam.alter.domain.chat.port.outbound.ChatMessageRepository;
 import com.dreamteam.alter.domain.chat.port.outbound.ChatRoomQueryRepository;
 import com.dreamteam.alter.domain.chat.port.outbound.ChatRoomRepository;
 import com.dreamteam.alter.application.notification.NotificationService;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -104,7 +105,7 @@ public abstract class AbstractSendChatMessageUseCase<U> extends AbstractChatUseC
             );
 
             // FCM 알림 전송
-            notificationService.sendNotificationOnly(opponentId, title, body);
+            notificationService.sendNotificationOnly(opponentId, NotificationType.CHAT, title, body);
 
         } catch (Exception e) {
             // 알림 실패는 로그만 남기고 메시지 전송은 성공 처리

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -9,6 +9,7 @@ import com.dreamteam.alter.domain.notification.entity.Notification;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationRepository;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.FcmDeviceToken;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserFcmDeviceTokenRepository;
@@ -94,7 +95,7 @@ public class NotificationService {
         String deviceTokenString = deviceTokenOpt.map(FcmDeviceToken::getDeviceToken).orElse(null);
 
         // 3. 알림 레코드 저장
-        saveNotification(user, request.getScope(), deviceTokenString, request.getTitle(), request.getBody());
+        saveNotification(user, request.getScope(), request.getType(), deviceTokenString, request.getTitle(), request.getBody());
 
         // 4. FCM 발송
         sendFcmNotification(user, request.getTitle(), request.getBody(), true);
@@ -124,6 +125,7 @@ public class NotificationService {
             .map(user -> Notification.create(
                 user,
                 request.getScope(),
+                request.getType(),
                 deviceTokenMap.get(user.getId()),
                 request.getTitle(),
                 request.getBody()
@@ -267,9 +269,11 @@ public class NotificationService {
     /**
      * Notification 엔티티 저장
      */
-    private void saveNotification(User user, TokenScope scope, String deviceToken, String title, String body) {
+    private void saveNotification(
+        User user, TokenScope scope, NotificationType type, String deviceToken, String title, String body
+    ) {
         notificationRepository.save(Notification.create(
-            user, scope, deviceToken, title, body
+            user, scope, type, deviceToken, title, body
         ));
     }
 

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -98,7 +98,7 @@ public class NotificationService {
         saveNotification(user, request.getScope(), request.getType(), deviceTokenString, request.getTitle(), request.getBody());
 
         // 4. FCM 발송
-        sendFcmNotification(user, request.getTitle(), request.getBody(), true);
+        sendFcmNotification(user, request.getType(), request.getTitle(), request.getBody(), true);
     }
 
     public void sendMultipleNotifications(FcmBatchNotificationRequestDto request) {
@@ -138,11 +138,13 @@ public class NotificationService {
             .stream()
             .collect(Collectors.toMap(c -> c.getUser().getId(), c -> c));
 
+        boolean daytime = isDaytime();
+        NotificationType type = request.getType();
         List<FcmDeviceToken> eligibleTokens = deviceTokens.stream()
             .filter(dt -> {
                 NotificationConsent consent = Optional.ofNullable(consentMap.get(dt.getUser().getId()))
                     .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 동의 레코드를 찾을 수 없습니다."));
-                return consent.isNotificationConsent() && (consent.isNightNotificationConsent() || isDaytime());
+                return !consent.isBlocked(type, daytime);
             })
             .toList();
 
@@ -208,7 +210,7 @@ public class NotificationService {
      * FCM 알림만 발송 (Notification 엔티티 저장 없음)
      * 채팅 메시지 등 별도 저장 로직이 있는 경우 사용
      */
-    public void sendNotificationOnly(Long userId, String title, String body) {
+    public void sendNotificationOnly(Long userId, NotificationType type, String title, String body) {
         User user = userQueryRepository.findById(userId)
             .orElse(null);
 
@@ -217,12 +219,12 @@ public class NotificationService {
             return;
         }
 
-        if (isNotificationBlocked(user)) {
+        if (isNotificationBlocked(user, type)) {
             log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", userId);
             return;
         }
 
-        sendFcmNotification(user, title, body, false);
+        sendFcmNotification(user, type, title, body, false);
     }
 
     /**
@@ -232,8 +234,8 @@ public class NotificationService {
      * @param body 알림 본문
      * @param throwOnError 발송 실패 시 예외 throw 여부
      */
-    private void sendFcmNotification(User user, String title, String body, boolean throwOnError) {
-        if (isNotificationBlocked(user)) {
+    private void sendFcmNotification(User user, NotificationType type, String title, String body, boolean throwOnError) {
+        if (isNotificationBlocked(user, type)) {
             log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", user.getId());
             return;
         }
@@ -286,10 +288,10 @@ public class NotificationService {
     }
 
 
-    private boolean isNotificationBlocked(User user) {
+    private boolean isNotificationBlocked(User user, NotificationType type) {
         NotificationConsent consent = notificationConsentQueryRepository.findByUser(user)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "알림 수신 동의 레코드를 찾을 수 없습니다."));
-        return !consent.isNotificationConsent() || (!consent.isNightNotificationConsent() && !isDaytime());
+        return consent.isBlocked(type, isDaytime());
     }
 
     private boolean isDaytime() {

--- a/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/NotificationService.java
@@ -219,11 +219,6 @@ public class NotificationService {
             return;
         }
 
-        if (isNotificationBlocked(user, type)) {
-            log.debug("알림 수신 동의 거부로 FCM 발송 건너뜀. userId={}", userId);
-            return;
-        }
-
         sendFcmNotification(user, type, title, body, false);
     }
 

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/GetMyNotifications.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/GetMyNotifications.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.adapter.outbound.notification.persistence.readonly.NotificationResponse;
 import com.dreamteam.alter.common.util.CursorUtil;
@@ -29,20 +30,22 @@ public class GetMyNotifications implements GetMyNotificationsUseCase {
     private final ObjectMapper objectMapper;
 
     @Override
-    public CursorPaginatedApiResponse<NotificationResponseDto> execute(AppActor actor, CursorPageRequestDto pageRequest) {
+    public CursorPaginatedApiResponse<NotificationResponseDto> execute(
+        AppActor actor, CursorPageRequestDto pageRequest, NotificationListFilterDto filter
+    ) {
         CursorDto cursorDto = null;
         if (ObjectUtils.isNotEmpty(pageRequest.cursor())) {
             cursorDto = CursorUtil.decodeCursor(pageRequest.cursor(), CursorDto.class, objectMapper);
         }
         CursorPageRequest<CursorDto> cursorPageRequest = CursorPageRequest.of(cursorDto, pageRequest.pageSize());
 
-        long count = notificationQueryRepository.getCountOfNotifications(actor.getUser(), TokenScope.APP);
+        long count = notificationQueryRepository.getCountOfNotifications(actor.getUser(), TokenScope.APP, filter.getType());
         if (count == 0) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));
         }
 
         List<NotificationResponse> notifications = notificationQueryRepository.getNotificationsWithCursor(
-            cursorPageRequest, actor.getUser(), TokenScope.APP
+            cursorPageRequest, actor.getUser(), TokenScope.APP, filter.getType()
         );
         if (ObjectUtils.isEmpty(notifications)) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));

--- a/src/main/java/com/dreamteam/alter/application/notification/usecase/ManagerGetMyNotifications.java
+++ b/src/main/java/com/dreamteam/alter/application/notification/usecase/ManagerGetMyNotifications.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageResponseDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.adapter.outbound.notification.persistence.readonly.NotificationResponse;
 import com.dreamteam.alter.common.util.CursorUtil;
@@ -30,7 +31,9 @@ public class ManagerGetMyNotifications implements ManagerGetMyNotificationsUseCa
     private final ObjectMapper objectMapper;
 
     @Override
-    public CursorPaginatedApiResponse<NotificationResponseDto> execute(ManagerActor actor, CursorPageRequestDto pageRequest) {
+    public CursorPaginatedApiResponse<NotificationResponseDto> execute(
+        ManagerActor actor, CursorPageRequestDto pageRequest, NotificationListFilterDto filter
+    ) {
         CursorDto cursorDto = null;
         if (ObjectUtils.isNotEmpty(pageRequest.cursor())) {
             cursorDto = CursorUtil.decodeCursor(pageRequest.cursor(), CursorDto.class, objectMapper);
@@ -40,13 +43,13 @@ public class ManagerGetMyNotifications implements ManagerGetMyNotificationsUseCa
         // ManagerActor에서 User 추출
         User targetUser = actor.getManagerUser().getUser();
 
-        long count = notificationQueryRepository.getCountOfNotifications(targetUser, TokenScope.MANAGER);
+        long count = notificationQueryRepository.getCountOfNotifications(targetUser, TokenScope.MANAGER, filter.getType());
         if (count == 0) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));
         }
 
         List<NotificationResponse> notifications = notificationQueryRepository.getNotificationsWithCursor(
-            cursorPageRequest, targetUser, TokenScope.MANAGER
+            cursorPageRequest, targetUser, TokenScope.MANAGER, filter.getType()
         );
         if (ObjectUtils.isEmpty(notifications)) {
             return CursorPaginatedApiResponse.empty(CursorPageResponseDto.empty(pageRequest.pageSize(), (int) count));

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePostingApplication.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePostingApplication.java
@@ -7,6 +7,7 @@ import com.dreamteam.alter.common.notification.NotificationMessageBuilder;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.entity.Posting;
 import com.dreamteam.alter.domain.posting.entity.PostingApplication;
@@ -70,7 +71,7 @@ public class CreatePostingApplication implements CreatePostingApplicationUseCase
             String body = NotificationMessageBuilder.buildNewApplicationMessage(postingTitle);
             
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(managerUserId, TokenScope.MANAGER, title, body)
+                FcmNotificationRequestDto.of(managerUserId, TokenScope.MANAGER, NotificationType.POSTING_APPLICATION, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 지원 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePostingApplicationStatus.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePostingApplicationStatus.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.entity.PostingApplication;
 import com.dreamteam.alter.domain.posting.port.inbound.ManagerUpdatePostingApplicationStatusUseCase;
@@ -99,7 +100,7 @@ public class ManagerUpdatePostingApplicationStatus implements ManagerUpdatePosti
             }
 
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(applicantUserId, TokenScope.APP, title, body)
+                FcmNotificationRequestDto.of(applicantUserId, TokenScope.APP, NotificationType.POSTING_APPLICATION, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 상태 변경 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/reputation/usecase/AbstractCreateReputation.java
+++ b/src/main/java/com/dreamteam/alter/application/reputation/usecase/AbstractCreateReputation.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.general.reputation.dto.ReputationKeyw
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.reputation.entity.Reputation;
 import com.dreamteam.alter.domain.reputation.entity.ReputationKeyword;
@@ -75,7 +76,7 @@ public abstract class AbstractCreateReputation {
     protected final void sendNotificationToTarget(Long targetUserId, String title, String body) {
         try {
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(targetUserId, TokenScope.APP, title, body)
+                FcmNotificationRequestDto.of(targetUserId, TokenScope.APP, NotificationType.REPUTATION, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 평판 요청 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/AcceptSubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/AcceptSubstituteRequest.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.FcmNotificationRequestDto;
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.user.context.AppActor;
@@ -87,7 +88,7 @@ public class AcceptSubstituteRequest implements AcceptSubstituteRequestUseCase {
                 );
 
                 notificationService.sendNotification(
-                    FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, title, body)
+                    FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
                 );
             }
 
@@ -105,7 +106,7 @@ public class AcceptSubstituteRequest implements AcceptSubstituteRequestUseCase {
             );
 
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(managerUser.getUser().getId(), TokenScope.MANAGER, managerTitle, managerBody)
+                FcmNotificationRequestDto.of(managerUser.getUser().getId(), TokenScope.MANAGER, NotificationType.SUBSTITUTE, managerTitle, managerBody)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 수락 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ApproveJoinRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ApproveJoinRequest.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.entity.BusinessJoinRequest;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
@@ -54,7 +55,7 @@ public class ApproveJoinRequest implements ApproveJoinRequestUseCase {
             workspace.getBusinessName()
         );
         eventPublisher.publishEvent(
-            new FcmNotificationEvent(FcmNotificationRequestDto.of(joinRequest.getUser().getId(), TokenScope.APP, title, body))
+            new FcmNotificationEvent(FcmNotificationRequestDto.of(joinRequest.getUser().getId(), TokenScope.APP, NotificationType.JOIN_REQUEST, title, body))
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/CreateSubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/CreateSubstituteRequest.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.general.schedule.dto.CreateSubstitute
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.user.context.AppActor;
@@ -219,7 +220,7 @@ public class CreateSubstituteRequest implements CreateSubstituteRequestUseCase {
 
             // 다중 사용자 알림 발송
             notificationService.sendMultipleNotifications(
-                FcmBatchNotificationRequestDto.of(targetUserIds, TokenScope.APP, title, body)
+                FcmBatchNotificationRequestDto.of(targetUserIds, TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
             );
 
         } catch (CustomException e) {

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerApproveSubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerApproveSubstituteRequest.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ApproveSubstitut
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
@@ -77,7 +78,7 @@ public class ManagerApproveSubstituteRequest implements ManagerApproveSubstitute
             workspaceWorkerQueryRepository.findById(request.getRequesterId())
                 .ifPresent(requesterWorker -> {
                     notificationService.sendNotification(
-                        FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, title, body)
+                        FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
                     );
                 });
 
@@ -85,7 +86,7 @@ public class ManagerApproveSubstituteRequest implements ManagerApproveSubstitute
             workspaceWorkerQueryRepository.findById(request.getAcceptedWorkerId())
                 .ifPresent(acceptedWorker -> {
                     notificationService.sendNotification(
-                        FcmNotificationRequestDto.of(acceptedWorker.getUser().getId(), TokenScope.APP, title, body)
+                        FcmNotificationRequestDto.of(acceptedWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
                     );
                 });
         } catch (CustomException e) {

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerAssignWorkerToSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerAssignWorkerToSchedule.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.notification.NotificationMessageBuilder;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
@@ -87,7 +88,7 @@ public class ManagerAssignWorkerToSchedule implements ManagerAssignWorkerUseCase
             );
             
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(worker.getUser().getId(), TokenScope.APP, title, body)
+                FcmNotificationRequestDto.of(worker.getUser().getId(), TokenScope.APP, NotificationType.SCHEDULE, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 스케줄 배정 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerRejectSubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerRejectSubstituteRequest.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.manager.schedule.dto.ManagerRejectSub
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
@@ -71,7 +72,7 @@ public class ManagerRejectSubstituteRequest implements ManagerRejectSubstituteRe
             workspaceWorkerQueryRepository.findById(request.getRequesterId())
                 .ifPresent(requesterWorker -> {
                     notificationService.sendNotification(
-                        FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, title, body)
+                        FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
                     );
                 });
 
@@ -79,7 +80,7 @@ public class ManagerRejectSubstituteRequest implements ManagerRejectSubstituteRe
             workspaceWorkerQueryRepository.findById(request.getAcceptedWorkerId())
                 .ifPresent(acceptedWorker -> {
                     notificationService.sendNotification(
-                        FcmNotificationRequestDto.of(acceptedWorker.getUser().getId(), TokenScope.APP, title, body)
+                        FcmNotificationRequestDto.of(acceptedWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
                     );
                 });
         } catch (CustomException e) {

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerRemoveWorkerFromSchedule.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerRemoveWorkerFromSchedule.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.notification.NotificationMessageBuilder;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
@@ -64,7 +65,7 @@ public class ManagerRemoveWorkerFromSchedule implements ManagerRemoveWorkerUseCa
             );
             
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(worker.getUser().getId(), TokenScope.APP, title, body)
+                FcmNotificationRequestDto.of(worker.getUser().getId(), TokenScope.APP, NotificationType.SCHEDULE, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 스케줄 제거 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/RejectJoinRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/RejectJoinRequest.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.workspace.entity.BusinessJoinRequest;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
@@ -50,7 +51,7 @@ public class RejectJoinRequest implements RejectJoinRequestUseCase {
             workspace.getBusinessName()
         );
         eventPublisher.publishEvent(
-            new FcmNotificationEvent(FcmNotificationRequestDto.of(joinRequest.getUser().getId(), TokenScope.APP, title, body))
+            new FcmNotificationEvent(FcmNotificationRequestDto.of(joinRequest.getUser().getId(), TokenScope.APP, NotificationType.JOIN_REQUEST, title, body))
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/RejectSubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/RejectSubstituteRequest.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.general.schedule.dto.RejectSubstitute
 import com.dreamteam.alter.application.notification.NotificationService;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.user.context.AppActor;
@@ -71,7 +72,7 @@ public class RejectSubstituteRequest implements RejectSubstituteRequestUseCase {
             );
 
             notificationService.sendNotification(
-                FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, title, body)
+                FcmNotificationRequestDto.of(requesterWorker.getUser().getId(), TokenScope.APP, NotificationType.SUBSTITUTE, title, body)
             );
         } catch (CustomException e) {
             // 알림 발송 실패는 거절 프로세스에 영향을 주지 않음

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/SendJoinRequest.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/SendJoinRequest.java
@@ -6,6 +6,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.workspace.entity.BusinessJoinRequest;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
@@ -53,7 +54,7 @@ public class SendJoinRequest implements SendJoinRequestUseCase {
         );
         Long managerUserId = workspace.getManagerUser().getUser().getId();
         eventPublisher.publishEvent(
-            new FcmNotificationEvent(FcmNotificationRequestDto.of(managerUserId, TokenScope.MANAGER, title, body))
+            new FcmNotificationEvent(FcmNotificationRequestDto.of(managerUserId, TokenScope.MANAGER, NotificationType.JOIN_REQUEST, title, body))
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/SendWorkspaceInvitation.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/SendWorkspaceInvitation.java
@@ -7,6 +7,7 @@ import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.common.notification.NotificationMessageConstants;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.BusinessInvitation;
@@ -93,7 +94,7 @@ public class SendWorkspaceInvitation implements SendWorkspaceInvitationUseCase {
             workspace.getBusinessName()
         );
         eventPublisher.publishEvent(
-            new FcmNotificationEvent(FcmNotificationRequestDto.of(invitedUser.getId(), TokenScope.APP, title, body))
+            new FcmNotificationEvent(FcmNotificationRequestDto.of(invitedUser.getId(), TokenScope.APP, NotificationType.WORKSPACE_INVITATION, title, body))
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.domain.notification.entity;
 
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,6 +32,10 @@ public class Notification {
     @Column(name = "scope", nullable = false)
     private TokenScope scope;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 30, nullable = false)
+    private NotificationType type;
+
     @Column(name = "device_token", length = 500)
     private String deviceToken;
 
@@ -47,6 +52,7 @@ public class Notification {
     public static Notification create(
         User targetUser,
         TokenScope scope,
+        NotificationType type,
         String deviceToken,
         String title,
         String body
@@ -54,6 +60,7 @@ public class Notification {
         return Notification.builder()
             .targetUser(targetUser)
             .scope(scope)
+            .type(type)
             .deviceToken(deviceToken)
             .title(title)
             .body(body)

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -57,6 +58,7 @@ public class Notification {
         String title,
         String body
     ) {
+        Objects.requireNonNull(type, "notification type must not be null");
         return Notification.builder()
             .targetUser(targetUser)
             .scope(scope)

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -3,6 +3,7 @@ package com.dreamteam.alter.domain.notification.entity;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,6 +49,12 @@ public class NotificationConsent {
     @Column(name = "night_notification_consent", nullable = false)
     private boolean nightNotificationConsent;
 
+    @Column(name = "substitute_notification_consent", nullable = false)
+    private boolean substituteNotificationConsent;
+
+    @Column(name = "reputation_notification_consent", nullable = false)
+    private boolean reputationNotificationConsent;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -61,6 +68,8 @@ public class NotificationConsent {
             .user(user)
             .notificationConsent(notificationConsent)
             .nightNotificationConsent(notificationConsent && nightNotificationConsent)
+            .substituteNotificationConsent(notificationConsent)
+            .reputationNotificationConsent(notificationConsent)
             .build();
     }
 
@@ -70,17 +79,46 @@ public class NotificationConsent {
                 this.notificationConsent = consent;
                 if (!consent) {
                     this.nightNotificationConsent = false;
+                    this.substituteNotificationConsent = false;
+                    this.reputationNotificationConsent = false;
                 }
             }
             case NIGHT -> {
-                if (consent && !this.notificationConsent) {
-                    throw new CustomException(
-                        ErrorCode.ILLEGAL_ARGUMENT,
-                        "전체 알림 수신 동의가 꺼진 상태에서는 야간 알림을 켤 수 없습니다."
-                    );
-                }
+                validateSubConsent(consent, "야간");
                 this.nightNotificationConsent = consent;
             }
+            case SUBSTITUTE -> {
+                validateSubConsent(consent, "대타");
+                this.substituteNotificationConsent = consent;
+            }
+            case REPUTATION -> {
+                validateSubConsent(consent, "평판");
+                this.reputationNotificationConsent = consent;
+            }
+        }
+    }
+
+    public boolean isBlocked(NotificationType type, boolean isDaytime) {
+        if (!this.notificationConsent) {
+            return true;
+        }
+        if (!isDaytime && !this.nightNotificationConsent) {
+            return true;
+        }
+        return switch (type) {
+            case SUBSTITUTE -> !this.substituteNotificationConsent;
+            case REPUTATION -> !this.reputationNotificationConsent;
+            case GENERAL, SCHEDULE, POSTING_APPLICATION, CHAT,
+                 WORKSPACE_INVITATION, JOIN_REQUEST -> false;
+        };
+    }
+
+    private void validateSubConsent(boolean consent, String label) {
+        if (consent && !this.notificationConsent) {
+            throw new CustomException(
+                ErrorCode.ILLEGAL_ARGUMENT,
+                String.format("전체 알림 수신 동의가 꺼진 상태에서는 %s 알림을 켤 수 없습니다.", label)
+            );
         }
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/NotificationConsent.java
@@ -25,6 +25,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -99,6 +100,7 @@ public class NotificationConsent {
     }
 
     public boolean isBlocked(NotificationType type, boolean isDaytime) {
+        Objects.requireNonNull(type, "notification type must not be null");
         if (!this.notificationConsent) {
             return true;
         }

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/GetMyNotificationsUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/GetMyNotificationsUseCase.java
@@ -2,9 +2,12 @@ package com.dreamteam.alter.domain.notification.port.inbound;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.domain.user.context.AppActor;
 
 public interface GetMyNotificationsUseCase {
-    CursorPaginatedApiResponse<NotificationResponseDto> execute(AppActor actor, CursorPageRequestDto pageRequest);
+    CursorPaginatedApiResponse<NotificationResponseDto> execute(
+        AppActor actor, CursorPageRequestDto pageRequest, NotificationListFilterDto filter
+    );
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/ManagerGetMyNotificationsUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/inbound/ManagerGetMyNotificationsUseCase.java
@@ -2,9 +2,12 @@ package com.dreamteam.alter.domain.notification.port.inbound;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequestDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPaginatedApiResponse;
+import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationListFilterDto;
 import com.dreamteam.alter.adapter.inbound.general.notification.dto.NotificationResponseDto;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 
 public interface ManagerGetMyNotificationsUseCase {
-    CursorPaginatedApiResponse<NotificationResponseDto> execute(ManagerActor actor, CursorPageRequestDto pageRequest);
+    CursorPaginatedApiResponse<NotificationResponseDto> execute(
+        ManagerActor actor, CursorPageRequestDto pageRequest, NotificationListFilterDto filter
+    );
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/port/outbound/NotificationQueryRepository.java
@@ -4,6 +4,7 @@ import com.dreamteam.alter.adapter.inbound.common.dto.CursorDto;
 import com.dreamteam.alter.adapter.inbound.common.dto.CursorPageRequest;
 import com.dreamteam.alter.adapter.outbound.notification.persistence.readonly.NotificationResponse;
 import com.dreamteam.alter.domain.auth.type.TokenScope;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.User;
 
 import java.util.List;
@@ -12,7 +13,8 @@ public interface NotificationQueryRepository {
     List<NotificationResponse> getNotificationsWithCursor(
         CursorPageRequest<CursorDto> pageRequest,
         User targetUser,
-        TokenScope scope
+        TokenScope scope,
+        NotificationType type
     );
-    long getCountOfNotifications(User targetUser, TokenScope scope);
+    long getCountOfNotifications(User targetUser, TokenScope scope, NotificationType type);
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/result/GetNotificationConsentResult.java
@@ -11,7 +11,9 @@ public record GetNotificationConsentResult(
     public static GetNotificationConsentResult from(NotificationConsent consent) {
         return new GetNotificationConsentResult(Map.of(
             NotificationConsentType.GENERAL, consent.isNotificationConsent(),
-            NotificationConsentType.NIGHT, consent.isNightNotificationConsent()
+            NotificationConsentType.NIGHT, consent.isNightNotificationConsent(),
+            NotificationConsentType.SUBSTITUTE, consent.isSubstituteNotificationConsent(),
+            NotificationConsentType.REPUTATION, consent.isReputationNotificationConsent()
         ));
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationConsentType.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationConsentType.java
@@ -5,12 +5,16 @@ import java.util.Map;
 public enum NotificationConsentType {
     GENERAL,
     NIGHT,
+    SUBSTITUTE,
+    REPUTATION,
     ;
 
     public static Map<NotificationConsentType, String> describe() {
         return Map.of(
             NotificationConsentType.GENERAL, "전체 알림 수신",
-            NotificationConsentType.NIGHT, "야간 알림 수신"
+            NotificationConsentType.NIGHT, "야간 알림 수신",
+            NotificationConsentType.SUBSTITUTE, "대타 알림 수신",
+            NotificationConsentType.REPUTATION, "평판 알림 수신"
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationType.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/type/NotificationType.java
@@ -1,0 +1,28 @@
+package com.dreamteam.alter.domain.notification.type;
+
+import java.util.Map;
+
+public enum NotificationType {
+    GENERAL,
+    SCHEDULE,
+    SUBSTITUTE,
+    REPUTATION,
+    POSTING_APPLICATION,
+    CHAT,
+    WORKSPACE_INVITATION,
+    JOIN_REQUEST,
+    ;
+
+    public static Map<NotificationType, String> describe() {
+        return Map.of(
+            NotificationType.GENERAL, "일반",
+            NotificationType.SCHEDULE, "근무",
+            NotificationType.SUBSTITUTE, "대타",
+            NotificationType.REPUTATION, "평판",
+            NotificationType.POSTING_APPLICATION, "알바 지원",
+            NotificationType.CHAT, "채팅",
+            NotificationType.WORKSPACE_INVITATION, "업장 초대",
+            NotificationType.JOIN_REQUEST, "합류 요청"
+        );
+    }
+}

--- a/src/main/resources/db/migration/V1__add_substitute_reputation_consent_columns.sql
+++ b/src/main/resources/db/migration/V1__add_substitute_reputation_consent_columns.sql
@@ -1,0 +1,12 @@
+ALTER TABLE notification_consents
+    ADD COLUMN IF NOT EXISTS substitute_notification_consent BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN IF NOT EXISTS reputation_notification_consent BOOLEAN NOT NULL DEFAULT true;
+
+UPDATE notification_consents
+SET substitute_notification_consent = notification_consent,
+    reputation_notification_consent = notification_consent
+WHERE notification_consent = false;
+
+ALTER TABLE notification_consents
+    ALTER COLUMN substitute_notification_consent DROP DEFAULT,
+    ALTER COLUMN reputation_notification_consent DROP DEFAULT;

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -9,6 +9,7 @@ import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationRepository;
+import com.dreamteam.alter.domain.notification.type.NotificationConsentType;
 import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.FcmDeviceToken;
 import com.dreamteam.alter.domain.user.entity.User;
@@ -74,6 +75,17 @@ class NotificationServiceConsentTests {
         return NotificationConsent.create(user, notificationConsent, nightNotificationConsent);
     }
 
+    private NotificationConsent consentWithAll(User targetUser, boolean general, boolean night, boolean substitute, boolean reputation) {
+        NotificationConsent consent = NotificationConsent.create(targetUser, general, night);
+        if (general && !substitute) {
+            consent.updateConsent(NotificationConsentType.SUBSTITUTE, false);
+        }
+        if (general && !reputation) {
+            consent.updateConsent(NotificationConsentType.REPUTATION, false);
+        }
+        return consent;
+    }
+
     // ── 고정 시각을 반환하는 LocalTime 헬퍼 ──────────────────────────────
     private LocalTime localTimeAt(int hour) {
         return LocalTime.of(hour, 0);
@@ -81,12 +93,20 @@ class NotificationServiceConsentTests {
 
     // ── FcmNotificationRequestDto 헬퍼 ───────────────────────────────────
     private FcmNotificationRequestDto notificationRequest(Long userId) {
-        return FcmNotificationRequestDto.of(userId, TokenScope.APP, NotificationType.GENERAL, "제목", "내용");
+        return notificationRequest(userId, NotificationType.GENERAL);
+    }
+
+    private FcmNotificationRequestDto notificationRequest(Long userId, NotificationType type) {
+        return FcmNotificationRequestDto.of(userId, TokenScope.APP, type, "제목", "내용");
     }
 
     // ── FcmBatchNotificationRequestDto 헬퍼 ──────────────────────────────
     private FcmBatchNotificationRequestDto batchRequest(List<Long> userIds) {
-        return FcmBatchNotificationRequestDto.of(userIds, TokenScope.APP, NotificationType.GENERAL, "제목", "내용");
+        return batchRequest(userIds, NotificationType.GENERAL);
+    }
+
+    private FcmBatchNotificationRequestDto batchRequest(List<Long> userIds, NotificationType type) {
+        return FcmBatchNotificationRequestDto.of(userIds, TokenScope.APP, type, "제목", "내용");
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -236,7 +256,7 @@ class NotificationServiceConsentTests {
             given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
 
             // when
-            notificationService.sendNotificationOnly(1L, "제목", "내용");
+            notificationService.sendNotificationOnly(1L, NotificationType.CHAT, "제목", "내용");
 
             // then
             then(fcmClient).should(never()).sendNotification(any(), any(), any());
@@ -254,11 +274,116 @@ class NotificationServiceConsentTests {
                 mockedStatic.when(LocalTime::now).thenReturn(nightTime);
 
                 // when
-                notificationService.sendNotificationOnly(1L, "제목", "내용");
+                notificationService.sendNotificationOnly(1L, NotificationType.CHAT, "제목", "내용");
             }
 
             // then
             then(fcmClient).should(never()).sendNotification(any(), any(), any());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    @Nested
+    @DisplayName("타입별 수신 동의 필터링 (SUBSTITUTE / REPUTATION)")
+    class TypeSpecificConsentTests {
+
+        @Test
+        @DisplayName("SUBSTITUTE 미동의 + SUBSTITUTE 타입 발송 → FCM 미호출")
+        void skips_fcm_when_substitute_consent_is_false_and_type_is_substitute() throws Exception {
+            // given
+            NotificationConsent consent = consentWithAll(user, true, true, false, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            notificationService.sendNotification(notificationRequest(1L, NotificationType.SUBSTITUTE));
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+            then(notificationRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("SUBSTITUTE 미동의 + GENERAL 타입 발송 → FCM 호출됨 (타입 차단 누수 없음)")
+        void sends_fcm_when_substitute_consent_is_false_but_type_is_general() throws Exception {
+            // given
+            NotificationConsent consent = consentWithAll(user, true, true, false, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            notificationService.sendNotification(notificationRequest(1L, NotificationType.GENERAL));
+
+            // then
+            then(fcmClient).should().sendNotification(eq("test-device-token"), any(), any());
+        }
+
+        @Test
+        @DisplayName("REPUTATION 미동의 + REPUTATION 타입 발송 → FCM 미호출")
+        void skips_fcm_when_reputation_consent_is_false_and_type_is_reputation() throws Exception {
+            // given
+            NotificationConsent consent = consentWithAll(user, true, true, true, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(consent));
+
+            // when
+            notificationService.sendNotification(notificationRequest(1L, NotificationType.REPUTATION));
+
+            // then
+            then(fcmClient).should(never()).sendNotification(any(), any(), any());
+            then(notificationRepository).should().save(any());
+        }
+
+        @Test
+        @DisplayName("배치 SUBSTITUTE 발송: 일부 사용자만 SUBSTITUTE 미동의 → 미동의자 제외")
+        void batch_excludes_users_without_substitute_consent_for_substitute_type() throws Exception {
+            // given
+            User userA = mock(User.class);
+            given(userA.getId()).willReturn(10L);
+
+            User userB = mock(User.class);
+            given(userB.getId()).willReturn(20L);
+
+            given(userQueryRepository.findAllById(List.of(10L, 20L)))
+                .willReturn(List.of(userA, userB));
+
+            FcmDeviceToken tokenA = mock(FcmDeviceToken.class);
+            given(tokenA.getDeviceToken()).willReturn("token-A");
+            given(tokenA.getUser()).willReturn(userA);
+
+            FcmDeviceToken tokenB = mock(FcmDeviceToken.class);
+            given(tokenB.getDeviceToken()).willReturn("token-B");
+            given(tokenB.getUser()).willReturn(userB);
+
+            given(userFCMDeviceTokenQueryRepository.findByUsers(anyList()))
+                .willReturn(List.of(tokenA, tokenB));
+
+            // userA는 SUBSTITUTE 동의, userB는 SUBSTITUTE 미동의
+            NotificationConsent consentA = consentWithAll(userA, true, true, true, true);
+            NotificationConsent consentB = consentWithAll(userB, true, true, false, true);
+            given(notificationConsentQueryRepository.findByUsers(anyList()))
+                .willReturn(List.of(consentA, consentB));
+
+            com.google.firebase.messaging.BatchResponse batchResponse =
+                mock(com.google.firebase.messaging.BatchResponse.class);
+            com.google.firebase.messaging.SendResponse sendResponse =
+                mock(com.google.firebase.messaging.SendResponse.class);
+            given(sendResponse.isSuccessful()).willReturn(true);
+            given(batchResponse.getResponses()).willReturn(List.of(sendResponse));
+            given(fcmClient.sendMultipleNotifications(anyList(), any(), any())).willReturn(batchResponse);
+
+            // when
+            notificationService.sendMultipleNotifications(batchRequest(List.of(10L, 20L), NotificationType.SUBSTITUTE));
+
+            // then: Notification 레코드는 두 사용자 모두 저장
+            then(notificationRepository).should().saveAll(argThat(list -> ((List<?>) list).size() == 2));
+
+            // then: FCM 배치는 SUBSTITUTE 동의자 토큰만 포함
+            then(fcmClient).should().sendMultipleNotifications(
+                argThat(tokens -> {
+                    @SuppressWarnings("unchecked")
+                    List<String> tokenList = (List<String>) tokens;
+                    return tokenList.size() == 1 && tokenList.contains("token-A");
+                }),
+                any(), any()
+            );
         }
     }
 }

--- a/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/NotificationServiceConsentTests.java
@@ -9,6 +9,7 @@ import com.dreamteam.alter.domain.auth.type.TokenScope;
 import com.dreamteam.alter.domain.notification.entity.NotificationConsent;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationConsentQueryRepository;
 import com.dreamteam.alter.domain.notification.port.outbound.NotificationRepository;
+import com.dreamteam.alter.domain.notification.type.NotificationType;
 import com.dreamteam.alter.domain.user.entity.FcmDeviceToken;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserFcmDeviceTokenRepository;
@@ -80,12 +81,12 @@ class NotificationServiceConsentTests {
 
     // ── FcmNotificationRequestDto 헬퍼 ───────────────────────────────────
     private FcmNotificationRequestDto notificationRequest(Long userId) {
-        return FcmNotificationRequestDto.of(userId, TokenScope.APP, "제목", "내용");
+        return FcmNotificationRequestDto.of(userId, TokenScope.APP, NotificationType.GENERAL, "제목", "내용");
     }
 
     // ── FcmBatchNotificationRequestDto 헬퍼 ──────────────────────────────
     private FcmBatchNotificationRequestDto batchRequest(List<Long> userIds) {
-        return FcmBatchNotificationRequestDto.of(userIds, TokenScope.APP, "제목", "내용");
+        return FcmBatchNotificationRequestDto.of(userIds, TokenScope.APP, NotificationType.GENERAL, "제목", "내용");
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/GetNotificationConsentTests.java
@@ -53,8 +53,8 @@ class GetNotificationConsentTests {
         }
 
         @Test
-        @DisplayName("레코드 존재 + 둘 다 true이면 GENERAL/NIGHT 모두 true 반환")
-        void returnsActualValues_whenBothTrue() {
+        @DisplayName("레코드 존재 + GENERAL=true 이면 GENERAL/NIGHT/SUBSTITUTE/REPUTATION 모두 true 반환")
+        void returnsActualValues_whenAllTrue() {
             // given
             User user = mock(User.class);
             GetNotificationConsentCommand command = GetNotificationConsentCommand.from(user);
@@ -68,10 +68,12 @@ class GetNotificationConsentTests {
             // then
             assertThat(result.consents().get(NotificationConsentType.GENERAL)).isTrue();
             assertThat(result.consents().get(NotificationConsentType.NIGHT)).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.SUBSTITUTE)).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.REPUTATION)).isTrue();
         }
 
         @Test
-        @DisplayName("레코드 존재 + GENERAL=false이면 NIGHT도 false 반환")
+        @DisplayName("레코드 존재 + GENERAL=false이면 NIGHT/SUBSTITUTE/REPUTATION 모두 false 반환")
         void returnsActualValues_whenGeneralIsFalse() {
             // given
             User user = mock(User.class);
@@ -86,10 +88,12 @@ class GetNotificationConsentTests {
             // then
             assertThat(result.consents().get(NotificationConsentType.GENERAL)).isFalse();
             assertThat(result.consents().get(NotificationConsentType.NIGHT)).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.SUBSTITUTE)).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.REPUTATION)).isFalse();
         }
 
         @Test
-        @DisplayName("레코드 존재 + NIGHT=false이면 false 반환")
+        @DisplayName("레코드 존재 + NIGHT=false이면 NIGHT만 false, 나머지는 true 반환")
         void returnsActualValues_whenNightIsFalse() {
             // given
             User user = mock(User.class);
@@ -104,6 +108,8 @@ class GetNotificationConsentTests {
             // then
             assertThat(result.consents().get(NotificationConsentType.GENERAL)).isTrue();
             assertThat(result.consents().get(NotificationConsentType.NIGHT)).isFalse();
+            assertThat(result.consents().get(NotificationConsentType.SUBSTITUTE)).isTrue();
+            assertThat(result.consents().get(NotificationConsentType.REPUTATION)).isTrue();
         }
     }
 }

--- a/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
+++ b/src/test/java/com/dreamteam/alter/application/notification/usecase/UpdateNotificationConsentTests.java
@@ -83,8 +83,8 @@ class UpdateNotificationConsentTests {
         }
 
         @Test
-        @DisplayName("GENERAL=false 토글 시 NIGHT도 자동으로 false로 cascade")
-        void savesGeneralFalse_cascadesNightToFalse() {
+        @DisplayName("GENERAL=false 토글 시 NIGHT/SUBSTITUTE/REPUTATION 모두 false로 cascade")
+        void savesGeneralFalse_cascadesAllSubConsentsToFalse() {
             // given
             User user = mock(User.class);
             UpdateNotificationConsentCommand command =
@@ -99,6 +99,8 @@ class UpdateNotificationConsentTests {
             // then
             assertThat(existing.isNotificationConsent()).isFalse();
             assertThat(existing.isNightNotificationConsent()).isFalse();
+            assertThat(existing.isSubstituteNotificationConsent()).isFalse();
+            assertThat(existing.isReputationNotificationConsent()).isFalse();
             then(notificationConsentRepository).shouldHaveNoInteractions();
         }
 
@@ -159,6 +161,130 @@ class UpdateNotificationConsentTests {
             // then
             assertThat(existing.isNotificationConsent()).isTrue();
             assertThat(existing.isNightNotificationConsent()).isFalse();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("GENERAL=true 상태에서 SUBSTITUTE=true 토글 시 정상 저장")
+        void savesSubstituteTrue_whenGeneralIsTrue() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.SUBSTITUTE, true);
+
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
+            existing.updateConsent(NotificationConsentType.SUBSTITUTE, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            assertThat(existing.isSubstituteNotificationConsent()).isTrue();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("GENERAL=false 상태에서 SUBSTITUTE=true 토글 시 ILLEGAL_ARGUMENT 예외")
+        void throwsIllegalArgument_whenSubstituteTrueWithGeneralFalse() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.SUBSTITUTE, true);
+
+            NotificationConsent existing = NotificationConsent.create(user, false, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when & then
+            assertThatThrownBy(() -> updateNotificationConsent.execute(command))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
+
+            then(notificationConsentRepository).should(never()).save(any(NotificationConsent.class));
+        }
+
+        @Test
+        @DisplayName("SUBSTITUTE=false 토글 시 다른 동의 상태는 유지")
+        void savesSubstituteFalse_keepsOthersAsIs() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.SUBSTITUTE, false);
+
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            assertThat(existing.isNotificationConsent()).isTrue();
+            assertThat(existing.isNightNotificationConsent()).isTrue();
+            assertThat(existing.isSubstituteNotificationConsent()).isFalse();
+            assertThat(existing.isReputationNotificationConsent()).isTrue();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("GENERAL=true 상태에서 REPUTATION=true 토글 시 정상 저장")
+        void savesReputationTrue_whenGeneralIsTrue() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.REPUTATION, true);
+
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
+            existing.updateConsent(NotificationConsentType.REPUTATION, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            assertThat(existing.isReputationNotificationConsent()).isTrue();
+            then(notificationConsentRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("GENERAL=false 상태에서 REPUTATION=true 토글 시 ILLEGAL_ARGUMENT 예외")
+        void throwsIllegalArgument_whenReputationTrueWithGeneralFalse() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.REPUTATION, true);
+
+            NotificationConsent existing = NotificationConsent.create(user, false, false);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when & then
+            assertThatThrownBy(() -> updateNotificationConsent.execute(command))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ILLEGAL_ARGUMENT);
+
+            then(notificationConsentRepository).should(never()).save(any(NotificationConsent.class));
+        }
+
+        @Test
+        @DisplayName("REPUTATION=false 토글 시 다른 동의 상태는 유지")
+        void savesReputationFalse_keepsOthersAsIs() {
+            // given
+            User user = mock(User.class);
+            UpdateNotificationConsentCommand command =
+                UpdateNotificationConsentCommand.of(user, NotificationConsentType.REPUTATION, false);
+
+            NotificationConsent existing = NotificationConsent.create(user, true, true);
+            given(notificationConsentQueryRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+            // when
+            updateNotificationConsent.execute(command);
+
+            // then
+            assertThat(existing.isNotificationConsent()).isTrue();
+            assertThat(existing.isNightNotificationConsent()).isTrue();
+            assertThat(existing.isSubstituteNotificationConsent()).isTrue();
+            assertThat(existing.isReputationNotificationConsent()).isFalse();
             then(notificationConsentRepository).shouldHaveNoInteractions();
         }
     }


### PR DESCRIPTION
## 변경사항

- NotificationConsentType에 SUBSTITUTE(대타), REPUTATION(평판) 타입 추가
- NotificationConsent에 대타/평판 동의 필드 추가
- GetNotificationConsentResult에 동의 정보 매핑
- NotificationService에 타입 기반 필터링 로직 적용
- 알림 목록 조회 UseCase에 타입 필터 파라미터 추가
- DB 마이그레이션 스크립트 추가

관련 커밋:
- e76cf5e: 알림 목록 조회 UseCase에 타입 필터 파라미터 추가
- 854da64: 대타/평판 동의 필터링 및 토글 테스트 케이스 추가
- d4ae7f3: DB 마이그레이션 스크립트 추가
- 3bac179: GetNotificationConsentResult에 대타/평판 동의 매핑 추가
- 0d353eb: NotificationService에 타입 기반 필터링 적용
- d0ad45e: NotificationConsent에 동의 필드 추가
- 182f6fe: NotificationConsentType에 새 타입 추가
- e24d610: 알림 발송 코드 NotificationType 파라미터 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림에 유형을 도입해 유형별(일반/스케줄/대체/평판 등)로 분류·전송 및 조회 필터 제공
  * 알림 목록 조회 API에 type 필터 추가(개인/매니저용)
  * 수신 동의 항목을 세분화해 유형별(대체·평판 등) 동의 설정 및 차단 반영
  * 관리자용 모의 발송에 타입 지정 옵션 추가

* **Tests**
  * 알림 타입별 수신 동의 및 필터 동작 검증 테스트 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alter-app/alter-backend/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->