### PR TITLE
feat: [alt-267] 업종 키워드 관련 기능 고도화 및 지원조건 버그 수정

### DIFF
--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordController.java
@@ -1,0 +1,85 @@
+package com.dreamteam.alter.adapter.inbound.admin.posting.controller;
+
+import com.dreamteam.alter.adapter.inbound.admin.posting.dto.AdminPostingKeywordRequestDto;
+import com.dreamteam.alter.adapter.inbound.admin.posting.dto.AdminPostingKeywordResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import com.dreamteam.alter.domain.posting.command.AdminCreatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.command.AdminUpdatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminCreatePostingKeywordUseCase;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminDeletePostingKeywordUseCase;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminGetPostingKeywordListUseCase;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminUpdatePostingKeywordUseCase;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/posting-keywords")
+@PreAuthorize("hasAnyRole('ADMIN')")
+@RequiredArgsConstructor
+@Validated
+public class AdminPostingKeywordController implements AdminPostingKeywordControllerSpec {
+
+    @Resource(name = "adminGetPostingKeywordList")
+    private final AdminGetPostingKeywordListUseCase adminGetPostingKeywordList;
+
+    @Resource(name = "adminCreatePostingKeyword")
+    private final AdminCreatePostingKeywordUseCase adminCreatePostingKeyword;
+
+    @Resource(name = "adminUpdatePostingKeyword")
+    private final AdminUpdatePostingKeywordUseCase adminUpdatePostingKeyword;
+
+    @Resource(name = "adminDeletePostingKeyword")
+    private final AdminDeletePostingKeywordUseCase adminDeletePostingKeyword;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<CommonApiResponse<List<AdminPostingKeywordResponseDto>>> getPostingKeywordList() {
+        List<AdminPostingKeywordResponseDto> result = adminGetPostingKeywordList.execute().stream()
+            .map(AdminPostingKeywordResponseDto::from)
+            .toList();
+        return ResponseEntity.ok(CommonApiResponse.of(result));
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<AdminPostingKeywordResponseDto>> createPostingKeyword(
+        @Valid @RequestBody AdminPostingKeywordRequestDto request
+    ) {
+        Long id = adminCreatePostingKeyword.execute(
+            new AdminCreatePostingKeywordCommand(request.getName(), request.getDescription())
+        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(CommonApiResponse.of(
+                AdminPostingKeywordResponseDto.of(id, request.getName(), request.getDescription())
+            ));
+    }
+
+    @Override
+    @PutMapping("/{id}")
+    public ResponseEntity<CommonApiResponse<Void>> updatePostingKeyword(
+        @PathVariable Long id,
+        @Valid @RequestBody AdminPostingKeywordRequestDto request
+    ) {
+        adminUpdatePostingKeyword.execute(
+            id, new AdminUpdatePostingKeywordCommand(request.getName(), request.getDescription())
+        );
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    public ResponseEntity<CommonApiResponse<Void>> deletePostingKeyword(
+        @PathVariable Long id
+    ) {
+        adminDeletePostingKeyword.execute(id);
+        return ResponseEntity.ok(CommonApiResponse.empty());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordController.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordController.java
@@ -5,6 +5,7 @@ import com.dreamteam.alter.adapter.inbound.admin.posting.dto.AdminPostingKeyword
 import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
 import com.dreamteam.alter.domain.posting.command.AdminCreatePostingKeywordCommand;
 import com.dreamteam.alter.domain.posting.command.AdminUpdatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.port.inbound.AdminCreatePostingKeywordUseCase;
 import com.dreamteam.alter.domain.posting.port.inbound.AdminDeletePostingKeywordUseCase;
 import com.dreamteam.alter.domain.posting.port.inbound.AdminGetPostingKeywordListUseCase;
@@ -53,13 +54,11 @@ public class AdminPostingKeywordController implements AdminPostingKeywordControl
     public ResponseEntity<CommonApiResponse<AdminPostingKeywordResponseDto>> createPostingKeyword(
         @Valid @RequestBody AdminPostingKeywordRequestDto request
     ) {
-        Long id = adminCreatePostingKeyword.execute(
+        PostingKeyword created = adminCreatePostingKeyword.execute(
             new AdminCreatePostingKeywordCommand(request.getName(), request.getDescription())
         );
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(CommonApiResponse.of(
-                AdminPostingKeywordResponseDto.of(id, request.getName(), request.getDescription())
-            ));
+            .body(CommonApiResponse.of(AdminPostingKeywordResponseDto.from(created)));
     }
 
     @Override

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordControllerSpec.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/controller/AdminPostingKeywordControllerSpec.java
@@ -1,0 +1,53 @@
+package com.dreamteam.alter.adapter.inbound.admin.posting.controller;
+
+import com.dreamteam.alter.adapter.inbound.admin.posting.dto.AdminPostingKeywordRequestDto;
+import com.dreamteam.alter.adapter.inbound.admin.posting.dto.AdminPostingKeywordResponseDto;
+import com.dreamteam.alter.adapter.inbound.common.dto.CommonApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "ADMIN - 업종(키워드) 관리 API")
+public interface AdminPostingKeywordControllerSpec {
+
+    @Operation(summary = "업종 목록 조회", description = "관리자가 등록된 업종(키워드) 전체 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "업종 목록 조회 성공")
+    })
+    ResponseEntity<CommonApiResponse<List<AdminPostingKeywordResponseDto>>> getPostingKeywordList();
+
+    @Operation(summary = "업종 생성", description = "관리자가 새 업종(키워드)을 등록합니다. 이름은 중복될 수 없습니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "업종 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "이름 중복 또는 유효성 검증 실패")
+    })
+    ResponseEntity<CommonApiResponse<AdminPostingKeywordResponseDto>> createPostingKeyword(
+        @Valid @RequestBody AdminPostingKeywordRequestDto request
+    );
+
+    @Operation(summary = "업종 수정", description = "관리자가 업종(키워드)의 이름/설명을 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "업종 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "이름 중복 또는 존재하지 않는 업종")
+    })
+    ResponseEntity<CommonApiResponse<Void>> updatePostingKeyword(
+        @PathVariable Long id,
+        @Valid @RequestBody AdminPostingKeywordRequestDto request
+    );
+
+    @Operation(summary = "업종 삭제", description = "관리자가 업종(키워드)을 삭제합니다. 공고에서 사용 중인 업종은 삭제할 수 없습니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "업종 삭제 성공"),
+        @ApiResponse(responseCode = "409", description = "공고에서 사용 중인 업종")
+    })
+    ResponseEntity<CommonApiResponse<Void>> deletePostingKeyword(
+        @PathVariable Long id
+    );
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordRequestDto.java
@@ -1,0 +1,24 @@
+package com.dreamteam.alter.adapter.inbound.admin.posting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "업종(키워드) 생성/수정 요청 DTO")
+public class AdminPostingKeywordRequestDto {
+
+    @NotBlank
+    @Size(max = 128)
+    @Schema(description = "업종명", example = "카페")
+    private String name;
+
+    @Size(max = 255)
+    @Schema(description = "업종 설명", example = "카페/디저트 매장")
+    private String description;
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordResponseDto.java
@@ -1,0 +1,42 @@
+package com.dreamteam.alter.adapter.inbound.admin.posting.dto;
+
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "업종(키워드) 응답 DTO")
+public class AdminPostingKeywordResponseDto {
+
+    @Schema(description = "업종 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "업종명", example = "카페")
+    private String name;
+
+    @Schema(description = "업종 설명", example = "카페/디저트 매장")
+    private String description;
+
+    public static AdminPostingKeywordResponseDto from(PostingKeyword keyword) {
+        return AdminPostingKeywordResponseDto.builder()
+            .id(keyword.getId())
+            .name(keyword.getName())
+            .description(keyword.getDescription())
+            .build();
+    }
+
+    public static AdminPostingKeywordResponseDto of(Long id, String name, String description) {
+        return AdminPostingKeywordResponseDto.builder()
+            .id(id)
+            .name(name)
+            .description(description)
+            .build();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/admin/posting/dto/AdminPostingKeywordResponseDto.java
@@ -31,12 +31,4 @@ public class AdminPostingKeywordResponseDto {
             .description(keyword.getDescription())
             .build();
     }
-
-    public static AdminPostingKeywordResponseDto of(Long id, String name, String description) {
-        return AdminPostingKeywordResponseDto.builder()
-            .id(id)
-            .name(name)
-            .description(description)
-            .build();
-    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/CreatePostingRequestDto.java
@@ -3,10 +3,12 @@ package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 import com.dreamteam.alter.domain.posting.type.PaymentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.List;
 
@@ -39,9 +41,12 @@ public class CreatePostingRequestDto {
     @NotNull
     private PaymentType paymentType;
 
-    @Schema(description = "키워드", example = "[2, 3, 1]")
-    @NotEmpty
+    @Schema(description = "마스터 업종 ID 목록 (선택)", example = "[2, 3, 1]")
     private List<Long> keywords;
+
+    @Schema(description = "직접입력 업종 (마스터 미등록, 공고 라벨로 저장)", example = "[\"브런치카페\"]")
+    @Size(max = 10)
+    private List<@NotBlank @Size(max = 128) String> customKeywords;
 
     @Schema(description = "공고 스케줄", example = "[" +
             "{" +
@@ -53,5 +58,11 @@ public class CreatePostingRequestDto {
         "]")
     @Valid
     private List<CreatePostingScheduleRequestDto> schedules;
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "업종은 최소 1개 이상 선택하거나 직접 입력해야 합니다.")
+    public boolean isKeywordProvided() {
+        return ObjectUtils.isNotEmpty(keywords) || ObjectUtils.isNotEmpty(customKeywords);
+    }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingDetailResponseDto.java
@@ -48,8 +48,12 @@ public class PostingDetailResponseDto {
     private LocalDateTime createdAt;
 
     @NotNull
-    @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
+    @Schema(description = "키워드(마스터 업종)", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
     private List<PostingKeywordListResponseDto> keywords;
+
+    @NotNull
+    @Schema(description = "직접입력 업종", example = "[\"브런치카페\"]")
+    private List<String> customKeywords;
 
     @NotNull
     @Schema(description = "공고 스케줄", example = "[{\"id\":1,\"workingDays\":[\"MONDAY\",\"WEDNESDAY\"],\"startTime\":\"09:00\",\"endTime\":\"18:00\",\"positionsNeeded\":3,\"positionsAvailable\":2,\"position\":\"홀서빙\"}]")
@@ -77,6 +81,7 @@ public class PostingDetailResponseDto {
             .keywords(entity.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .customKeywords(entity.getCustomKeywords())
             .scrapped(entity.isScrapped())
             .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingFilterOptionsResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingFilterOptionsResponseDto.java
@@ -1,6 +1,7 @@
 package com.dreamteam.alter.adapter.inbound.general.posting.dto;
 
 import com.dreamteam.alter.adapter.inbound.common.dto.DescribedEnumDto;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.type.PostingSortType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -26,11 +27,15 @@ public class PostingFilterOptionsResponseDto {
     @Schema(description = "정렬 옵션 목록")
     private List<DescribedEnumDto<PostingSortType>> sortOptions;
 
+    @Schema(description = "업종(마스터) 추천 목록 — 필터 검색어 자동완성/칩 용도")
+    private List<PostingKeywordListResponseDto> keywords;
+
     public static PostingFilterOptionsResponseDto of(
         List<String> provinces,
         List<String> districts,
         List<String> towns,
-        List<PostingSortType> sortOptions
+        List<PostingSortType> sortOptions,
+        List<PostingKeyword> keywords
     ) {
         return PostingFilterOptionsResponseDto.builder()
             .provinces(provinces)
@@ -38,6 +43,10 @@ public class PostingFilterOptionsResponseDto {
             .towns(towns)
             .sortOptions(sortOptions.stream()
                 .map(sortType -> DescribedEnumDto.of(sortType, PostingSortType.describe()))
+                .toList()
+            )
+            .keywords(keywords.stream()
+                .map(PostingKeywordListResponseDto::from)
                 .toList()
             )
             .build();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListFilterDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListFilterDto.java
@@ -37,4 +37,7 @@ public class PostingListFilterDto {
 
     @Parameter(description = "급여순 정렬 여부")
     private Boolean payAmountSort;
+
+    @Parameter(description = "업종 검색어 (마스터 업종명 또는 직접입력 업종 부분일치)")
+    private String keyword;
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/general/posting/dto/PostingListResponseDto.java
@@ -38,8 +38,12 @@ public class PostingListResponseDto {
     private LocalDateTime createdAt;
 
     @NotNull
-    @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
+    @Schema(description = "키워드(마스터 업종)", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
     private List<PostingKeywordListResponseDto> keywords;
+
+    @NotNull
+    @Schema(description = "직접입력 업종", example = "[\"브런치카페\"]")
+    private List<String> customKeywords;
 
     @NotNull
     @Schema(description = "공고 스케줄", example = "[" +
@@ -73,6 +77,7 @@ public class PostingListResponseDto {
             .keywords(entity.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .customKeywords(entity.getCustomKeywords())
             .workspace(PostingListWorkspaceResponseDto.from(entity.getWorkspace()))
             .scrapped(entity.isScrapped())
             .build();

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingDetailResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingDetailResponseDto.java
@@ -59,8 +59,12 @@ public class ManagerPostingDetailResponseDto {
     private LocalDateTime updatedAt;
 
     @NotNull
-    @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
+    @Schema(description = "키워드(마스터 업종)", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
     private List<PostingKeywordListResponseDto> keywords;
+
+    @NotNull
+    @Schema(description = "직접입력 업종", example = "[\"브런치카페\"]")
+    private List<String> customKeywords;
 
     @NotNull
     @Schema(description = "공고 스케줄", example = "[{\"id\":1,\"workingDays\":[\"MONDAY\",\"WEDNESDAY\"],\"startTime\":\"09:00\",\"endTime\":\"18:00\",\"positionsNeeded\":3,\"positionsAvailable\":2,\"position\":\"홀서빙\"}]")
@@ -83,6 +87,7 @@ public class ManagerPostingDetailResponseDto {
             .keywords(entity.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .customKeywords(entity.getCustomKeywords())
             .build();
     }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingListResponseDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/ManagerPostingListResponseDto.java
@@ -41,8 +41,12 @@ public class ManagerPostingListResponseDto {
     private LocalDateTime createdAt;
 
     @NotNull
-    @Schema(description = "키워드", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
+    @Schema(description = "키워드(마스터 업종)", example = "[{\"id\":1,\"name\":\"카페\"},{\"id\":4,\"name\":\"분식\"}]")
     private List<PostingKeywordListResponseDto> keywords;
+
+    @NotNull
+    @Schema(description = "직접입력 업종", example = "[\"브런치카페\"]")
+    private List<String> customKeywords;
 
     @NotNull
     @Schema(description = "공고 스케줄", example = "[" +
@@ -69,6 +73,7 @@ public class ManagerPostingListResponseDto {
             .keywords(response.getPostingKeywords().stream()
                 .map(PostingKeywordListResponseDto::from)
                 .toList())
+            .customKeywords(response.getCustomKeywords())
             .schedules(response.getSchedules().stream()
                 .map(PostingScheduleResponseDto::from)
                 .toList())

--- a/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/UpdatePostingRequestDto.java
+++ b/src/main/java/com/dreamteam/alter/adapter/inbound/manager/posting/dto/UpdatePostingRequestDto.java
@@ -7,15 +7,17 @@ import com.dreamteam.alter.domain.posting.type.PaymentType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -39,9 +41,12 @@ public class UpdatePostingRequestDto {
     @Schema(description = "급여 타입", example = "HOURLY")
     private PaymentType paymentType;
 
-    @NotEmpty
-    @Schema(description = "키워드", example = "[2, 3, 1]")
+    @Schema(description = "마스터 업종 ID 목록 (선택)", example = "[2, 3, 1]")
     private List<Long> keywords;
+
+    @Size(max = 10)
+    @Schema(description = "직접입력 업종 (마스터 미등록, 공고 라벨로 저장)", example = "[\"브런치카페\"]")
+    private List<@NotBlank @Size(max = 128) String> customKeywords;
 
     @Valid
     @Schema(description = "새로 추가할 스케줄", example = "[{\"workingDays\": [\"FRIDAY\"], \"startTime\": \"13:00\", \"endTime\": \"21:00\", \"positionsNeeded\": 1, \"position\": \"설거지\"}]")
@@ -53,4 +58,10 @@ public class UpdatePostingRequestDto {
 
     @Schema(description = "삭제할 스케줄 ID", example = "[2, 3]")
     private List<Long> deleteScheduleIds;
+
+    @Schema(hidden = true)
+    @AssertTrue(message = "업종은 최소 1개 이상 선택하거나 직접 입력해야 합니다.")
+    public boolean isKeywordProvided() {
+        return ObjectUtils.isNotEmpty(keywords) || ObjectUtils.isNotEmpty(customKeywords);
+    }
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingKeywordQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingKeywordQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.adapter.outbound.posting.persistence;
 
 import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.entity.QPostingKeyword;
+import com.dreamteam.alter.domain.posting.entity.QPostingKeywordMap;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,19 @@ public class PostingKeywordQueryRepositoryImpl implements PostingKeywordQueryRep
         return queryFactory
             .selectFrom(qPostingKeyword)
             .fetch();
+    }
+
+    @Override
+    public boolean existsPostingUsingKeyword(Long keywordId) {
+        QPostingKeywordMap qPostingKeywordMap = QPostingKeywordMap.postingKeywordMap;
+
+        Integer exists = queryFactory
+            .selectOne()
+            .from(qPostingKeywordMap)
+            .where(qPostingKeywordMap.postingKeyword.id.eq(keywordId))
+            .fetchFirst();
+
+        return exists != null;
     }
 
 }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
@@ -19,6 +19,7 @@ import com.dreamteam.alter.domain.workspace.entity.QWorkspace;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
@@ -41,6 +42,8 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
     public long getCountOfPostings(PostingListFilterDto filter) {
         QPosting qPosting = QPosting.posting;
         QPostingSchedule qPostingSchedule = QPostingSchedule.postingSchedule;
+        QPostingKeywordMap qPostingKeywordMap = QPostingKeywordMap.postingKeywordMap;
+        QPostingKeyword qPostingKeyword = QPostingKeyword.postingKeyword;
         QWorkspace qWorkspace = QWorkspace.workspace;
 
         Long count = queryFactory
@@ -48,6 +51,8 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
             .from(qPosting)
             .leftJoin(qPosting.schedules, qPostingSchedule)
             .leftJoin(qPosting.workspace, qWorkspace)
+            .leftJoin(qPosting.keywords, qPostingKeywordMap)
+            .leftJoin(qPostingKeywordMap.postingKeyword, qPostingKeyword)
             .where(
                 qPosting.status.eq(PostingStatus.OPEN),
                 eqProvince(qWorkspace, filter.getProvince()),
@@ -56,7 +61,8 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
                 gtePayAmount(qPosting, filter.getMinPayAmount()),
                 ltePayAmount(qPosting, filter.getMaxPayAmount()),
                 gteStartTime(qPostingSchedule, filter.getStartTime()),
-                lteEndTime(qPostingSchedule, filter.getEndTime())
+                lteEndTime(qPostingSchedule, filter.getEndTime()),
+                keywordMatches(qPostingKeyword, qPosting, filter.getKeyword())
             )
             .fetchOne();
 
@@ -96,6 +102,8 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
             .from(qPosting)
             .leftJoin(qPosting.schedules, qPostingSchedule)
             .leftJoin(qPosting.workspace, qWorkspace)
+            .leftJoin(qPosting.keywords, qPostingKeywordMap)
+            .leftJoin(qPostingKeywordMap.postingKeyword, qPostingKeyword)
             .where(
                 qPosting.status.eq(PostingStatus.OPEN),
                 cursorConditions(qPosting, request.cursor(), filter.getPayAmountSort()),
@@ -105,7 +113,8 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
                 gtePayAmount(qPosting, filter.getMinPayAmount()),
                 ltePayAmount(qPosting, filter.getMaxPayAmount()),
                 gteStartTime(qPostingSchedule, filter.getStartTime()),
-                lteEndTime(qPostingSchedule, filter.getEndTime())
+                lteEndTime(qPostingSchedule, filter.getEndTime()),
+                keywordMatches(qPostingKeyword, qPosting, filter.getKeyword())
             )
             .groupBy(qPosting.id, qPosting.payAmount, qPosting.createdAt)
             .orderBy(getOrderSpecifiers(qPosting, filter.getPayAmountSort()))
@@ -583,6 +592,21 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
         }
         return qPosting.title.containsIgnoreCase(searchKeyword)
             .or(qWorkspace.businessName.containsIgnoreCase(searchKeyword));
+    }
+
+    /**
+     * 업종 필터: 입력 텍스트가 (마스터 연결 업종명 OR 직접입력 업종 라벨)에 부분일치.
+     * 직접입력 라벨은 jsonb(custom_keywords)라 text 캐스팅 후 ilike로 매칭한다.
+     */
+    private BooleanExpression keywordMatches(QPostingKeyword qPostingKeyword, QPosting qPosting, String keyword) {
+        if (ObjectUtils.isEmpty(keyword) || keyword.isBlank()) {
+            return null;
+        }
+        BooleanExpression masterMatch = qPostingKeyword.name.containsIgnoreCase(keyword);
+        BooleanExpression customMatch = Expressions.booleanTemplate(
+            "cast({0} as string) ilike {1}", qPosting.customKeywords, "%" + keyword + "%"
+        );
+        return masterMatch.or(customMatch);
     }
 
     private OrderSpecifier<?>[] getOrderSpecifiersForMapList(QPosting qPosting, PostingSortType sortType) {

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/PostingQueryRepositoryImpl.java
@@ -596,15 +596,21 @@ public class PostingQueryRepositoryImpl implements PostingQueryRepository {
 
     /**
      * 업종 필터: 입력 텍스트가 (마스터 연결 업종명 OR 직접입력 업종 라벨)에 부분일치.
-     * 직접입력 라벨은 jsonb(custom_keywords)라 text 캐스팅 후 ilike로 매칭한다.
+     * 직접입력 라벨은 jsonb(custom_keywords)라 text 캐스팅(HQL string → PostgreSQL text) 후 ilike로 매칭한다.
+     * LIKE 와일드카드(%, _)는 '!'로 이스케이프해 마스터 매칭(containsIgnoreCase)과 동일하게 부분일치만 허용한다.
      */
     private BooleanExpression keywordMatches(QPostingKeyword qPostingKeyword, QPosting qPosting, String keyword) {
         if (ObjectUtils.isEmpty(keyword) || keyword.isBlank()) {
             return null;
         }
         BooleanExpression masterMatch = qPostingKeyword.name.containsIgnoreCase(keyword);
+
+        String escaped = keyword
+            .replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_");
         BooleanExpression customMatch = Expressions.booleanTemplate(
-            "cast({0} as string) ilike {1}", qPosting.customKeywords, "%" + keyword + "%"
+            "cast({0} as string) ilike {1} escape '!'", qPosting.customKeywords, "%" + escaped + "%"
         );
         return masterMatch.or(customMatch);
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingDetailResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingDetailResponse.java
@@ -10,6 +10,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -36,6 +37,8 @@ public class ManagerPostingDetailResponse {
 
     private List<PostingKeyword> postingKeywords;
 
+    private List<String> customKeywords;
+
     private List<PostingSchedule> schedules;
 
     public static ManagerPostingDetailResponse of(
@@ -53,6 +56,7 @@ public class ManagerPostingDetailResponse {
             posting.getCreatedAt(),
             posting.getUpdatedAt(),
             postingKeywords,
+            Objects.requireNonNullElse(posting.getCustomKeywords(), List.of()),
             posting.getSchedules()
         );
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/ManagerPostingListResponse.java
@@ -10,6 +10,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,6 +30,8 @@ public class ManagerPostingListResponse {
 
     private List<PostingKeyword> postingKeywords;
 
+    private List<String> customKeywords;
+
     private List<PostingSchedule> schedules;
 
     private Workspace workspace;
@@ -41,7 +44,8 @@ public class ManagerPostingListResponse {
             .paymentType(posting.getPaymentType())
             .createdAt(posting.getCreatedAt())
             .schedules(posting.getSchedules())
-            .postingKeywords(keywordsMap.get(posting.getId()))
+            .postingKeywords(keywordsMap.getOrDefault(posting.getId(), List.of()))
+            .customKeywords(Objects.requireNonNullElse(posting.getCustomKeywords(), List.of()))
             .workspace(posting.getWorkspace())
             .build();
     }

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingDetailResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingDetailResponse.java
@@ -9,6 +9,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -31,6 +32,8 @@ public class PostingDetailResponse {
 
     private List<PostingKeyword> postingKeywords;
 
+    private List<String> customKeywords;
+
     private List<PostingSchedule> schedules;
 
     private boolean scrapped;
@@ -49,6 +52,7 @@ public class PostingDetailResponse {
             posting.getPaymentType(),
             posting.getCreatedAt(),
             postingKeywords,
+            Objects.requireNonNullElse(posting.getCustomKeywords(), List.of()),
             posting.getSchedules(),
             scrapped
         );

--- a/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingListResponse.java
+++ b/src/main/java/com/dreamteam/alter/adapter/outbound/posting/persistence/readonly/PostingListResponse.java
@@ -10,6 +10,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -29,6 +30,8 @@ public class PostingListResponse {
 
     private List<PostingKeyword> postingKeywords;
 
+    private List<String> customKeywords;
+
     private List<PostingSchedule> schedules;
 
     private Workspace workspace;
@@ -43,7 +46,8 @@ public class PostingListResponse {
             .paymentType(posting.getPaymentType())
             .createdAt(posting.getCreatedAt())
             .schedules(posting.getSchedules())
-            .postingKeywords(keywordsMap.get(posting.getId()))
+            .postingKeywords(keywordsMap.getOrDefault(posting.getId(), List.of()))
+            .customKeywords(Objects.requireNonNullElse(posting.getCustomKeywords(), List.of()))
             .workspace(posting.getWorkspace())
             .scrapped(scrapped)
             .build();

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminCreatePostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminCreatePostingKeyword.java
@@ -1,0 +1,29 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.command.AdminCreatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminCreatePostingKeywordUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminCreatePostingKeyword")
+@RequiredArgsConstructor
+@Transactional
+public class AdminCreatePostingKeyword implements AdminCreatePostingKeywordUseCase {
+
+    private final PostingKeywordRepository postingKeywordRepository;
+
+    @Override
+    public Long execute(AdminCreatePostingKeywordCommand command) {
+        if (postingKeywordRepository.existsByName(command.name())) {
+            throw new CustomException(ErrorCode.INVALID_KEYWORD, "이미 존재하는 업종입니다.");
+        }
+
+        PostingKeyword keyword = PostingKeyword.create(command.name(), command.description());
+        return postingKeywordRepository.save(keyword).getId();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminCreatePostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminCreatePostingKeyword.java
@@ -18,12 +18,12 @@ public class AdminCreatePostingKeyword implements AdminCreatePostingKeywordUseCa
     private final PostingKeywordRepository postingKeywordRepository;
 
     @Override
-    public Long execute(AdminCreatePostingKeywordCommand command) {
+    public PostingKeyword execute(AdminCreatePostingKeywordCommand command) {
         if (postingKeywordRepository.existsByName(command.name())) {
             throw new CustomException(ErrorCode.INVALID_KEYWORD, "이미 존재하는 업종입니다.");
         }
 
         PostingKeyword keyword = PostingKeyword.create(command.name(), command.description());
-        return postingKeywordRepository.save(keyword).getId();
+        return postingKeywordRepository.save(keyword);
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminDeletePostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminDeletePostingKeyword.java
@@ -1,0 +1,32 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminDeletePostingKeywordUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminDeletePostingKeyword")
+@RequiredArgsConstructor
+@Transactional
+public class AdminDeletePostingKeyword implements AdminDeletePostingKeywordUseCase {
+
+    private final PostingKeywordRepository postingKeywordRepository;
+    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+
+    @Override
+    public void execute(Long id) {
+        PostingKeyword keyword = postingKeywordRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.POSTING_KEYWORDS_NOT_FOUND));
+
+        if (postingKeywordQueryRepository.existsPostingUsingKeyword(id)) {
+            throw new CustomException(ErrorCode.CONFLICT, "공고에서 사용 중인 업종은 삭제할 수 없습니다.");
+        }
+
+        postingKeywordRepository.delete(keyword);
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminGetPostingKeywordList.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminGetPostingKeywordList.java
@@ -1,0 +1,23 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminGetPostingKeywordListUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service("adminGetPostingKeywordList")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGetPostingKeywordList implements AdminGetPostingKeywordListUseCase {
+
+    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+
+    @Override
+    public List<PostingKeyword> execute() {
+        return postingKeywordQueryRepository.findAll();
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminUpdatePostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/AdminUpdatePostingKeyword.java
@@ -1,0 +1,31 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.command.AdminUpdatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.inbound.AdminUpdatePostingKeywordUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("adminUpdatePostingKeyword")
+@RequiredArgsConstructor
+@Transactional
+public class AdminUpdatePostingKeyword implements AdminUpdatePostingKeywordUseCase {
+
+    private final PostingKeywordRepository postingKeywordRepository;
+
+    @Override
+    public void execute(Long id, AdminUpdatePostingKeywordCommand command) {
+        PostingKeyword keyword = postingKeywordRepository.findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.POSTING_KEYWORDS_NOT_FOUND));
+
+        if (postingKeywordRepository.existsByNameAndIdNot(command.name(), id)) {
+            throw new CustomException(ErrorCode.INVALID_KEYWORD, "이미 존재하는 업종입니다.");
+        }
+
+        keyword.update(command.name(), command.description());
+    }
+}

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.application.posting.usecase;
 
 import java.util.List;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +30,11 @@ public class CreatePosting implements CreatePostingUseCase {
 
     @Override
     public void execute(CreatePostingRequestDto request) {
-        List<PostingKeyword> postingKeywords = postingKeywordQueryRepository.findByIds(request.getKeywords());
-        if (postingKeywords.size() != request.getKeywords().size()) {
+        List<PostingKeyword> postingKeywords = ObjectUtils.isEmpty(request.getKeywords())
+            ? List.of()
+            : postingKeywordQueryRepository.findByIds(request.getKeywords());
+        if (ObjectUtils.isNotEmpty(request.getKeywords())
+            && postingKeywords.size() != request.getKeywords().size()) {
             throw new CustomException(ErrorCode.INVALID_KEYWORD);
         }
 

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePosting.java
@@ -2,7 +2,6 @@ package com.dreamteam.alter.application.posting.usecase;
 
 import java.util.List;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +11,6 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.entity.Posting;
 import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.port.inbound.CreatePostingUseCase;
-import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingRepository;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
 import com.dreamteam.alter.domain.workspace.port.outbound.WorkspaceQueryRepository;
@@ -25,18 +23,12 @@ import lombok.RequiredArgsConstructor;
 public class CreatePosting implements CreatePostingUseCase {
 
     private final PostingRepository postingRepository;
-    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+    private final PostingKeywordResolver postingKeywordResolver;
     private final WorkspaceQueryRepository workspaceQueryRepository;
 
     @Override
     public void execute(CreatePostingRequestDto request) {
-        List<PostingKeyword> postingKeywords = ObjectUtils.isEmpty(request.getKeywords())
-            ? List.of()
-            : postingKeywordQueryRepository.findByIds(request.getKeywords());
-        if (ObjectUtils.isNotEmpty(request.getKeywords())
-            && postingKeywords.size() != request.getKeywords().size()) {
-            throw new CustomException(ErrorCode.INVALID_KEYWORD);
-        }
+        List<PostingKeyword> postingKeywords = postingKeywordResolver.resolveAndValidate(request.getKeywords());
 
         Workspace workspace = workspaceQueryRepository.findById(request.getWorkspaceId())
             .orElseThrow(() -> new CustomException(ErrorCode.WORKSPACE_NOT_FOUND));

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePostingApplication.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/CreatePostingApplication.java
@@ -40,7 +40,7 @@ public class CreatePostingApplication implements CreatePostingApplicationUseCase
                 .orElseThrow(() -> new CustomException(ErrorCode.POSTING_SCHEDULE_NOT_FOUND));
 
         Posting posting = postingSchedule.getPosting();
-        if (PostingStatus.OPEN.equals(posting.getStatus())) {
+        if (!PostingStatus.OPEN.equals(posting.getStatus())) {
             throw new CustomException(ErrorCode.ILLEGAL_ARGUMENT, "모집이 종료된 공고입니다.");
         }
 

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingFilterOptions.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/GetPostingFilterOptions.java
@@ -3,6 +3,7 @@ package com.dreamteam.alter.application.posting.usecase;
 import com.dreamteam.alter.adapter.inbound.general.posting.dto.PostingFilterOptionsResponseDto;
 import com.dreamteam.alter.adapter.outbound.posting.persistence.readonly.PostingFilterOptionsResponse;
 import com.dreamteam.alter.domain.posting.port.inbound.GetPostingFilterOptionsUseCase;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingQueryRepository;
 import com.dreamteam.alter.domain.posting.type.PostingSortType;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.Arrays;
 public class GetPostingFilterOptions implements GetPostingFilterOptionsUseCase {
 
     private final PostingQueryRepository postingQueryRepository;
+    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
 
     @Override
     public PostingFilterOptionsResponseDto execute() {
@@ -26,7 +28,8 @@ public class GetPostingFilterOptions implements GetPostingFilterOptionsUseCase {
             filterOptions.getProvinces(),
             filterOptions.getDistricts(),
             filterOptions.getTowns(),
-            Arrays.asList(PostingSortType.values())
+            Arrays.asList(PostingSortType.values()),
+            postingKeywordQueryRepository.findAll()
         );
     }
 }

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePosting.java
@@ -2,7 +2,6 @@ package com.dreamteam.alter.application.posting.usecase;
 
 import java.util.List;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,7 +11,6 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.entity.Posting;
 import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 import com.dreamteam.alter.domain.posting.port.inbound.ManagerUpdatePostingUseCase;
-import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
 import com.dreamteam.alter.domain.posting.port.outbound.PostingQueryRepository;
 import com.dreamteam.alter.domain.user.context.ManagerActor;
 import com.dreamteam.alter.domain.user.entity.ManagerUser;
@@ -25,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class ManagerUpdatePosting implements ManagerUpdatePostingUseCase {
 
     private final PostingQueryRepository postingQueryRepository;
-    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+    private final PostingKeywordResolver postingKeywordResolver;
 
     @Override
     public void execute(Long postingId, UpdatePostingRequestDto request, ManagerActor actor) {
@@ -34,13 +32,7 @@ public class ManagerUpdatePosting implements ManagerUpdatePostingUseCase {
         Posting posting = postingQueryRepository.findByManagerAndId(postingId, managerUser)
             .orElseThrow(() -> new CustomException(ErrorCode.POSTING_NOT_FOUND));
 
-        List<PostingKeyword> postingKeywords = ObjectUtils.isEmpty(request.getKeywords())
-            ? List.of()
-            : postingKeywordQueryRepository.findByIds(request.getKeywords());
-        if (ObjectUtils.isNotEmpty(request.getKeywords())
-            && postingKeywords.size() != request.getKeywords().size()) {
-            throw new CustomException(ErrorCode.INVALID_KEYWORD);
-        }
+        List<PostingKeyword> postingKeywords = postingKeywordResolver.resolveAndValidate(request.getKeywords());
 
         posting.updateContent(
             request.getTitle(),

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePosting.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/ManagerUpdatePosting.java
@@ -2,6 +2,7 @@ package com.dreamteam.alter.application.posting.usecase;
 
 import java.util.List;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,8 +34,11 @@ public class ManagerUpdatePosting implements ManagerUpdatePostingUseCase {
         Posting posting = postingQueryRepository.findByManagerAndId(postingId, managerUser)
             .orElseThrow(() -> new CustomException(ErrorCode.POSTING_NOT_FOUND));
 
-        List<PostingKeyword> postingKeywords = postingKeywordQueryRepository.findByIds(request.getKeywords());
-        if (postingKeywords.size() != request.getKeywords().size()) {
+        List<PostingKeyword> postingKeywords = ObjectUtils.isEmpty(request.getKeywords())
+            ? List.of()
+            : postingKeywordQueryRepository.findByIds(request.getKeywords());
+        if (ObjectUtils.isNotEmpty(request.getKeywords())
+            && postingKeywords.size() != request.getKeywords().size()) {
             throw new CustomException(ErrorCode.INVALID_KEYWORD);
         }
 
@@ -44,6 +48,7 @@ public class ManagerUpdatePosting implements ManagerUpdatePostingUseCase {
             request.getPayAmount(),
             request.getPaymentType(),
             postingKeywords,
+            request.getCustomKeywords(),
             request.getCreateSchedules(),
             request.getUpdateSchedules(),
             request.getDeleteScheduleIds()

--- a/src/main/java/com/dreamteam/alter/application/posting/usecase/PostingKeywordResolver.java
+++ b/src/main/java/com/dreamteam/alter/application/posting/usecase/PostingKeywordResolver.java
@@ -1,0 +1,36 @@
+package com.dreamteam.alter.application.posting.usecase;
+
+import com.dreamteam.alter.common.exception.CustomException;
+import com.dreamteam.alter.common.exception.ErrorCode;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import com.dreamteam.alter.domain.posting.port.outbound.PostingKeywordQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PostingKeywordResolver {
+
+    private final PostingKeywordQueryRepository postingKeywordQueryRepository;
+
+    /**
+     * 마스터 업종 ID 목록을 조회·검증한다.
+     * 비어 있으면 빈 리스트를 반환하고, 조회 결과 수가 요청 수와 다르면 존재하지 않는 ID가 있는 것으로 보아 예외.
+     * @param keywordIds 마스터 업종 ID 목록 (nullable)
+     * @return 검증된 PostingKeyword 목록
+     */
+    public List<PostingKeyword> resolveAndValidate(List<Long> keywordIds) {
+        if (ObjectUtils.isEmpty(keywordIds)) {
+            return List.of();
+        }
+
+        List<PostingKeyword> keywords = postingKeywordQueryRepository.findByIds(keywordIds);
+        if (keywords.size() != keywordIds.size()) {
+            throw new CustomException(ErrorCode.INVALID_KEYWORD);
+        }
+        return keywords;
+    }
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/command/AdminCreatePostingKeywordCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/command/AdminCreatePostingKeywordCommand.java
@@ -1,0 +1,6 @@
+package com.dreamteam.alter.domain.posting.command;
+
+public record AdminCreatePostingKeywordCommand(
+    String name,
+    String description
+) {}

--- a/src/main/java/com/dreamteam/alter/domain/posting/command/AdminUpdatePostingKeywordCommand.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/command/AdminUpdatePostingKeywordCommand.java
@@ -1,0 +1,6 @@
+package com.dreamteam.alter.domain.posting.command;
+
+public record AdminUpdatePostingKeywordCommand(
+    String name,
+    String description
+) {}

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
@@ -93,7 +93,7 @@ public class Posting {
             .toList();
 
         posting.customKeywords = ObjectUtils.isNotEmpty(request.getCustomKeywords())
-            ? request.getCustomKeywords()
+            ? new ArrayList<>(request.getCustomKeywords())
             : new ArrayList<>();
 
         if (ObjectUtils.isNotEmpty(request.getSchedules())) {
@@ -132,7 +132,7 @@ public class Posting {
         this.description = description;
         this.payAmount = payAmount;
         this.paymentType = paymentType;
-        this.customKeywords = ObjectUtils.isNotEmpty(customKeywords) ? customKeywords : new ArrayList<>();
+        this.customKeywords = ObjectUtils.isNotEmpty(customKeywords) ? new ArrayList<>(customKeywords) : new ArrayList<>();
 
         // 키워드 업데이트
         updateKeyword(postingKeywords);

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/Posting.java
@@ -8,17 +8,20 @@ import com.dreamteam.alter.common.exception.ErrorCode;
 import com.dreamteam.alter.domain.posting.type.PaymentType;
 import com.dreamteam.alter.domain.posting.type.PostingStatus;
 import com.dreamteam.alter.domain.workspace.entity.Workspace;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import jakarta.persistence.*;
 import lombok.*;
 import org.apache.commons.lang3.ObjectUtils;
+import org.hibernate.annotations.Type;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -70,6 +73,10 @@ public class Posting {
     @OneToMany(mappedBy = "posting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostingKeywordMap> keywords;
 
+    @Type(JsonBinaryType.class)
+    @Column(name = "custom_keywords", columnDefinition = "jsonb")
+    private List<String> customKeywords;
+
     public static Posting create(CreatePostingRequestDto request, Workspace workspace, List<PostingKeyword> postingKeywords) {
         Posting posting = Posting.builder()
             .workspace(workspace)
@@ -84,6 +91,10 @@ public class Posting {
             .stream()
             .map(keyword -> PostingKeywordMap.create(keyword, posting))
             .toList();
+
+        posting.customKeywords = ObjectUtils.isNotEmpty(request.getCustomKeywords())
+            ? request.getCustomKeywords()
+            : new ArrayList<>();
 
         if (ObjectUtils.isNotEmpty(request.getSchedules())) {
             posting.schedules = request.getSchedules()
@@ -112,6 +123,7 @@ public class Posting {
         int payAmount,
         PaymentType paymentType,
         List<PostingKeyword> postingKeywords,
+        List<String> customKeywords,
         List<CreatePostingScheduleRequestDto> createSchedules,
         List<UpdatePostingScheduleDto> updateSchedules,
         List<Long> deleteScheduleIds
@@ -120,6 +132,7 @@ public class Posting {
         this.description = description;
         this.payAmount = payAmount;
         this.paymentType = paymentType;
+        this.customKeywords = ObjectUtils.isNotEmpty(customKeywords) ? customKeywords : new ArrayList<>();
 
         // 키워드 업데이트
         updateKeyword(postingKeywords);

--- a/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingKeyword.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/entity/PostingKeyword.java
@@ -43,4 +43,9 @@ public class PostingKeyword {
             .build();
     }
 
+    public void update(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
 }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminCreatePostingKeywordUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminCreatePostingKeywordUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+import com.dreamteam.alter.domain.posting.command.AdminCreatePostingKeywordCommand;
+
+public interface AdminCreatePostingKeywordUseCase {
+
+    Long execute(AdminCreatePostingKeywordCommand command);
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminCreatePostingKeywordUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminCreatePostingKeywordUseCase.java
@@ -1,8 +1,9 @@
 package com.dreamteam.alter.domain.posting.port.inbound;
 
 import com.dreamteam.alter.domain.posting.command.AdminCreatePostingKeywordCommand;
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
 
 public interface AdminCreatePostingKeywordUseCase {
 
-    Long execute(AdminCreatePostingKeywordCommand command);
+    PostingKeyword execute(AdminCreatePostingKeywordCommand command);
 }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminDeletePostingKeywordUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminDeletePostingKeywordUseCase.java
@@ -1,0 +1,6 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+public interface AdminDeletePostingKeywordUseCase {
+
+    void execute(Long id);
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminGetPostingKeywordListUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminGetPostingKeywordListUseCase.java
@@ -1,0 +1,10 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+
+import java.util.List;
+
+public interface AdminGetPostingKeywordListUseCase {
+
+    List<PostingKeyword> execute();
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminUpdatePostingKeywordUseCase.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/inbound/AdminUpdatePostingKeywordUseCase.java
@@ -1,0 +1,8 @@
+package com.dreamteam.alter.domain.posting.port.inbound;
+
+import com.dreamteam.alter.domain.posting.command.AdminUpdatePostingKeywordCommand;
+
+public interface AdminUpdatePostingKeywordUseCase {
+
+    void execute(Long id, AdminUpdatePostingKeywordCommand command);
+}

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordQueryRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordQueryRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface PostingKeywordQueryRepository {
     List<PostingKeyword> findByIds(List<Long> keywordIds);
     List<PostingKeyword> findAll();
+    boolean existsPostingUsingKeyword(Long keywordId);
 }

--- a/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordRepository.java
+++ b/src/main/java/com/dreamteam/alter/domain/posting/port/outbound/PostingKeywordRepository.java
@@ -1,0 +1,11 @@
+package com.dreamteam.alter.domain.posting.port.outbound;
+
+import com.dreamteam.alter.domain.posting.entity.PostingKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostingKeywordRepository extends JpaRepository<PostingKeyword, Long> {
+
+    boolean existsByName(String name);
+
+    boolean existsByNameAndIdNot(String name, Long id);
+}

--- a/src/main/resources/db/migration/V4__add_postings_custom_keywords_column.sql
+++ b/src/main/resources/db/migration/V4__add_postings_custom_keywords_column.sql
@@ -1,0 +1,4 @@
+-- 공고 직접입력 업종(라벨) 저장용 jsonb 컬럼 추가.
+-- 마스터(posting_keywords)에 등록하지 않는 자유 입력 업종명 리스트를 공고에 직접 보관한다.
+ALTER TABLE postings
+    ADD COLUMN custom_keywords jsonb;

--- a/src/main/resources/db/migration/V5__seed_posting_keywords.sql
+++ b/src/main/resources/db/migration/V5__seed_posting_keywords.sql
@@ -1,0 +1,17 @@
+-- 업종/키워드 마스터 초기 시드.
+-- 기존 수동 삽입분과의 충돌을 막기 위해 이름 기준 멱등 처리(ON CONFLICT DO NOTHING).
+-- created_at/updated_at은 NOT NULL이며 기본값이 없어(Flyway는 JPA Auditing 우회) now()를 명시한다.
+INSERT INTO posting_keywords (name, description, created_at, updated_at)
+VALUES
+    ('카페', NULL, now(), now()),
+    ('음식점', NULL, now(), now()),
+    ('주점', NULL, now(), now()),
+    ('편의점', NULL, now(), now()),
+    ('베이커리', NULL, now(), now()),
+    ('패스트푸드', NULL, now(), now()),
+    ('배달', NULL, now(), now()),
+    ('판매/매장', NULL, now(), now()),
+    ('사무보조', NULL, now(), now()),
+    ('물류/포장', NULL, now(), now()),
+    ('기타', NULL, now(), now())
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## 변경사항
[[기획] 구인구직 기능 정비 및 구현 계획](https://app.notion.com/p/389865531628806294a6c6a2654a2208)

Notion 문서 7번(확인 필요·이슈) 중 "키워드(업종) 필터 부재"와 "지원 조건 로직 반전"을 해소합니다.

- 업종(PostingKeyword) 마스터 관리자 CRUD 및 초기 시드 추가 (`/admin/posting-keywords`, Flyway V5)
- 공고 등록·수정 시 마스터 선택(`keywords`) + 직접입력(`customKeywords`) 병행 지원 (`postings.custom_keywords` jsonb, Flyway V4)
- 알바생 공고 목록 업종 필터 추가 (`GET /app/postings?keyword=`, 마스터 업종명 OR 직접입력 라벨 부분일치) + `filter-options` 업종 facet
- 공고 응답(목록·상세, 알바생·매니저)에 `customKeywords` 노출 및 마스터 키워드 0개 공고 조회 시 NPE 가드
- fix: 공고 지원 조건 반전 버그 수정 — 모집중(OPEN) 공고 지원이 차단되던 문제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 게시 키워드(업종) 관리 API 추가(목록/생성/수정/삭제).
  * 공고 작성·수정 시 직접 입력 업종을 함께 등록 가능.
  * 공고 목록/상세 및 필터에서 마스터 키워드와 직접 입력 키워드 동시 제공, 업종 기반 검색·필터 지원.

* **버그 수정**
  * 모집 중인 공고에서만 지원 절차가 진행되도록 수정.
  * 사용 중인 업종 키워드는 삭제 불가하도록 제한하고, 직접 입력 키워드 입력 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->