### PR TITLE
feat: 근무자 퇴사 처리

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserWorkController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserWorkController.java
@@ -11,9 +11,11 @@ import com.dreamteam.alter.domain.user.context.AppActor;
 import com.dreamteam.alter.domain.workspace.port.inbound.GetUserActiveWorkspaceListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.GetUserWorkspaceWorkerListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.GetUserWorkspaceManagerListUseCase;
+import com.dreamteam.alter.domain.workspace.port.inbound.UserResignWorkspaceWorkerUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +28,7 @@ public class UserWorkController implements UserWorkControllerSpec {
     private final GetUserActiveWorkspaceListUseCase getUserActiveWorkspaceListUseCase;
     private final GetUserWorkspaceWorkerListUseCase getUserWorkspaceWorkerListUseCase;
     private final GetUserWorkspaceManagerListUseCase getUserWorkspaceManagerListUseCase;
+    private final UserResignWorkspaceWorkerUseCase userResignWorkspaceWorkerUseCase;
 
     @GetMapping
     public ResponseEntity<CommonApiResponse<CursorPaginatedApiResponse<UserWorkspaceListResponseDto>>> getActiveWorkspaceList(
@@ -59,6 +62,17 @@ public class UserWorkController implements UserWorkControllerSpec {
         AppActor actor = AppActionContext.getInstance().getActor();
 
         return ResponseEntity.ok(CommonApiResponse.of(getUserWorkspaceManagerListUseCase.execute(actor, workspaceId, pageRequest)));
+    }
+
+    @Override
+    @PatchMapping("/{workspaceId}/resign")
+    public ResponseEntity<CommonApiResponse<Void>> resignWorkspaceWorker(
+        @PathVariable Long workspaceId
+    ) {
+        AppActor actor = AppActionContext.getInstance().getActor();
+
+        userResignWorkspaceWorkerUseCase.execute(actor, workspaceId);
+        return ResponseEntity.ok(CommonApiResponse.empty());
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserWorkControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/controller/UserWorkControllerSpec.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "APP - 사용자 자신이 근무중인 아르바이트 조회")
 public interface UserWorkControllerSpec {
@@ -39,6 +40,16 @@ public interface UserWorkControllerSpec {
     ResponseEntity<CommonApiResponse<CursorPaginatedApiResponse<UserWorkspaceManagerListResponseDto>>> getWorkspaceManagerList(
         Long workspaceId,
         CursorPageRequestDto pageRequest
+    );
+
+    @Operation(summary = "근무중인 업장 퇴사", description = "사용자가 본인이 근무중인 업장에서 퇴사합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "퇴사 성공"),
+        @ApiResponse(responseCode = "400", description = "존재하지 않는 업장 (B008)"),
+        @ApiResponse(responseCode = "403", description = "해당 업장에서 근무중이 아님 (A002)"),
+    })
+    ResponseEntity<CommonApiResponse<Void>> resignWorkspaceWorker(
+        @PathVariable Long workspaceId
     );
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceController.java
@@ -29,6 +29,7 @@ import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceList
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceManagerListUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerGetWorkspaceWorkerListUseCase;
+import com.dreamteam.alter.domain.workspace.port.inbound.ManagerResignWorkspaceWorkerUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateFixedScheduleDateUseCase;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerUpdateWorkspaceWorkerColorCodeUseCase;
 
@@ -60,6 +61,9 @@ public class ManagerWorkspaceController implements ManagerWorkspaceControllerSpe
 
     @Resource(name = "managerUpdateWorkspaceWorkerColorCode")
     private final ManagerUpdateWorkspaceWorkerColorCodeUseCase managerUpdateWorkspaceWorkerColor;
+
+    @Resource(name = "managerResignWorkspaceWorker")
+    private final ManagerResignWorkspaceWorkerUseCase managerResignWorkspaceWorker;
 
     @Override
     @GetMapping
@@ -127,6 +131,17 @@ public class ManagerWorkspaceController implements ManagerWorkspaceControllerSpe
             workerId,
             UpdateWorkspaceWorkerColorCommand.of(request.getColorCode())
         );
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @PatchMapping("/{workspaceId}/workers/{workerId}/resign")
+    public ResponseEntity<CommonApiResponse<Void>> resignWorkspaceWorker(
+        @PathVariable Long workspaceId,
+        @PathVariable Long workerId
+    ) {
+        ManagerActor actor = ManagerActionContext.getInstance().getActor();
+        managerResignWorkspaceWorker.execute(actor, workspaceId, workerId);
         return ResponseEntity.ok(CommonApiResponse.empty());
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
@@ -130,6 +130,29 @@ public interface ManagerWorkspaceControllerSpec {
         @RequestBody @Valid UpdateWorkspaceWorkerColorRequestDto request
     );
 
+    @Operation(summary = "매니저 - 근무자 퇴사 처리", description = "근무자를 퇴사 처리합니다. 현재 시점 이후 해당 근무자에게 배정된 모든 스케줄은 미배정(CANCELLED) 상태로 전환됩니다. 과거 근무 기록은 유지됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "퇴사 처리 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 업장 또는 근무자",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "존재하지 않는 업장입니다.",
+                        value = "{\"code\" : \"B008\"}"
+                    ),
+                    @ExampleObject(
+                        name = "근무자를 찾을 수 없습니다.",
+                        value = "{\"code\" : \"B019\"}"
+                    ),
+                })),
+    })
+    ResponseEntity<CommonApiResponse<Void>> resignWorkspaceWorker(
+        @PathVariable Long workspaceId,
+        @PathVariable Long workerId
+    );
+
     // 업장 근무자 상세 정보 조회
 
     // 업장 근무자 상태 변경

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/controller/ManagerWorkspaceControllerSpec.java
@@ -69,15 +69,9 @@ public interface ManagerWorkspaceControllerSpec {
                         name = "1~31 범위를 벗어난 값입니다.",
                         value = "{\"code\" : \"B001\"}"
                     ),
-                })),
-        @ApiResponse(responseCode = "404", description = "404 Error 실패 케이스",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ErrorResponse.class),
-                examples = {
                     @ExampleObject(
                         name = "존재하지 않는 업장입니다.",
-                        value = "{\"code\" : \"B019\"}"
+                        value = "{\"code\" : \"B008\"}"
                     ),
                 })),
     })
