### PR TITLE
chore: [ALT-268] DB ↔ 엔티티 스키마 일치화 작업

### DIFF
--- a/src/main/java/com/dreamteam/alter/domain/email/entity/EmailSendLog.java
+++ b/src/main/java/com/dreamteam/alter/domain/email/entity/EmailSendLog.java
@@ -30,7 +30,7 @@ public class EmailSendLog {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private EmailSendStatus status;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/file/entity/File.java
+++ b/src/main/java/com/dreamteam/alter/domain/file/entity/File.java
@@ -26,37 +26,37 @@ import java.time.LocalDateTime;
 public class File {
 
     @Id
-    @Column(name = "id", nullable = false, unique = true)
+    @Column(name = "id", length = 36, nullable = false, unique = true)
     private String id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "target_type", nullable = false)
+    @Column(name = "target_type", length = 40, nullable = false)
     private FileTargetType targetType;
 
-    @Column(name = "target_id")
+    @Column(name = "target_id", length = 36)
     private String targetId;
 
     @Column(name = "original_file_name", nullable = false)
     private String originalFileName;
 
-    @Column(name = "stored_key", nullable = false, unique = true)
+    @Column(name = "stored_key", length = 512, nullable = false, unique = true)
     private String storedKey;
 
-    @Column(name = "file_url")
+    @Column(name = "file_url", length = 1024)
     private String fileUrl;
 
-    @Column(name = "content_type", nullable = false)
+    @Column(name = "content_type", length = 100, nullable = false)
     private String contentType;
 
     @Column(name = "file_size", nullable = false)
     private Long fileSize;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "bucket_type", nullable = false)
