### PR TITLE
feat: [alt-248] 사용자 목록 응답에 프로필 이미지 필드 추가

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/ReceivedSubstituteRequestResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/ReceivedSubstituteRequestResponseDto.java
@@ -65,12 +65,14 @@ public class ReceivedSubstituteRequestResponseDto {
             ))
             .requester(WorkerInfo.of(
                 response.getRequesterId(),
-                response.getRequesterName()
+                response.getRequesterName(),
+                response.getRequesterProfileImageUrl()
             ))
             .requestType(DescribedEnumDto.of(response.getRequestType(), SubstituteRequestType.describe()))
             .acceptedWorker(ObjectUtils.isNotEmpty(response.getAcceptedWorkerId()) ? WorkerInfo.of(
                 response.getAcceptedWorkerId(),
-                response.getAcceptedWorkerName()
+                response.getAcceptedWorkerName(),
+                response.getAcceptedWorkerProfileImageUrl()
             ) : null)
             .status(DescribedEnumDto.of(response.getStatus(), SubstituteRequestStatus.describe()))
             .requestReason(response.getRequestReason())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/SubstituteRequestDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/SubstituteRequestDetailResponseDto.java
@@ -69,16 +69,18 @@ public class SubstituteRequestDetailResponseDto {
             ))
             .requester(WorkerInfo.of(
                 response.getRequesterId(),
-                response.getRequesterName()
+                response.getRequesterName(),
+                response.getRequesterProfileImageUrl()
             ))
             .requestType(DescribedEnumDto.of(response.getRequestType(), SubstituteRequestType.describe()))