@@ -89,7 +83,7 @@ public interface ManagerWorkspaceControllerSpec {
     @Operation(summary = "매니저 - 근무자 색상 변경", description = "근무자 캘린더에서 사용할 표시 색상을 변경합니다. 같은 업장의 ACTIVATED 근무자끼리 색상은 unique 합니다 (기본 색상 #9CA3AF 제외).")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "색상 변경 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 색상 형식",
+        @ApiResponse(responseCode = "400", description = "잘못된 색상 형식 또는 존재하지 않는 업장",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class),
@@ -98,16 +92,16 @@ public interface ManagerWorkspaceControllerSpec {
                         name = "잘못된 요청",
                         value = "{\"code\" : \"B001\"}"
                     ),
-                })),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 업장 또는 근무자",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ErrorResponse.class),
-                examples = {
                     @ExampleObject(
                         name = "존재하지 않는 업장입니다.",
                         value = "{\"code\" : \"B008\"}"
                     ),
+                })),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 근무자",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
                     @ExampleObject(
                         name = "근무자를 찾을 수 없습니다.",
                         value = "{\"code\" : \"B019\"}"
@@ -133,7 +127,7 @@ public interface ManagerWorkspaceControllerSpec {
     @Operation(summary = "매니저 - 근무자 퇴사 처리", description = "근무자를 퇴사 처리합니다. 현재 시점 이후 해당 근무자에게 배정된 모든 스케줄은 미배정(CANCELLED) 상태로 전환됩니다. 과거 근무 기록은 유지됩니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "퇴사 처리 성공"),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 업장 또는 근무자",
+        @ApiResponse(responseCode = "400", description = "존재하지 않는 업장",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class),
@@ -142,6 +136,12 @@ public interface ManagerWorkspaceControllerSpec {
                         name = "존재하지 않는 업장입니다.",
                         value = "{\"code\" : \"B008\"}"
                     ),
+                })),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 근무자",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
                     @ExampleObject(
                         name = "근무자를 찾을 수 없습니다.",
                         value = "{\"code\" : \"B019\"}"

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -454,4 +454,38 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             )
             .fetch();
     }
+
+    @Override
+    public List<SubstituteRequest> findAllActiveByRequesterWorkerId(Long workerId) {
+        return queryFactory
+            .selectFrom(substituteRequest)
+            .where(
+                substituteRequest.requesterId.eq(workerId),
+                substituteRequest.status.in(SubstituteRequestStatus.PENDING, SubstituteRequestStatus.ACCEPTED)
+            )
+            .fetch();
+    }
+
+    @Override
+    public List<SubstituteRequest> findAllPendingTargetRequestsByTargetWorkerId(Long targetWorkerId) {
+        QSubstituteRequestTarget target = QSubstituteRequestTarget.substituteRequestTarget;
+
+        return queryFactory
+            .selectFrom(substituteRequest)
+            .distinct()
+            .join(substituteRequest.targets, target).fetchJoin()
+            .where(
+                substituteRequest.status.eq(SubstituteRequestStatus.PENDING),
+                JPAExpressions
+                    .selectOne()
+                    .from(QSubstituteRequestTarget.substituteRequestTarget)
+                    .where(
+                        QSubstituteRequestTarget.substituteRequestTarget.substituteRequest.eq(substituteRequest),
+                        QSubstituteRequestTarget.substituteRequestTarget.targetWorkerId.eq(targetWorkerId),
+                        QSubstituteRequestTarget.substituteRequestTarget.status.eq(SubstituteRequestTargetStatus.PENDING)
+                    )
+                    .exists()
+            )
+            .fetch();
+    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -468,7 +468,8 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
 
     @Override
     public List<SubstituteRequest> findAllPendingTargetRequestsByTargetWorkerId(Long targetWorkerId) {
-        QSubstituteRequestTarget target = QSubstituteRequestTarget.substituteRequestTarget;
+        QSubstituteRequestTarget target = new QSubstituteRequestTarget("target");
+        QSubstituteRequestTarget pendingTarget = new QSubstituteRequestTarget("pendingTarget");
 
         return queryFactory
             .selectFrom(substituteRequest)
@@ -478,11 +479,11 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
                 substituteRequest.status.eq(SubstituteRequestStatus.PENDING),
                 JPAExpressions
                     .selectOne()
-                    .from(QSubstituteRequestTarget.substituteRequestTarget)
+                    .from(pendingTarget)
                     .where(
-                        QSubstituteRequestTarget.substituteRequestTarget.substituteRequest.eq(substituteRequest),
-                        QSubstituteRequestTarget.substituteRequestTarget.targetWorkerId.eq(targetWorkerId),
-                        QSubstituteRequestTarget.substituteRequestTarget.status.eq(SubstituteRequestTargetStatus.PENDING)
+                        pendingTarget.substituteRequest.eq(substituteRequest),
+                        pendingTarget.targetWorkerId.eq(targetWorkerId),
+                        pendingTarget.status.eq(SubstituteRequestTargetStatus.PENDING)
                     )
                     .exists()
             )

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceShiftQueryRepositoryImpl.java
@@ -189,4 +189,17 @@ public class WorkspaceShiftQueryRepositoryImpl implements WorkspaceShiftQueryRep
             .orderBy(workspaceShift.startDateTime.asc())
             .fetch();
     }
+
+    @Override
+    public List<WorkspaceShift> findFutureShiftsByAssignedWorker(
+        WorkspaceWorker worker,
+        LocalDateTime fromInclusive
+    ) {
+        return queryFactory
+            .selectFrom(workspaceShift)
+            .where(workspaceShift.assignedWorkspaceWorker.eq(worker)
+                .and(workspaceShift.startDateTime.goe(fromInclusive))
+                .and(workspaceShift.status.ne(WorkspaceShiftStatus.DELETED)))
+            .fetch();
+    }
 }

--- a/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
+++ b/src/main/java/com/dreamteam/alter/application/user/usecase/WithdrawalUser.java
@@ -16,14 +16,9 @@ import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.inbound.WithdrawalUserUseCase;
 import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