+    @Column(name = "bucket_type", length = 10, nullable = false)
     private BucketType bucketType;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     private FileStatus status;
 
     @Column(name = "uploaded_by", nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dreamteam/alter/domain/notification/entity/Notification.java
@@ -30,7 +30,7 @@ public class Notification {
     private User targetUser;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "scope", nullable = false)
+    @Column(name = "scope", length = 20, nullable = false)
     private TokenScope scope;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingApplication.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingApplication.java
@@ -41,7 +41,7 @@ public class PostingApplication {
 
     @Enumerated(EnumType.STRING)
     @SQLRestriction("status != 'DELETED'")
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 50, nullable = false)
     private PostingApplicationStatus status;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/Reputation.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/Reputation.java
@@ -34,14 +34,14 @@ public class Reputation {
     @ManyToOne(fetch = FetchType.LAZY)
     private ReputationRequest reputationRequest;
 
-    @Column(name = "writer_type", nullable = false)
+    @Column(name = "writer_type", length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private ReputationType writerType;
 
     @Column(name = "writer_id", nullable = false)
     private Long writerId;
 
-    @Column(name = "target_type", nullable = false)
+    @Column(name = "target_type", length = 20, nullable = false)
     @Enumerated(EnumType.STRING)
     private ReputationType targetType;
 

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationKeywordMap.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationKeywordMap.java
@@ -38,7 +38,7 @@ public class ReputationKeywordMap {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private ReputationKeyword keyword;
 
-    @Column(name = "description")
+    @Column(name = "description", length = 128)
     private String description;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationRequest.java
@@ -34,7 +34,7 @@ public class ReputationRequest {
     private Workspace workspace;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "request_type", length = 20, nullable = false)
+    @Column(name = "request_type", length = 24, nullable = false)
     private ReputationRequestType requestType;
 
     @Column(name = "requester_type", length = 20, nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationSummary.java
+++ b/src/main/java/com/dreamteam/alter/domain/reputation/entity/ReputationSummary.java
@@ -38,7 +38,7 @@ public class ReputationSummary {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = COLUMN_TARGET_TYPE, nullable = false)
+    @Column(name = COLUMN_TARGET_TYPE, length = 20, nullable = false)
     private ReputationType targetType;
 
     @Column(name = COLUMN_TARGET_ID, nullable = false)
@@ -51,7 +51,7 @@ public class ReputationSummary {
     @Column(name = COLUMN_TOP_KEYWORDS, columnDefinition = "jsonb")
     private List<KeywordSummaryDto> topKeywords;
 
-    @Column(name = COLUMN_SUMMARY_DESCRIPTION)
+    @Column(name = COLUMN_SUMMARY_DESCRIPTION, length = 500)
     private String summaryDescription;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/ManagerUser.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/ManagerUser.java
@@ -31,7 +31,7 @@ public class ManagerUser {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 50, nullable = false)
     private ManagerUserStatus status;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -35,13 +35,14 @@ public class User {
     @Column(name = "password", length = 255, nullable = true)
     private String password;
 
-    @Column(name = "name", length = 12, nullable = false)
+    @Column(name = "name", length = 30, nullable = false)
     private String name;
 
     @Column(name = "nickname", length = 64, nullable = false, unique = true)
     private String nickname;
 
-    @Column(name = "contact", length = 11, nullable = false)
+    // length 30: withdraw() 익명화 값(id + "_탈퇴") 수용 (전화번호 자체는 11자)
+    @Column(name = "contact", length = 30, nullable = false)
     private String contact;
 
     @Column(name = "birthday", length = 8, nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/User.java
@@ -41,18 +41,18 @@ public class User {
     @Column(name = "nickname", length = 64, nullable = false, unique = true)
     private String nickname;
 
-    @Column(name = "contact", length = 13, nullable = false)
+    @Column(name = "contact", length = 11, nullable = false)
     private String contact;
 
     @Column(name = "birthday", length = 8, nullable = false)
     private String birthday;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "gender", nullable = false)
+    @Column(name = "gender", length = 20, nullable = false)
     private UserGender gender;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
+    @Column(name = "role", length = 20, nullable = false)
     private UserRole role;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dreamteam/alter/domain/user/entity/UserCertificate.java
+++ b/src/main/java/com/dreamteam/alter/domain/user/entity/UserCertificate.java
@@ -33,7 +33,7 @@ public class UserCertificate {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
+    @Column(name = "type", length = 24, nullable = false)
     private CertificateType type;
 
     @Column(name = "certificate_name", length = 255, nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/BusinessInvitation.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/BusinessInvitation.java
@@ -39,7 +39,7 @@ public class BusinessInvitation {
     private ManagerUser invitedBy;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private BusinessInvitationStatus status;
 
     @Column(name = "expires_at", nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/BusinessJoinRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/BusinessJoinRequest.java
@@ -34,7 +34,7 @@ public class BusinessJoinRequest {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private BusinessJoinRequestStatus status;
 
     @CreatedDate

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequest.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequest.java
@@ -39,7 +39,7 @@ public class SubstituteRequest {
     private Long requesterId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "request_type", nullable = false)
+    @Column(name = "request_type", length = 20, nullable = false)
     private SubstituteRequestType requestType;
 
     @OneToMany(mappedBy = "substituteRequest", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -52,16 +52,16 @@ public class SubstituteRequest {
     private Long approverId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private SubstituteRequestStatus status;
 
-    @Column(name = "request_reason")
+    @Column(name = "request_reason", length = 500)
     private String requestReason;
 
-    @Column(name = "approver_rejection_reason")
+    @Column(name = "approver_rejection_reason", length = 500)
     private String approverRejectionReason;
 
-    @Column(name = "approval_comment")
+    @Column(name = "approval_comment", length = 500)
     private String approvalComment;
 
     @Column(name = "accepted_at")

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequestTarget.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/SubstituteRequestTarget.java
@@ -30,10 +30,10 @@ public class SubstituteRequestTarget {
     private Long targetWorkerId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private SubstituteRequestTargetStatus status;
 
-    @Column(name = "rejection_reason")
+    @Column(name = "rejection_reason", length = 500)
     private String rejectionReason;
 
     @Column(name = "responded_at")

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/Workspace.java
@@ -39,7 +39,7 @@ public class Workspace {
     @Column(name = "business_type", length = 128, nullable = false)
     private String businessType; // Enum 으로 정의 고려
 
-    @Column(name = "contact", length = 13, nullable = false)
+    @Column(name = "contact", length = 11, nullable = false)
     private String contact;
 
     @Column(name = "description", length = Integer.MAX_VALUE, nullable = true)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceImage.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceImage.java
@@ -42,7 +42,7 @@ public class WorkspaceImage {
     @ManyToOne(fetch = FetchType.LAZY)
     private Workspace workspace;
 
-    @Column(name = "file_id", nullable = false)
+    @Column(name = "file_id", length = 36, nullable = false)
     private String fileId;
 
     @Column(name = "sort_order", nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceRequestComment.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceRequestComment.java
@@ -49,7 +49,7 @@ public class WorkspaceRequestComment {
 	private User user;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "comment_owner", nullable = false)
+	@Column(name = "comment_owner", length = 50, nullable = false)
 	private CommentOwner commentOwner;
 
 	@Column(name = "comment", nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceRequestImage.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceRequestImage.java
@@ -39,7 +39,7 @@ public class WorkspaceRequestImage {
     @ManyToOne(fetch = FetchType.LAZY)
     private WorkspaceRequest workspaceRequest;
 
-    @Column(name = "file_id", nullable = false)
+    @Column(name = "file_id", length = 36, nullable = false)
     private String fileId;
 
     @Column(name = "sort_order", nullable = false)

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceShift.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceShift.java
@@ -36,7 +36,7 @@ public class WorkspaceShift {
     private String position;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private WorkspaceShiftStatus status;
 
     @JoinColumn(name = "worker_id")

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorker.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorker.java
@@ -35,7 +35,7 @@ public class WorkspaceWorker {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", length = 20, nullable = false)
     private WorkspaceWorkerStatus status;
 
     @Builder.Default

--- a/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorkerSchedule.java
+++ b/src/main/java/com/dreamteam/alter/domain/workspace/entity/WorkspaceWorkerSchedule.java
@@ -48,21 +48,21 @@ public class WorkspaceWorkerSchedule {
 	private WorkspaceWorker workspaceWorker;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "start_day_of_week", nullable = false)
+	@Column(name = "start_day_of_week", length = 16, nullable = false)
 	private DayOfWeek startDayOfWeek;
 
 	@Column(name = "start_time", nullable = false)
 	private LocalTime startTime;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "end_day_of_week", nullable = false)
+	@Column(name = "end_day_of_week", length = 16, nullable = false)
 	private DayOfWeek endDayOfWeek;
 
 	@Column(name = "end_time", nullable = false)
 	private LocalTime endTime;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "status", nullable = false)
+	@Column(name = "status", length = 32, nullable = false)
 	private WorkspaceWorkerScheduleStatus status;
 
 	@CreatedDate

--- a/src/main/resources/db/migration/V2__align_entity_db_column_lengths.sql
+++ b/src/main/resources/db/migration/V2__align_entity_db_column_lengths.sql
@@ -1,0 +1,11 @@
+-- C-2: email_send_logs.email  varchar(255) -> varchar(100)
+ALTER TABLE email_send_logs
+    ALTER COLUMN email TYPE varchar(100);
+
+-- D-1: user_certificates.type  text -> varchar(24)
+ALTER TABLE user_certificates
+    ALTER COLUMN type TYPE varchar(24);
+
+-- D-2: reputation_keyword_map.description  text -> varchar(128)
+ALTER TABLE reputation_keyword_map
+    ALTER COLUMN description TYPE varchar(128);

--- a/src/main/resources/db/migration/V3__widen_user_anonymize_columns.sql
+++ b/src/main/resources/db/migration/V3__widen_user_anonymize_columns.sql
@@ -1,0 +1,4 @@
+-- 탈퇴 익명화(id + "_탈퇴") 수용을 위해 name/contact 폭 확대.
+-- varchar 확대는 PostgreSQL 카탈로그 메타데이터 변경(테이블 재작성 없음, 락 순간적).
+ALTER TABLE users ALTER COLUMN name    TYPE varchar(30);
+ALTER TABLE users ALTER COLUMN contact TYPE varchar(30);


### PR DESCRIPTION
## 변경사항

https://app.notion.com/p/38a8655316288130a60be648150aab0e

### 엔티티 컬럼 length 정의 일치화 (22개 파일, 40건)
- enum 필드 length 추가 (23건): User/EmailSendLog/Notification/Reputation/ReputationSummary/WorkspaceShift/WorkspaceWorker/BusinessInvitation/BusinessJoinRequest/SubstituteRequest/SubstituteRequestTarget/ManagerUser/PostingApplication/WorkspaceRequestComment/File/WorkspaceWorkerSchedule
- String 필드 length 추가 (12건): File(id/targetId/contentType/storedKey/fileUrl)/ReputationSummary/SubstituteRequest/SubstituteRequestTarget/WorkspaceImage/WorkspaceRequestImage
- 명시 length 정정 (3건): User.contact/Workspace.contact (13→11), ReputationRequest.requestType (20→24)
- varchar↔text 일치화 (2건): UserCertificate.type/ReputationKeywordMap.description에 length 추가

### Flyway 마이그레이션 (V2) 추가
- email_send_logs.email: varchar(255) → varchar(100)
- user_certificates.type: text → varchar(24)
- reputation_keyword_map.description: text → varchar(128)

마이그레이션 적용 검증 완료 (로컬 DB 데이터 길이 초과 없음, 서버 기동 시 Flyway validation/migration 성공)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 여러 입력값과 상태값의 허용 길이를 정리해, 더 일관된 데이터 저장이 가능해졌습니다.
  * 일부 연락처, 상태, 유형, 설명 필드의 길이 제한이 조정되어 예기치 않은 저장 오류를 줄였습니다.
  * 워크스페이스, 사용자, 알림, 평판 관련 정보의 컬럼 제약이 맞춰져 데이터 정합성이 강화되었습니다.

* **Chores**
  * 데이터베이스 컬럼 길이 설정을 전반적으로 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->