-            .targets(ObjectUtils.isNotEmpty(response.getTargets()) ? 
+            .targets(ObjectUtils.isNotEmpty(response.getTargets()) ?
                 response.getTargets().stream()
                     .map(SubstituteRequestTargetResponseDto::of)
                     .toList() : null)
             .acceptedWorker(ObjectUtils.isNotEmpty(response.getAcceptedWorkerId()) ? WorkerInfo.of(
                 response.getAcceptedWorkerId(),
-                response.getAcceptedWorkerName()
+                response.getAcceptedWorkerName(),
+                response.getAcceptedWorkerProfileImageUrl()
             ) : null)
             .status(DescribedEnumDto.of(response.getStatus(), SubstituteRequestStatus.describe()))
             .requestReason(response.getRequestReason())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/SubstituteRequestTargetResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/SubstituteRequestTargetResponseDto.java
@@ -31,7 +31,8 @@ public class SubstituteRequestTargetResponseDto {
         return SubstituteRequestTargetResponseDto.builder()
             .target(WorkerInfo.of(
                 targetInfo.getTargetWorkerId(),
-                targetInfo.getTargetWorkerName()
+                targetInfo.getTargetWorkerName(),
+                targetInfo.getProfileImageUrl()
             ))
             .status(DescribedEnumDto.of(targetInfo.getStatus(), SubstituteRequestTargetStatus.describe()))
             .rejectionReason(targetInfo.getRejectionReason())
@@ -41,7 +42,7 @@ public class SubstituteRequestTargetResponseDto {
 
     public static SubstituteRequestTargetResponseDto of(Long targetWorkerId, String targetWorkerName) {
         return SubstituteRequestTargetResponseDto.builder()
-            .target(WorkerInfo.of(targetWorkerId, targetWorkerName))
+            .target(WorkerInfo.of(targetWorkerId, targetWorkerName, null))
             .status(DescribedEnumDto.of(SubstituteRequestTargetStatus.PENDING, SubstituteRequestTargetStatus.describe()))
             .rejectionReason(null)
             .respondedAt(null)

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/WorkerInfo.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/schedule/dto/WorkerInfo.java
@@ -16,13 +16,18 @@ public class WorkerInfo {
     @Schema(description = "근무자 이름", example = "홍길동")
     private String workerName;
 
+    @Schema(description = "근무자 프로필 이미지 URL (미설정 시 null)", example = "https://cdn.alter-app.com/users/1/profile.png")
+    private String profileImageUrl;
+
     public static WorkerInfo of(
         Long workerId,
-        String workerName
+        String workerName,
+        String profileImageUrl
     ) {
         return WorkerInfo.builder()
             .workerId(workerId)
             .workerName(workerName)
+            .profileImageUrl(profileImageUrl)
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserWorkspaceWorkerResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/user/dto/UserWorkspaceWorkerResponseDto.java
@@ -21,10 +21,14 @@ public class UserWorkspaceWorkerResponseDto {
     @Schema(description = "근무자 이름", example = "홍길동")
     private String name;
 
+    @Schema(description = "근무자 프로필 이미지 URL (미설정 시 null)", example = "https://cdn.alter-app.com/users/1/profile.png")
+    private String profileImageUrl;
+
     public static UserWorkspaceWorkerResponseDto of(UserWorkspaceWorkerResponse entity) {
         return UserWorkspaceWorkerResponseDto.builder()
             .id(entity.getId())
             .name(entity.getName())
+            .profileImageUrl(entity.getProfileImageUrl())
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerSubstituteRequestResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerSubstituteRequestResponseDto.java
@@ -58,12 +58,14 @@ public class ManagerSubstituteRequestResponseDto {
             ))
             .requester(ManagerWorkerInfo.of(
                 response.getRequesterId(),
-                response.getRequesterName()
+                response.getRequesterName(),
+                response.getRequesterProfileImageUrl()
             ))
             .requestType(DescribedEnumDto.of(response.getRequestType(), SubstituteRequestType.describe()))
             .acceptedWorker(ObjectUtils.isNotEmpty(response.getAcceptedWorkerId()) ? ManagerWorkerInfo.of(
                 response.getAcceptedWorkerId(),
-                response.getAcceptedWorkerName()
+                response.getAcceptedWorkerName(),
+                response.getAcceptedWorkerProfileImageUrl()
             ) : null)
             .status(DescribedEnumDto.of(response.getStatus(), SubstituteRequestStatus.describe()))
             .requestReason(response.getRequestReason())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerWorkerInfo.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/schedule/dto/ManagerWorkerInfo.java
@@ -16,10 +16,14 @@ public class ManagerWorkerInfo {
     @Schema(description = "근무자 이름", example = "홍길동")
     private String workerName;
 
-    public static ManagerWorkerInfo of(Long workerId, String workerName) {
+    @Schema(description = "근무자 프로필 이미지 URL (미설정 시 null)", example = "https://cdn.alter-app.com/users/1/profile.png")
+    private String profileImageUrl;
+
+    public static ManagerWorkerInfo of(Long workerId, String workerName, String profileImageUrl) {
         return ManagerWorkerInfo.builder()
             .workerId(workerId)
             .workerName(workerName)
+            .profileImageUrl(profileImageUrl)
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/WorkspaceWorkerResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/workspace/dto/WorkspaceWorkerResponseDto.java
@@ -30,12 +30,16 @@ public class WorkspaceWorkerResponseDto {
     @Schema(description = "근무자 성별", example = "GENDER_MALE")
     private UserGender gender;
 
+    @Schema(description = "근무자 프로필 이미지 URL (미설정 시 null)", example = "https://cdn.alter-app.com/users/1/profile.png")
+    private String profileImageUrl;
+
     public static WorkspaceWorkerResponseDto of(WorkspaceWorkerResponse entity) {
         return WorkspaceWorkerResponseDto.builder()
             .id(entity.getId())
             .name(entity.getName())
             .contact(entity.getContact())
             .gender(entity.getGender())
+            .profileImageUrl(entity.getProfileImageUrl())
             .build();
     }
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -197,18 +197,10 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
-            .leftJoin(requesterFile).on(
-                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
-                requesterFile.targetId.eq(requesterUser.id.stringValue()),
-                requesterFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(requesterFile).on(fileConditions(requesterFile, requesterUser))
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
-            .leftJoin(acceptedFile).on(
-                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
-                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
-                acceptedFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(acceptedFile).on(fileConditions(acceptedFile, acceptedUser))
             .join(workspaceWorker).on(
                 workspaceWorker.workspace.id.eq(workspace.id)
                     .and(workspaceWorker.user.eq(user))
@@ -322,18 +314,10 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
-            .leftJoin(requesterFile).on(
-                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
-                requesterFile.targetId.eq(requesterUser.id.stringValue()),
-                requesterFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(requesterFile).on(fileConditions(requesterFile, requesterUser))
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
-            .leftJoin(acceptedFile).on(
-                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
-                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
-                acceptedFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(acceptedFile).on(fileConditions(acceptedFile, acceptedUser))
             .where(
                 substituteRequest.id.eq(requestId)
                     .and(requesterWorker.user.eq(user))
@@ -363,11 +347,7 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .from(substituteRequestTarget)
             .join(targetWorker).on(targetWorker.id.eq(substituteRequestTarget.targetWorkerId))
             .join(targetUser).on(targetUser.id.eq(targetWorker.user.id))
-            .leftJoin(targetFile).on(
-                targetFile.targetType.eq(FileTargetType.USER_PROFILE),
-                targetFile.targetId.eq(targetUser.id.stringValue()),
-                targetFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(targetFile).on(fileConditions(targetFile, targetUser))
             .where(substituteRequestTarget.substituteRequest.id.eq(requestId))
             .orderBy(substituteRequestTarget.id.asc())
             .fetch();
@@ -436,18 +416,10 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
-            .leftJoin(requesterFile).on(
-                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
-                requesterFile.targetId.eq(requesterUser.id.stringValue()),
-                requesterFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(requesterFile).on(fileConditions(requesterFile, requesterUser))
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
-            .leftJoin(acceptedFile).on(
-                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
-                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
-                acceptedFile.status.eq(FileStatus.ATTACHED)
-            )
+            .leftJoin(acceptedFile).on(fileConditions(acceptedFile, acceptedUser))
             .where(
                 ObjectUtils.isNotEmpty(workspaceId) ? workspace.id.eq(workspaceId) : null,
                 managerRequestStatusCondition(status),
@@ -540,5 +512,13 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
                     .exists()
             )
             .fetch();
+    }
+
+    private BooleanExpression[] fileConditions(QFile file, QUser user) {
+        return new BooleanExpression[] {
+            file.targetType.eq(FileTargetType.USER_PROFILE),
+            file.targetId.eq(user.id.stringValue()),
+            file.status.eq(FileStatus.ATTACHED)
+        };
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -126,6 +126,7 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .where(
                 workspaceCondition
                     .and(statusCondition(filter.getStatus()))
+                    .and(substituteRequest.requesterId.ne(workspaceWorker.id))
                     .and(
                         substituteRequest.requestType.eq(SubstituteRequestType.ALL)
                             .or(JPAExpressions.selectFrom(QSubstituteRequestTarget.substituteRequestTarget)
@@ -209,6 +210,7 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .where(
                 workspaceCondition
                     .and(statusCondition(filter.getStatus()))
+                    .and(substituteRequest.requesterId.ne(workspaceWorker.id))
                     .and(
                         substituteRequest.requestType.eq(SubstituteRequestType.ALL)
                             .or(JPAExpressions.selectFrom(QSubstituteRequestTarget.substituteRequestTarget)

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/SubstituteRequestQueryRepositoryImpl.java
@@ -8,6 +8,9 @@ import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.Recei
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.SentSubstituteRequestListResponse;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.SentSubstituteRequestDetailResponse;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.SubstituteRequestTargetInfo;
+import com.dreamteam.alter.domain.file.entity.QFile;
+import com.dreamteam.alter.domain.file.type.FileStatus;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.user.entity.QUser;
 import com.dreamteam.alter.domain.user.entity.User;
 import com.dreamteam.alter.domain.workspace.entity.QWorkspaceWorker;
@@ -147,6 +150,8 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
         QWorkspaceWorker requesterWorker = new QWorkspaceWorker("requesterWorker");
         QWorkspaceWorker acceptedWorker = new QWorkspaceWorker("acceptedWorker");
         QWorkspaceWorker myWorker = new QWorkspaceWorker("myWorker");
+        QFile requesterFile = new QFile("requesterFile");
+        QFile acceptedFile = new QFile("acceptedFile");
 
         BooleanExpression workspaceCondition;
         if (ObjectUtils.isNotEmpty(filter.getWorkspaceId())) {
@@ -176,9 +181,11 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
                 workspace.businessName,
                 requesterWorker.id,
                 requesterUser.name,
+                requesterFile.fileUrl,
                 substituteRequest.requestType,
                 acceptedWorker.id,
                 acceptedUser.name,
+                acceptedFile.fileUrl,
                 substituteRequest.status,
                 substituteRequest.requestReason,
                 substituteRequest.createdAt,
@@ -190,8 +197,18 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
+            .leftJoin(requesterFile).on(
+                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
+                requesterFile.targetId.eq(requesterUser.id.stringValue()),
+                requesterFile.status.eq(FileStatus.ATTACHED)
+            )
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
+            .leftJoin(acceptedFile).on(
+                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
+                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
+                acceptedFile.status.eq(FileStatus.ATTACHED)
+            )
             .join(workspaceWorker).on(
                 workspaceWorker.workspace.id.eq(workspace.id)
                     .and(workspaceWorker.user.eq(user))
@@ -274,7 +291,9 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
         QUser requesterUser = new QUser("requesterUser");
         QWorkspaceWorker acceptedWorker = new QWorkspaceWorker("acceptedWorker");
         QUser acceptedUser = new QUser("acceptedUser");
-        
+        QFile requesterFile = new QFile("requesterFile");
+        QFile acceptedFile = new QFile("acceptedFile");
+
         SentSubstituteRequestDetailResponse requestInfo = queryFactory
             .select(Projections.bean(
                 SentSubstituteRequestDetailResponse.class,
@@ -287,9 +306,11 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
                 workspace.businessName.as("workspaceName"),
                 requesterWorker.id.as("requesterId"),
                 requesterUser.name.as("requesterName"),
+                requesterFile.fileUrl.as("requesterProfileImageUrl"),
                 substituteRequest.requestType.as("requestType"),
                 acceptedWorker.id.as("acceptedWorkerId"),
                 acceptedUser.name.as("acceptedWorkerName"),
+                acceptedFile.fileUrl.as("acceptedWorkerProfileImageUrl"),
                 substituteRequest.status.as("status"),
                 substituteRequest.requestReason.as("requestReason"),
                 substituteRequest.createdAt.as("createdAt"),
@@ -301,8 +322,18 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
+            .leftJoin(requesterFile).on(
+                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
+                requesterFile.targetId.eq(requesterUser.id.stringValue()),
+                requesterFile.status.eq(FileStatus.ATTACHED)
+            )
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
+            .leftJoin(acceptedFile).on(
+                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
+                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
+                acceptedFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 substituteRequest.id.eq(requestId)
                     .and(requesterWorker.user.eq(user))
@@ -317,12 +348,14 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
         QUser targetUser = new QUser("targetUser");
         QWorkspaceWorker targetWorker = new QWorkspaceWorker("targetWorker");
         QSubstituteRequestTarget substituteRequestTarget = new QSubstituteRequestTarget("substituteRequestTarget");
+        QFile targetFile = new QFile("targetFile");
 
         List<SubstituteRequestTargetInfo> targets = queryFactory
             .select(Projections.constructor(
                 SubstituteRequestTargetInfo.class,
                 targetWorker.id,
                 targetUser.name,
+                targetFile.fileUrl,
                 substituteRequestTarget.status,
                 substituteRequestTarget.rejectionReason,
                 substituteRequestTarget.respondedAt
@@ -330,6 +363,11 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .from(substituteRequestTarget)
             .join(targetWorker).on(targetWorker.id.eq(substituteRequestTarget.targetWorkerId))
             .join(targetUser).on(targetUser.id.eq(targetWorker.user.id))
+            .leftJoin(targetFile).on(
+                targetFile.targetType.eq(FileTargetType.USER_PROFILE),
+                targetFile.targetId.eq(targetUser.id.stringValue()),
+                targetFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(substituteRequestTarget.substituteRequest.id.eq(requestId))
             .orderBy(substituteRequestTarget.id.asc())
             .fetch();
@@ -367,6 +405,8 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
         QUser acceptedUser = new QUser("acceptedUser");
         QWorkspaceWorker requesterWorker = new QWorkspaceWorker("requesterWorker");
         QWorkspaceWorker acceptedWorker = new QWorkspaceWorker("acceptedWorker");
+        QFile requesterFile = new QFile("requesterFile");
+        QFile acceptedFile = new QFile("acceptedFile");
 
         return queryFactory
             .select(Projections.constructor(
@@ -380,9 +420,11 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
                 workspace.businessName,
                 requesterWorker.id,
                 requesterUser.name,
+                requesterFile.fileUrl,
                 substituteRequest.requestType,
                 acceptedWorker.id,
                 acceptedUser.name,
+                acceptedFile.fileUrl,
                 substituteRequest.status,
                 substituteRequest.requestReason,
                 substituteRequest.createdAt,
@@ -394,8 +436,18 @@ public class SubstituteRequestQueryRepositoryImpl implements SubstituteRequestQu
             .join(workspaceShift.workspace, workspace)
             .join(requesterWorker).on(requesterWorker.id.eq(substituteRequest.requesterId))
             .join(requesterUser).on(requesterUser.id.eq(requesterWorker.user.id))
+            .leftJoin(requesterFile).on(
+                requesterFile.targetType.eq(FileTargetType.USER_PROFILE),
+                requesterFile.targetId.eq(requesterUser.id.stringValue()),
+                requesterFile.status.eq(FileStatus.ATTACHED)
+            )
             .leftJoin(acceptedWorker).on(acceptedWorker.id.eq(substituteRequest.acceptedWorkerId))
             .leftJoin(acceptedUser).on(acceptedUser.id.eq(acceptedWorker.user.id))
+            .leftJoin(acceptedFile).on(
+                acceptedFile.targetType.eq(FileTargetType.USER_PROFILE),
+                acceptedFile.targetId.eq(acceptedUser.id.stringValue()),
+                acceptedFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 ObjectUtils.isNotEmpty(workspaceId) ? workspace.id.eq(workspaceId) : null,
                 managerRequestStatusCondition(status),

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.dreamteam.alter.domain.file.type.FileStatus;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Repository;
 
@@ -22,8 +24,6 @@ import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.UserW
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.UserWorkspaceWorkerResponse;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.WorkspaceWorkerResponse;
 import com.dreamteam.alter.domain.file.entity.QFile;
-import com.dreamteam.alter.domain.file.type.FileStatus;
-import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.reputation.entity.QReputationSummary;
 import com.dreamteam.alter.domain.reputation.type.ReputationType;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
@@ -194,11 +194,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
             .leftJoin(qFile)
-            .on(
-                qFile.targetType.eq(FileTargetType.USER_PROFILE),
-                qFile.targetId.eq(qUser.id.stringValue()),
-                qFile.status.eq(FileStatus.ATTACHED)
-            )
+            .on(fileConditions(qFile, qUser))
             .where(
                 qWorkspace.managerUser.eq(managerUser),
                 qWorkspace.id.eq(workspaceId),
@@ -301,11 +297,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
             .leftJoin(qFile)
-            .on(
-                qFile.targetType.eq(FileTargetType.USER_PROFILE),
-                qFile.targetId.eq(qUser.id.stringValue()),
-                qFile.status.eq(FileStatus.ATTACHED)
-            )
+            .on(fileConditions(qFile, qUser))
             .where(
                 qWorkspace.id.eq(workspaceId),
                 qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED),
@@ -416,11 +408,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
             .leftJoin(qFile)
-            .on(
-                qFile.targetType.eq(FileTargetType.USER_PROFILE),
-                qFile.targetId.eq(qUser.id.stringValue()),
-                qFile.status.eq(FileStatus.ATTACHED)
-            )
+            .on(fileConditions(qFile, qUser))
             .where(
                 qWorkspace.id.eq(workspaceId),
                 qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED),
@@ -522,11 +510,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
             .join(qManagerUser.user, qUser)
             .join(qManagerUser.workspaces, qWorkspace)
             .leftJoin(qFile)
-            .on(
-                qFile.targetType.eq(FileTargetType.USER_PROFILE),
-                qFile.targetId.eq(qUser.id.stringValue()),
-                qFile.status.eq(FileStatus.ATTACHED)
-            )
+            .on(fileConditions(qFile, qUser))
             .where(
                 qWorkspace.id.eq(workspaceId),
                 cursorConditions(qManagerUser, pageRequest.cursor())
@@ -584,11 +568,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
             .join(qManagerUser.user, qUser)
             .join(qManagerUser.workspaces, qWorkspace)
             .leftJoin(qFile)
-            .on(
-                qFile.targetType.eq(FileTargetType.USER_PROFILE),
-                qFile.targetId.eq(qUser.id.stringValue()),
-                qFile.status.eq(FileStatus.ATTACHED)
-            )
+            .on(fileConditions(qFile, qUser))
             .where(
                 qWorkspace.managerUser.eq(managerUser),
                 qWorkspace.id.eq(workspaceId),
@@ -718,4 +698,11 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 .and(qManagerUser.id.lt(cursor.getId())));
     }
 
+    private BooleanExpression[] fileConditions(QFile file, QUser user) {
+        return new BooleanExpression[] {
+            file.targetType.eq(FileTargetType.USER_PROFILE),
+            file.targetId.eq(user.id.stringValue()),
+            file.status.eq(FileStatus.ATTACHED)
+        };
+    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/WorkspaceQueryRepositoryImpl.java
@@ -21,6 +21,9 @@ import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.UserW
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.UserWorkspaceWorkerListResponse;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.UserWorkspaceWorkerResponse;
 import com.dreamteam.alter.adapter.outbound.workspace.persistence.readonly.WorkspaceWorkerResponse;
+import com.dreamteam.alter.domain.file.entity.QFile;
+import com.dreamteam.alter.domain.file.type.FileStatus;
+import com.dreamteam.alter.domain.file.type.FileTargetType;
 import com.dreamteam.alter.domain.reputation.entity.QReputationSummary;
 import com.dreamteam.alter.domain.reputation.type.ReputationType;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
@@ -159,6 +162,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         QWorkspace qWorkspace = QWorkspace.workspace;
         QUser qUser = QUser.user;
         QWorkspaceShift qWorkspaceShift = QWorkspaceShift.workspaceShift;
+        QFile qFile = QFile.file;
 
         return queryFactory
             .select(Projections.constructor(
@@ -169,7 +173,8 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                     qUser.id,
                     qUser.name,
                     qUser.contact,
-                    qUser.gender
+                    qUser.gender,
+                    qFile.fileUrl
                 ),
                 qWorkspaceWorker.status,
                 Expressions.constant(WorkerPositionType.WORKER),
@@ -188,6 +193,12 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.startDateTime.gt(LocalDateTime.now()),
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
+            .leftJoin(qFile)
+            .on(
+                qFile.targetType.eq(FileTargetType.USER_PROFILE),
+                qFile.targetId.eq(qUser.id.stringValue()),
+                qFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 qWorkspace.managerUser.eq(managerUser),
                 qWorkspace.id.eq(workspaceId),
@@ -205,6 +216,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qUser.name,
                 qUser.contact,
                 qUser.gender,
+                qFile.fileUrl,
                 qWorkspaceWorker.status,
                 qWorkspaceWorker.colorCode,
                 qWorkspaceWorker.employedAt,
@@ -262,6 +274,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         QWorkspace qWorkspace = QWorkspace.workspace;
         QUser qUser = QUser.user;
         QWorkspaceShift qWorkspaceShift = QWorkspaceShift.workspaceShift;
+        QFile qFile = QFile.file;
 
         return queryFactory
             .select(Projections.constructor(
@@ -270,7 +283,8 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 Projections.constructor(
                     UserWorkspaceWorkerResponse.class,
                     qUser.id,
-                    qUser.name
+                    qUser.name,
+                    qFile.fileUrl
                 ),
                 Expressions.constant(WorkerPositionType.WORKER),
                 qWorkspaceWorker.employedAt,
@@ -286,6 +300,12 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.startDateTime.gt(LocalDateTime.now()),
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
+            .leftJoin(qFile)
+            .on(
+                qFile.targetType.eq(FileTargetType.USER_PROFILE),
+                qFile.targetId.eq(qUser.id.stringValue()),
+                qFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 qWorkspace.id.eq(workspaceId),
                 qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED),
@@ -295,6 +315,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceWorker.id,
                 qUser.id,
                 qUser.name,
+                qFile.fileUrl,
                 qWorkspaceWorker.employedAt,
                 qWorkspaceWorker.createdAt
             )
@@ -353,6 +374,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         QWorkspace qWorkspace = QWorkspace.workspace;
         QUser qUser = QUser.user;
         QWorkspaceShift qWorkspaceShift = QWorkspaceShift.workspaceShift;
+        QFile qFile = QFile.file;
 
         BooleanExpression excludeCondition = ObjectUtils.isNotEmpty(self)
             ? qUser.id.ne(self.getId())
@@ -376,7 +398,8 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 Projections.constructor(
                     UserWorkspaceWorkerResponse.class,
                     qUser.id,
-                    qUser.name
+                    qUser.name,
+                    qFile.fileUrl
                 ),
                 Expressions.constant(WorkerPositionType.WORKER),
                 qWorkspaceWorker.employedAt,
@@ -392,6 +415,12 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceShift.startDateTime.gt(LocalDateTime.now()),
                 qWorkspaceShift.status.eq(WorkspaceShiftStatus.CONFIRMED)
             )
+            .leftJoin(qFile)
+            .on(
+                qFile.targetType.eq(FileTargetType.USER_PROFILE),
+                qFile.targetId.eq(qUser.id.stringValue()),
+                qFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 qWorkspace.id.eq(workspaceId),
                 qWorkspaceWorker.status.eq(WorkspaceWorkerStatus.ACTIVATED),
@@ -403,6 +432,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 qWorkspaceWorker.id,
                 qUser.id,
                 qUser.name,
+                qFile.fileUrl,
                 qWorkspaceWorker.employedAt,
                 qWorkspaceWorker.createdAt
             )
@@ -473,6 +503,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         QManagerUser qManagerUser = QManagerUser.managerUser;
         QWorkspace qWorkspace = QWorkspace.workspace;
         QUser qUser = QUser.user;
+        QFile qFile = QFile.file;
 
         return queryFactory
             .select(Projections.constructor(
@@ -481,7 +512,8 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                 Projections.constructor(
                     UserWorkspaceWorkerResponse.class,
                     qUser.id,
-                    qUser.name
+                    qUser.name,
+                    qFile.fileUrl
                 ),
                 Expressions.constant(WorkerPositionType.OWNER),
                 qManagerUser.createdAt
@@ -489,6 +521,12 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
             .from(qManagerUser)
             .join(qManagerUser.user, qUser)
             .join(qManagerUser.workspaces, qWorkspace)
+            .leftJoin(qFile)
+            .on(
+                qFile.targetType.eq(FileTargetType.USER_PROFILE),
+                qFile.targetId.eq(qUser.id.stringValue()),
+                qFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 qWorkspace.id.eq(workspaceId),
                 cursorConditions(qManagerUser, pageRequest.cursor())
@@ -525,6 +563,7 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
         QManagerUser qManagerUser = QManagerUser.managerUser;
         QWorkspace qWorkspace = QWorkspace.workspace;
         QUser qUser = QUser.user;
+        QFile qFile = QFile.file;
 
         return queryFactory
             .select(Projections.constructor(
@@ -535,7 +574,8 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
                     qUser.id,
                     qUser.name,
                     qUser.contact,
-                    qUser.gender
+                    qUser.gender,
+                    qFile.fileUrl
                 ),
                 Expressions.constant(WorkerPositionType.OWNER),
                 qManagerUser.createdAt
@@ -543,6 +583,12 @@ public class WorkspaceQueryRepositoryImpl implements WorkspaceQueryRepository {
             .from(qManagerUser)
             .join(qManagerUser.user, qUser)
             .join(qManagerUser.workspaces, qWorkspace)
+            .leftJoin(qFile)
+            .on(
+                qFile.targetType.eq(FileTargetType.USER_PROFILE),
+                qFile.targetId.eq(qUser.id.stringValue()),
+                qFile.status.eq(FileStatus.ATTACHED)
+            )
             .where(
                 qWorkspace.managerUser.eq(managerUser),
                 qWorkspace.id.eq(workspaceId),

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerSubstituteRequestListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ManagerSubstituteRequestListResponse.java
@@ -22,9 +22,11 @@ public class ManagerSubstituteRequestListResponse {
     private String workspaceName;
     private Long requesterId;
     private String requesterName;
+    private String requesterProfileImageUrl;
     private SubstituteRequestType requestType;
     private Long acceptedWorkerId;
     private String acceptedWorkerName;
+    private String acceptedWorkerProfileImageUrl;
     private SubstituteRequestStatus status;
     private String requestReason;
     private LocalDateTime createdAt;

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ReceivedSubstituteRequestListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/ReceivedSubstituteRequestListResponse.java
@@ -31,11 +31,15 @@ public class ReceivedSubstituteRequestListResponse {
 
     private String requesterName;
 
+    private String requesterProfileImageUrl;
+
     private SubstituteRequestType requestType;
 
     private Long acceptedWorkerId;
 
     private String acceptedWorkerName;
+
+    private String acceptedWorkerProfileImageUrl;
 
     private SubstituteRequestStatus status;
 

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/SentSubstituteRequestDetailResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/SentSubstituteRequestDetailResponse.java
@@ -24,9 +24,11 @@ public class SentSubstituteRequestDetailResponse {
     private String workspaceName;
     private Long requesterId;
     private String requesterName;
+    private String requesterProfileImageUrl;
     private SubstituteRequestType requestType;
     private Long acceptedWorkerId;
     private String acceptedWorkerName;
+    private String acceptedWorkerProfileImageUrl;
     private SubstituteRequestStatus status;
     private String requestReason;
     private LocalDateTime createdAt;

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/SubstituteRequestTargetInfo.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/SubstituteRequestTargetInfo.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class SubstituteRequestTargetInfo {
     private Long targetWorkerId;
     private String targetWorkerName;
+    private String profileImageUrl;
     private SubstituteRequestTargetStatus status;
     private String rejectionReason;
     private LocalDateTime respondedAt;

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/UserWorkspaceWorkerResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/UserWorkspaceWorkerResponse.java
@@ -11,5 +11,6 @@ public class UserWorkspaceWorkerResponse {
 
     private Long id;
     private String name;
+    private String profileImageUrl;
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/WorkspaceWorkerResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/workspace/persistence/readonly/WorkspaceWorkerResponse.java
@@ -22,6 +22,8 @@ public class WorkspaceWorkerResponse {
     @Enumerated(EnumType.STRING)
     private UserGender gender;
 
+    private String profileImageUrl;
+
     /**
      * User 엔티티로부터 DTO 생성
      */
@@ -30,7 +32,8 @@ public class WorkspaceWorkerResponse {
             user.getId(),
             user.getName(),
             user.getContact(),
-            user.getGender()
+            user.getGender(),
+            null
         );
     }
 


### PR DESCRIPTION
## 변경사항
[사용자 기본 프로필 도입](https://app.notion.com/p/37a8655316288052a3bad9f560328e37)

- WorkerInfo/ManagerWorkerInfo 팩토리 및 응답 DTO에 profileImageUrl 매핑
- 대타요청 요청자/수락자/대상자 정보에 profileImageUrl 추가
- 워크스페이스 워커/매니저 목록에 profileImageUrl 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 근무자/사용자 응답에 프로필 이미지 URL 추가
  * 대타 요청 목록·상세 조회에 요청자 및 수락자 프로필 이미지 표시
  * 요청 대상자 및 워크스페이스 근무자 정보에 프로필 이미지 포함
  * 관리자용 대타 요청 목록 및 화면에서 프로필 이미지 노출 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->