-import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
-import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
-import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
-import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,8 +31,7 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 	private final UserCertificateRepository userCertificateRepository;
 	private final WorkspaceQueryRepository workspaceQueryRepository;
 	private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
-	private final WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
-	private final SubstituteRequestQueryRepository substituteRequestQueryRepository;
+	private final WorkerResignationService workerResignationService;
 	private final PostingApplicationQueryRepository postingApplicationQueryRepository;
 	private final FileQueryRepository fileQueryRepository;
 	private final AuthService authService;
@@ -56,19 +50,7 @@ public class WithdrawalUser implements WithdrawalUserUseCase {
 
 		// 활성화된 근무지 퇴직처리
 		workspaceWorkerQueryRepository.findAllActiveByUserId(user.getId())
-			.forEach(WorkspaceWorker::resign);
-
-		// 고정근무 스케줄 삭제
-		workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(user.getId())
-			.forEach(WorkspaceWorkerSchedule::delete);
-
-		// 본인이 요청자인 활성 대타 요청 취소 (자식 target 까지 cascade)
-		substituteRequestQueryRepository.findAllActiveByRequesterUserId(user.getId())
-			.forEach(SubstituteRequest::cancel);
-
-		// 본인이 PENDING target 으로 지정된 대타 요청 target 행 취소
-		substituteRequestQueryRepository.findAllPendingTargetsByUserId(user.getId())
-			.forEach(SubstituteRequestTarget::cancel);
+			.forEach(workerResignationService::resign);
 
 		// 본인이 지원한 활성 PostingApplication 취소
 		postingApplicationQueryRepository.findAllActiveByUserId(user.getId())

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
@@ -3,23 +3,14 @@ package com.dreamteam.alter.application.workspace.usecase;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
-import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
-import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerResignWorkspaceWorkerUseCase;
-import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
-import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
-import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Service("managerResignWorkspaceWorker")
 @RequiredArgsConstructor
@@ -28,9 +19,7 @@ public class ManagerResignWorkspaceWorker implements ManagerResignWorkspaceWorke
 
     private final WorkspaceQueryRepository workspaceQueryRepository;
     private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
-    private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
-    private final WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
-    private final SubstituteRequestQueryRepository substituteRequestQueryRepository;
+    private final WorkerResignationService workerResignationService;
 
     @Override
     public void execute(ManagerActor actor, Long workspaceId, Long workerId) {
@@ -45,22 +34,6 @@ public class ManagerResignWorkspaceWorker implements ManagerResignWorkspaceWorke
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        List<WorkspaceShift> futureShifts = workspaceShiftQueryRepository
-            .findFutureShiftsByAssignedWorker(worker, LocalDateTime.now());
-        futureShifts.forEach(WorkspaceShift::unassignWorker);
-
-        List<WorkspaceWorkerSchedule> fixedSchedules = workspaceWorkerScheduleQueryRepository
-            .getByWorkspaceWorker(worker);
-        fixedSchedules.forEach(WorkspaceWorkerSchedule::delete);
-
-        List<SubstituteRequest> activeRequests = substituteRequestQueryRepository
-            .findAllActiveByRequesterUserId(worker.getUser().getId());
-        activeRequests.forEach(SubstituteRequest::cancel);
-
-        List<SubstituteRequestTarget> pendingTargets = substituteRequestQueryRepository
-            .findAllPendingTargetsByUserId(worker.getUser().getId());
-        pendingTargets.forEach(SubstituteRequestTarget::expire);
-
-        worker.resign();
+        workerResignationService.resign(worker);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
@@ -1,0 +1,46 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.inbound.ManagerResignWorkspaceWorkerUseCase;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service("managerResignWorkspaceWorker")
+@RequiredArgsConstructor
+@Transactional
+public class ManagerResignWorkspaceWorker implements ManagerResignWorkspaceWorkerUseCase {
+
+    private final WorkspaceQueryRepository workspaceQueryRepository;
+    private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+    private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+
+    @Override
+    public void execute(ManagerActor actor, Long workspaceId, Long workerId) {
+        if (!workspaceQueryRepository.existsByIdAndManagerUser(workspaceId, actor.getManagerUser())) {
+            throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
+        WorkspaceWorker worker = workspaceWorkerQueryRepository.findById(workerId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "근무자를 찾을 수 없습니다."));
+
+        if (!worker.getWorkspace().getId().equals(workspaceId)) {
+            throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
+        List<WorkspaceShift> futureShifts = workspaceShiftQueryRepository.findFutureShiftsByAssignedWorker(worker, LocalDateTime.now());
+        futureShifts.forEach(WorkspaceShift::unassignWorker);
+
+        worker.resign();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorker.java
@@ -3,12 +3,17 @@ package com.dreamteam.alter.application.workspace.usecase;
 import com.dreamteam.alter.common.exception.CustomException;
 import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
 import com.dreamteam.alter.domain.workspace.port.inbound.ManagerResignWorkspaceWorkerUseCase;
+import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +29,8 @@ public class ManagerResignWorkspaceWorker implements ManagerResignWorkspaceWorke
     private final WorkspaceQueryRepository workspaceQueryRepository;
     private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
     private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+    private final WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
+    private final SubstituteRequestQueryRepository substituteRequestQueryRepository;
 
     @Override
     public void execute(ManagerActor actor, Long workspaceId, Long workerId) {
@@ -38,8 +45,21 @@ public class ManagerResignWorkspaceWorker implements ManagerResignWorkspaceWorke
             throw new CustomException(ErrorCode.WORKSPACE_NOT_FOUND);
         }
 
-        List<WorkspaceShift> futureShifts = workspaceShiftQueryRepository.findFutureShiftsByAssignedWorker(worker, LocalDateTime.now());
+        List<WorkspaceShift> futureShifts = workspaceShiftQueryRepository
+            .findFutureShiftsByAssignedWorker(worker, LocalDateTime.now());
         futureShifts.forEach(WorkspaceShift::unassignWorker);
+
+        List<WorkspaceWorkerSchedule> fixedSchedules = workspaceWorkerScheduleQueryRepository
+            .getByWorkspaceWorker(worker);
+        fixedSchedules.forEach(WorkspaceWorkerSchedule::delete);
+
+        List<SubstituteRequest> activeRequests = substituteRequestQueryRepository
+            .findAllActiveByRequesterUserId(worker.getUser().getId());
+        activeRequests.forEach(SubstituteRequest::cancel);
+
+        List<SubstituteRequestTarget> pendingTargets = substituteRequestQueryRepository
+            .findAllPendingTargetsByUserId(worker.getUser().getId());
+        pendingTargets.forEach(SubstituteRequestTarget::expire);
 
         worker.resign();
     }

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/UserResignWorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/UserResignWorkspaceWorker.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.inbound.UserResignWorkspaceWorkerUseCase;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("userResignWorkspaceWorker")
+@RequiredArgsConstructor
+@Transactional
+public class UserResignWorkspaceWorker implements UserResignWorkspaceWorkerUseCase {
+
+    private final WorkspaceQueryRepository workspaceQueryRepository;
+    private final WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+    private final WorkerResignationService workerResignationService;
+
+    @Override
+    public void execute(AppActor actor, Long workspaceId) {
+        Workspace workspace = workspaceQueryRepository.findById(workspaceId)
+            .orElseThrow(() -> new CustomException(ErrorCode.WORKSPACE_NOT_FOUND));
+
+        WorkspaceWorker worker = workspaceWorkerQueryRepository
+            .findActiveWorkerByWorkspaceAndUser(workspace, actor.getUser())
+            .orElseThrow(() -> new CustomException(ErrorCode.FORBIDDEN, "해당 업장에서 근무중이 아닙니다."));
+
+        workerResignationService.resign(worker);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/workspace/usecase/WorkerResignationServiceImpl.java
+++ b/src/main/java/com/dreamteam/alter/application/workspace/usecase/WorkerResignationServiceImpl.java
@@ -1,0 +1,49 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
+import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service("workerResignationService")
+@RequiredArgsConstructor
+@Transactional
+public class WorkerResignationServiceImpl implements WorkerResignationService {
+
+    private final WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+    private final WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
+    private final SubstituteRequestQueryRepository substituteRequestQueryRepository;
+
+    @Override
+    public void resign(WorkspaceWorker worker) {
+        List<WorkspaceShift> futureShifts = workspaceShiftQueryRepository
+            .findFutureShiftsByAssignedWorker(worker, LocalDateTime.now());
+        futureShifts.forEach(WorkspaceShift::unassignWorker);
+
+        List<WorkspaceWorkerSchedule> fixedSchedules = workspaceWorkerScheduleQueryRepository
+            .getByWorkspaceWorker(worker);
+        fixedSchedules.forEach(WorkspaceWorkerSchedule::delete);
+
+        List<SubstituteRequest> activeRequests = substituteRequestQueryRepository
+            .findAllActiveByRequesterWorkerId(worker.getId());
+        activeRequests.forEach(SubstituteRequest::cancel);
+
+        List<SubstituteRequest> pendingTargetRequests = substituteRequestQueryRepository
+            .findAllPendingTargetRequestsByTargetWorkerId(worker.getId());
+        pendingTargetRequests.forEach(request ->
+            request.cancelPendingTargetAndCancelIfNoPendingTargets(worker.getId())
+        );
+
+        worker.resign();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequest.java
@@ -170,6 +170,15 @@ public class SubstituteRequest {
         }
     }
 
+    public void cancelPendingTargetAndCancelIfNoPendingTargets(Long targetWorkerId) {
+        updatePendingTargetStatus(targetWorkerId, SubstituteRequestTarget::cancel);
+
+        if (SubstituteRequestStatus.PENDING.equals(this.status) && hasNoPendingTargets()) {
+            this.status = SubstituteRequestStatus.CANCELLED;
+            this.processedAt = LocalDateTime.now();
+        }
+    }
+
     public boolean canBeCancelledBy(Long userId) {
         return this.requesterId.equals(userId)
             && (SubstituteRequestStatus.PENDING.equals(this.status) || SubstituteRequestStatus.ACCEPTED.equals(this.status));
@@ -224,6 +233,19 @@ public class SubstituteRequest {
         this.targets.stream()
             .filter(target -> SubstituteRequestTargetStatus.PENDING.equals(target.getStatus()))
             .forEach(action);
+    }
+
+    private void updatePendingTargetStatus(Long workerId, Consumer<SubstituteRequestTarget> action) {
+        this.targets.stream()
+            .filter(target -> target.getTargetWorkerId().equals(workerId))
+            .filter(target -> SubstituteRequestTargetStatus.PENDING.equals(target.getStatus()))
+            .findFirst()
+            .ifPresent(action);
+    }
+
+    private boolean hasNoPendingTargets() {
+        return this.targets.stream()
+            .noneMatch(target -> SubstituteRequestTargetStatus.PENDING.equals(target.getStatus()));
     }
 
     /**

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerResignWorkspaceWorkerUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/ManagerResignWorkspaceWorkerUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+
+public interface ManagerResignWorkspaceWorkerUseCase {
+    void execute(ManagerActor actor, Long workspaceId, Long workerId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/UserResignWorkspaceWorkerUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/UserResignWorkspaceWorkerUseCase.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import com.dreamteam.alter.domain.user.context.AppActor;
+
+public interface UserResignWorkspaceWorkerUseCase {
+    void execute(AppActor actor, Long workspaceId);
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/WorkerResignationService.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/inbound/WorkerResignationService.java
@@ -1,0 +1,7 @@
+package com.dreamteam.alter.domain.workspace.port.inbound;
+
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+
+public interface WorkerResignationService {
+    void resign(WorkspaceWorker worker);
+}

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/SubstituteRequestQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/SubstituteRequestQueryRepository.java
@@ -49,5 +49,6 @@ public interface SubstituteRequestQueryRepository {
 
     List<SubstituteRequest> findAllActiveByRequesterUserId(Long userId);
     List<SubstituteRequestTarget> findAllPendingTargetsByUserId(Long userId);
+    List<SubstituteRequest> findAllActiveByRequesterWorkerId(Long workerId);
+    List<SubstituteRequest> findAllPendingTargetRequestsByTargetWorkerId(Long targetWorkerId);
 }
-

--- a/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/port/outbound/WorkspaceShiftQueryRepository.java
@@ -24,4 +24,5 @@ public interface WorkspaceShiftQueryRepository {
     boolean hasConflictingSchedule(WorkspaceWorker workspaceWorker, LocalDateTime startDateTime, LocalDateTime endDateTime);
     List<WorkspaceShift> findConfirmedByWorkerIdsAndDateRange(List<Long> workerIds, LocalDateTime startDateTime, LocalDateTime endDateTime);
     List<WorkspaceShift> findByUserAndWorkspaceAndMonthFrom(User user, Workspace workspace, int year, int month, LocalDateTime fromInclusive);
+    List<WorkspaceShift> findFutureShiftsByAssignedWorker(WorkspaceWorker worker, LocalDateTime fromInclusive);
 }

--- a/src/test/java/com/dreamteam/alter/application/user/usecase/WithdrawalUserTest.java
+++ b/src/test/java/com/dreamteam/alter/application/user/usecase/WithdrawalUserTest.java
@@ -13,14 +13,10 @@ import com.dreamteam.alter.domain.posting.type.PostingApplicationStatus;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.user.port.outbound.UserCertificateRepository;
 import com.dreamteam.alter.domain.user.port.outbound.UserRepository;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
-import com.dreamteam.alter.domain.workspace.entity.SubstituteRequestTarget;
 import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
-import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
-import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
-import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,10 +53,7 @@ class WithdrawalUserTest {
     private WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
 
     @Mock
-    private WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
-
-    @Mock
-    private SubstituteRequestQueryRepository substituteRequestQueryRepository;
+    private WorkerResignationService workerResignationService;
 
     @Mock
     private PostingApplicationQueryRepository postingApplicationQueryRepository;
@@ -93,8 +86,7 @@ class WithdrawalUserTest {
         verifyNoInteractions(userRepository);
         verifyNoInteractions(userCertificateRepository);
         verifyNoInteractions(workspaceWorkerQueryRepository);
-        verifyNoInteractions(workspaceWorkerScheduleQueryRepository);
-        verifyNoInteractions(substituteRequestQueryRepository);
+        verifyNoInteractions(workerResignationService);
         verifyNoInteractions(postingApplicationQueryRepository);
         verifyNoInteractions(fileQueryRepository);
         verifyNoInteractions(authService);
@@ -102,7 +94,7 @@ class WithdrawalUserTest {
     }
 
     @Test
-    @DisplayName("정상 탈퇴 흐름 - 모든 정리 로직이 호출되고 SubstituteRequest/Target/PostingApplication 이 취소된다")
+    @DisplayName("정상 탈퇴 흐름 - 활성 근무지 퇴직 공통 서비스와 탈퇴 고유 정리 로직이 호출된다")
     void execute_정상탈퇴_모든정리호출() {
         // given
         Long userId = 10L;
@@ -113,18 +105,6 @@ class WithdrawalUserTest {
         WorkspaceWorker activeWorker = mock(WorkspaceWorker.class);
         when(workspaceWorkerQueryRepository.findAllActiveByUserId(userId))
             .thenReturn(List.of(activeWorker));
-
-        WorkspaceWorkerSchedule activeSchedule = mock(WorkspaceWorkerSchedule.class);
-        when(workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(userId))
-            .thenReturn(List.of(activeSchedule));
-
-        SubstituteRequest activeRequest = mock(SubstituteRequest.class);
-        when(substituteRequestQueryRepository.findAllActiveByRequesterUserId(userId))
-            .thenReturn(List.of(activeRequest));
-
-        SubstituteRequestTarget pendingTarget = mock(SubstituteRequestTarget.class);
-        when(substituteRequestQueryRepository.findAllPendingTargetsByUserId(userId))
-            .thenReturn(List.of(pendingTarget));
 
         PostingApplication activeApplication = mock(PostingApplication.class);
         when(postingApplicationQueryRepository.findAllActiveByUserId(userId))
@@ -141,10 +121,7 @@ class WithdrawalUserTest {
         verify(user, times(1)).withdraw();
         verify(userRepository, times(1)).save(user);
         verify(userCertificateRepository, times(1)).deleteAll(user);
-        verify(activeWorker, times(1)).resign();
-        verify(activeSchedule, times(1)).delete();
-        verify(activeRequest, times(1)).cancel();
-        verify(pendingTarget, times(1)).cancel();
+        verify(workerResignationService, times(1)).resign(activeWorker);
         verify(activeApplication, times(1)).updateStatus(PostingApplicationStatus.CANCELLED);
         verify(profileImage, times(1)).markDeleted();
         verify(authService, times(1)).revokeAllExistingAuthorizations(user);
@@ -160,9 +137,6 @@ class WithdrawalUserTest {
         when(user.getId()).thenReturn(userId);
         when(workspaceQueryRepository.existsActiveWorkspaceByUserId(userId)).thenReturn(false);
         when(workspaceWorkerQueryRepository.findAllActiveByUserId(userId)).thenReturn(List.of());
-        when(workspaceWorkerScheduleQueryRepository.findAllActivatedByUserId(userId)).thenReturn(List.of());
-        when(substituteRequestQueryRepository.findAllActiveByRequesterUserId(userId)).thenReturn(List.of());
-        when(substituteRequestQueryRepository.findAllPendingTargetsByUserId(userId)).thenReturn(List.of());
         when(postingApplicationQueryRepository.findAllActiveByUserId(userId)).thenReturn(List.of());
         when(fileQueryRepository.findByTargetTypeAndTargetId(FileTargetType.USER_PROFILE, userId.toString()))
             .thenReturn(Optional.empty());
@@ -174,6 +148,7 @@ class WithdrawalUserTest {
         verify(user, times(1)).withdraw();
         verify(userRepository, times(1)).save(user);
         verify(userCertificateRepository, times(1)).deleteAll(user);
+        verifyNoInteractions(workerResignationService);
         verify(authService, times(1)).revokeAllExistingAuthorizations(user);
         verify(notificationService, times(1)).removeUserDeviceToken(user);
     }

--- a/src/test/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorkerTest.java
+++ b/src/test/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorkerTest.java
@@ -1,0 +1,121 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.ManagerActor;
+import com.dreamteam.alter.domain.user.entity.ManagerUser;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ManagerResignWorkspaceWorker 테스트")
+class ManagerResignWorkspaceWorkerTest {
+
+    @Mock
+    private WorkspaceQueryRepository workspaceQueryRepository;
+
+    @Mock
+    private WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+
+    @Mock
+    private WorkerResignationService workerResignationService;
+
+    @InjectMocks
+    private ManagerResignWorkspaceWorker managerResignWorkspaceWorker;
+
+    @Test
+    @DisplayName("관리 업장이 아니면 WORKSPACE_NOT_FOUND 예외가 발생한다")
+    void execute_관리업장아님_예외발생() {
+        // given
+        ManagerActor actor = mock(ManagerActor.class);
+        ManagerUser managerUser = mock(ManagerUser.class);
+        when(actor.getManagerUser()).thenReturn(managerUser);
+        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.WORKSPACE_NOT_FOUND));
+        verify(workerResignationService, never()).resign(any());
+    }
+
+    @Test
+    @DisplayName("근무자를 찾을 수 없으면 NOT_FOUND 예외가 발생한다")
+    void execute_근무자없음_예외발생() {
+        // given
+        ManagerActor actor = mock(ManagerActor.class);
+        ManagerUser managerUser = mock(ManagerUser.class);
+        when(actor.getManagerUser()).thenReturn(managerUser);
+        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
+        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
+        verify(workerResignationService, never()).resign(any());
+    }
+
+    @Test
+    @DisplayName("근무자가 다른 업장 소속이면 WORKSPACE_NOT_FOUND 예외가 발생한다")
+    void execute_다른업장근무자_예외발생() {
+        // given
+        ManagerActor actor = mock(ManagerActor.class);
+        ManagerUser managerUser = mock(ManagerUser.class);
+        when(actor.getManagerUser()).thenReturn(managerUser);
+        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
+
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.getId()).thenReturn(2L);
+        WorkspaceWorker worker = mock(WorkspaceWorker.class);
+        when(worker.getWorkspace()).thenReturn(workspace);
+        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.of(worker));
+
+        // when & then
+        assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.WORKSPACE_NOT_FOUND));
+        verify(workerResignationService, never()).resign(worker);
+    }
+
+    @Test
+    @DisplayName("정상 요청이면 공통 퇴직 서비스에 위임한다")
+    void execute_정상요청_공통서비스위임() {
+        // given
+        ManagerActor actor = mock(ManagerActor.class);
+        ManagerUser managerUser = mock(ManagerUser.class);
+        when(actor.getManagerUser()).thenReturn(managerUser);
+        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
+
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.getId()).thenReturn(1L);
+        WorkspaceWorker worker = mock(WorkspaceWorker.class);
+        when(worker.getWorkspace()).thenReturn(workspace);
+        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.of(worker));
+
+        // when
+        managerResignWorkspaceWorker.execute(actor, 1L, 10L);
+
+        // then
+        verify(workerResignationService).resign(worker);
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorkerTests.java
+++ b/src/test/java/com/dreamteam/alter/application/workspace/usecase/ManagerResignWorkspaceWorkerTests.java
@@ -21,14 +21,14 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ManagerResignWorkspaceWorker 테스트")
-class ManagerResignWorkspaceWorkerTest {
+class ManagerResignWorkspaceWorkerTests {
 
     @Mock
     private WorkspaceQueryRepository workspaceQueryRepository;
@@ -48,14 +48,14 @@ class ManagerResignWorkspaceWorkerTest {
         // given
         ManagerActor actor = mock(ManagerActor.class);
         ManagerUser managerUser = mock(ManagerUser.class);
-        when(actor.getManagerUser()).thenReturn(managerUser);
-        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(false);
+        given(actor.getManagerUser()).willReturn(managerUser);
+        given(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
             .isInstanceOf(CustomException.class)
             .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.WORKSPACE_NOT_FOUND));
-        verify(workerResignationService, never()).resign(any());
+        then(workerResignationService).should(never()).resign(any());
     }
 
     @Test
@@ -64,15 +64,15 @@ class ManagerResignWorkspaceWorkerTest {
         // given
         ManagerActor actor = mock(ManagerActor.class);
         ManagerUser managerUser = mock(ManagerUser.class);
-        when(actor.getManagerUser()).thenReturn(managerUser);
-        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
-        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.empty());
+        given(actor.getManagerUser()).willReturn(managerUser);
+        given(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).willReturn(true);
+        given(workspaceWorkerQueryRepository.findById(10L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
             .isInstanceOf(CustomException.class)
             .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
-        verify(workerResignationService, never()).resign(any());
+        then(workerResignationService).should(never()).resign(any());
     }
 
     @Test
@@ -81,20 +81,20 @@ class ManagerResignWorkspaceWorkerTest {
         // given
         ManagerActor actor = mock(ManagerActor.class);
         ManagerUser managerUser = mock(ManagerUser.class);
-        when(actor.getManagerUser()).thenReturn(managerUser);
-        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
+        given(actor.getManagerUser()).willReturn(managerUser);
+        given(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).willReturn(true);
 
         Workspace workspace = mock(Workspace.class);
-        when(workspace.getId()).thenReturn(2L);
+        given(workspace.getId()).willReturn(2L);
         WorkspaceWorker worker = mock(WorkspaceWorker.class);
-        when(worker.getWorkspace()).thenReturn(workspace);
-        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.of(worker));
+        given(worker.getWorkspace()).willReturn(workspace);
+        given(workspaceWorkerQueryRepository.findById(10L)).willReturn(Optional.of(worker));
 
         // when & then
         assertThatThrownBy(() -> managerResignWorkspaceWorker.execute(actor, 1L, 10L))
             .isInstanceOf(CustomException.class)
             .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.WORKSPACE_NOT_FOUND));
-        verify(workerResignationService, never()).resign(worker);
+        then(workerResignationService).should(never()).resign(worker);
     }
 
     @Test
@@ -103,19 +103,19 @@ class ManagerResignWorkspaceWorkerTest {
         // given
         ManagerActor actor = mock(ManagerActor.class);
         ManagerUser managerUser = mock(ManagerUser.class);
-        when(actor.getManagerUser()).thenReturn(managerUser);
-        when(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).thenReturn(true);
+        given(actor.getManagerUser()).willReturn(managerUser);
+        given(workspaceQueryRepository.existsByIdAndManagerUser(1L, managerUser)).willReturn(true);
 
         Workspace workspace = mock(Workspace.class);
-        when(workspace.getId()).thenReturn(1L);
+        given(workspace.getId()).willReturn(1L);
         WorkspaceWorker worker = mock(WorkspaceWorker.class);
-        when(worker.getWorkspace()).thenReturn(workspace);
-        when(workspaceWorkerQueryRepository.findById(10L)).thenReturn(Optional.of(worker));
+        given(worker.getWorkspace()).willReturn(workspace);
+        given(workspaceWorkerQueryRepository.findById(10L)).willReturn(Optional.of(worker));
 
         // when
         managerResignWorkspaceWorker.execute(actor, 1L, 10L);
 
         // then
-        verify(workerResignationService).resign(worker);
+        then(workerResignationService).should().resign(worker);
     }
 }

--- a/src/test/java/com/dreamteam/alter/application/workspace/usecase/UserResignWorkspaceWorkerTest.java
+++ b/src/test/java/com/dreamteam/alter/application/workspace/usecase/UserResignWorkspaceWorkerTest.java
@@ -1,0 +1,97 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.user.context.AppActor;
+import com.dreamteam.alter.domain.user.entity.User;
+import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.port.inbound.WorkerResignationService;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserResignWorkspaceWorker 테스트")
+class UserResignWorkspaceWorkerTest {
+
+    @Mock
+    private WorkspaceQueryRepository workspaceQueryRepository;
+
+    @Mock
+    private WorkspaceWorkerQueryRepository workspaceWorkerQueryRepository;
+
+    @Mock
+    private WorkerResignationService workerResignationService;
+
+    @InjectMocks
+    private UserResignWorkspaceWorker userResignWorkspaceWorker;
+
+    @Test
+    @DisplayName("업장이 없으면 WORKSPACE_NOT_FOUND 예외가 발생한다")
+    void execute_업장없음_예외발생() {
+        // given
+        AppActor actor = mock(AppActor.class);
+        when(workspaceQueryRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userResignWorkspaceWorker.execute(actor, 1L))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.WORKSPACE_NOT_FOUND));
+        verify(workerResignationService, never()).resign(any());
+    }
+
+    @Test
+    @DisplayName("활성 근무자가 아니면 FORBIDDEN 예외가 발생한다")
+    void execute_활성근무자아님_예외발생() {
+        // given
+        AppActor actor = mock(AppActor.class);
+        User user = mock(User.class);
+        Workspace workspace = mock(Workspace.class);
+        when(actor.getUser()).thenReturn(user);
+        when(workspaceQueryRepository.findById(1L)).thenReturn(Optional.of(workspace));
+        when(workspaceWorkerQueryRepository.findActiveWorkerByWorkspaceAndUser(workspace, user))
+            .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userResignWorkspaceWorker.execute(actor, 1L))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
+        verify(workerResignationService, never()).resign(any());
+    }
+
+    @Test
+    @DisplayName("정상 요청이면 공통 퇴직 서비스에 위임한다")
+    void execute_정상요청_공통서비스위임() {
+        // given
+        AppActor actor = mock(AppActor.class);
+        User user = mock(User.class);
+        Workspace workspace = mock(Workspace.class);
+        WorkspaceWorker worker = mock(WorkspaceWorker.class);
+        when(actor.getUser()).thenReturn(user);
+        when(workspaceQueryRepository.findById(1L)).thenReturn(Optional.of(workspace));
+        when(workspaceWorkerQueryRepository.findActiveWorkerByWorkspaceAndUser(workspace, user))
+            .thenReturn(Optional.of(worker));
+
+        // when
+        userResignWorkspaceWorker.execute(actor, 1L);
+
+        // then
+        verify(workerResignationService).resign(worker);
+    }
+}

--- a/src/test/java/com/dreamteam/alter/application/workspace/usecase/WorkerResignationServiceImplTest.java
+++ b/src/test/java/com/dreamteam/alter/application/workspace/usecase/WorkerResignationServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.dreamteam.alter.application.workspace.usecase;
+
+import com.dreamteam.alter.domain.workspace.entity.SubstituteRequest;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceShift;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorker;
+import com.dreamteam.alter.domain.workspace.entity.WorkspaceWorkerSchedule;
+import com.dreamteam.alter.domain.workspace.port.outbound.SubstituteRequestQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceShiftQueryRepository;
+import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceWorkerScheduleQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkerResignationServiceImpl 테스트")
+class WorkerResignationServiceImplTest {
+
+    @Mock
+    private WorkspaceShiftQueryRepository workspaceShiftQueryRepository;
+
+    @Mock
+    private WorkspaceWorkerScheduleQueryRepository workspaceWorkerScheduleQueryRepository;
+
+    @Mock
+    private SubstituteRequestQueryRepository substituteRequestQueryRepository;
+
+    @InjectMocks
+    private WorkerResignationServiceImpl workerResignationService;
+
+    @Test
+    @DisplayName("퇴직 정리 대상을 일괄 정리하고 worker를 퇴직 처리한다")
+    void resign_정리대상존재_일괄정리() {
+        // given
+        WorkspaceWorker worker = mock(WorkspaceWorker.class);
+        when(worker.getId()).thenReturn(10L);
+
+        WorkspaceShift futureShift = mock(WorkspaceShift.class);
+        when(workspaceShiftQueryRepository.findFutureShiftsByAssignedWorker(any(), any(LocalDateTime.class)))
+            .thenReturn(List.of(futureShift));
+
+        WorkspaceWorkerSchedule fixedSchedule = mock(WorkspaceWorkerSchedule.class);
+        when(workspaceWorkerScheduleQueryRepository.getByWorkspaceWorker(worker))
+            .thenReturn(List.of(fixedSchedule));
+
+        SubstituteRequest requesterRequest = mock(SubstituteRequest.class);
+        when(substituteRequestQueryRepository.findAllActiveByRequesterWorkerId(10L))
+            .thenReturn(List.of(requesterRequest));
+
+        SubstituteRequest targetRequest = mock(SubstituteRequest.class);
+        when(substituteRequestQueryRepository.findAllPendingTargetRequestsByTargetWorkerId(10L))
+            .thenReturn(List.of(targetRequest));
+
+        // when
+        workerResignationService.resign(worker);
+
+        // then
+        verify(futureShift, times(1)).unassignWorker();
+        verify(fixedSchedule, times(1)).delete();
+        verify(requesterRequest, times(1)).cancel();
+        verify(targetRequest, times(1)).cancelPendingTargetAndCancelIfNoPendingTargets(10L);
+        verify(worker, times(1)).resign();
+    }
+
+    @Test
+    @DisplayName("정리 대상이 없어도 worker를 퇴직 처리한다")
+    void resign_정리대상없음_퇴직처리() {
+        // given
+        WorkspaceWorker worker = mock(WorkspaceWorker.class);
+        when(worker.getId()).thenReturn(20L);
+        when(workspaceShiftQueryRepository.findFutureShiftsByAssignedWorker(any(), any(LocalDateTime.class)))
+            .thenReturn(List.of());
+        when(workspaceWorkerScheduleQueryRepository.getByWorkspaceWorker(worker)).thenReturn(List.of());
+        when(substituteRequestQueryRepository.findAllActiveByRequesterWorkerId(20L)).thenReturn(List.of());
+        when(substituteRequestQueryRepository.findAllPendingTargetRequestsByTargetWorkerId(20L)).thenReturn(List.of());
+
+        // when
+        workerResignationService.resign(worker);
+
+        // then
+        verify(worker, times(1)).resign();
+    }
+}

--- a/src/test/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequestTest.java
+++ b/src/test/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequestTest.java
@@ -1,0 +1,84 @@
+package com.dreamteam.alter.domain.workspace.entity;
+
+import com.dreamteam.alter.domain.workspace.type.SubstituteRequestStatus;
+import com.dreamteam.alter.domain.workspace.type.SubstituteRequestTargetStatus;
+import com.dreamteam.alter.domain.workspace.type.SubstituteRequestType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("SubstituteRequest 테스트")
+class SubstituteRequestTest {
+
+    @Test
+    @DisplayName("유일한 pending target이 취소되면 부모 요청도 취소된다")
+    void cancelPendingTarget_유일한타깃_부모요청취소() {
+        // given
+        SubstituteRequest request = SubstituteRequest.create(
+            mock(WorkspaceShift.class),
+            1L,
+            SubstituteRequestType.SPECIFIC,
+            "사유"
+        );
+        SubstituteRequestTarget target = SubstituteRequestTarget.create(request, 10L);
+        request.getTargets().add(target);
+
+        // when
+        request.cancelPendingTargetAndCancelIfNoPendingTargets(10L);
+
+        // then
+        assertThat(target.getStatus()).isEqualTo(SubstituteRequestTargetStatus.CANCELLED);
+        assertThat(request.getStatus()).isEqualTo(SubstituteRequestStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("다른 pending target이 남아 있으면 부모 요청은 대기 상태를 유지한다")
+    void cancelPendingTarget_다른Pending존재_부모요청유지() {
+        // given
+        SubstituteRequest request = SubstituteRequest.create(
+            mock(WorkspaceShift.class),
+            1L,
+            SubstituteRequestType.ALL,
+            "사유"
+        );
+        SubstituteRequestTarget resignedTarget = SubstituteRequestTarget.create(request, 10L);
+        SubstituteRequestTarget remainingTarget = SubstituteRequestTarget.create(request, 20L);
+        request.getTargets().add(resignedTarget);
+        request.getTargets().add(remainingTarget);
+
+        // when
+        request.cancelPendingTargetAndCancelIfNoPendingTargets(10L);
+
+        // then
+        assertThat(resignedTarget.getStatus()).isEqualTo(SubstituteRequestTargetStatus.CANCELLED);
+        assertThat(remainingTarget.getStatus()).isEqualTo(SubstituteRequestTargetStatus.PENDING);
+        assertThat(request.getStatus()).isEqualTo(SubstituteRequestStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("마지막 pending target이 취소되면 부모 요청도 취소된다")
+    void cancelPendingTarget_마지막Pending_부모요청취소() {
+        // given
+        SubstituteRequest request = SubstituteRequest.create(
+            mock(WorkspaceShift.class),
+            1L,
+            SubstituteRequestType.ALL,
+            "사유"
+        );
+        SubstituteRequestTarget rejectedTarget = SubstituteRequestTarget.create(request, 10L);
+        rejectedTarget.reject("불가");
+        SubstituteRequestTarget resignedTarget = SubstituteRequestTarget.create(request, 20L);
+        request.getTargets().add(rejectedTarget);
+        request.getTargets().add(resignedTarget);
+
+        // when
+        request.cancelPendingTargetAndCancelIfNoPendingTargets(20L);
+
+        // then
+        assertThat(rejectedTarget.getStatus()).isEqualTo(SubstituteRequestTargetStatus.REJECTED);
+        assertThat(resignedTarget.getStatus()).isEqualTo(SubstituteRequestTargetStatus.CANCELLED);
+        assertThat(request.getStatus()).isEqualTo(SubstituteRequestStatus.CANCELLED);
+    }
+}


### PR DESCRIPTION
## 관련 문서
[https://www.notion.so/BE-API-36e86553162880ffb242cc8918462f8c?v=2b186553162880979f62000c6c946512&source=copy_link](https://www.notion.so/BE-API-36e86553162880ffb242cc8918462f8c?v=2b186553162880979f62000c6c946512&source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자가 근무자를 퇴사 처리할 수 있는 기능 추가
  * 근무자가 업장에서 자진 퇴사할 수 있는 기능 추가
  * 근무자 퇴사 시 배정된 미래 근무, 고정 스케줄, 대체 근무 요청이 자동으로 정리되는 기능 추가

* **Tests**
  * 근무자 퇴사 기능에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->